### PR TITLE
Index requester's workspace by default

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -432,6 +432,10 @@ request_initialize :: proc (task: ^common.Task) {
 								config.collections[strings.clone(p.name)] = path.join(elems = {uri.path, forward_path}, allocator = context.allocator);
 							}
 						}
+
+						if ok := "" in config.collections; !ok {
+							config.collections[""] = uri.path;
+						}
 					} else {
 						log.errorf("Failed to unmarshal %v", ols_config_path);
 					}


### PR DESCRIPTION
Simple change to implicitly add a blank collection that points to the workspace's path if there isn't a blank collection specified in the configuration. (I figured I'd take the low hanging fruit)

resolves #21 