### PR TITLE
Fixed neovim hover issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 *.exp
 *.sqlite
 *.suo
-ols
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 *.exp
 *.sqlite
 *.suo
-
+ols

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -44,7 +44,7 @@ write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupC
 }
 
 
-get_hover_information :: proc(document: ^common.Document, position: common.Position) -> (Hover, bool) {
+get_hover_information :: proc(document: ^common.Document, position: common.Position) -> (Hover, bool, bool) {
 	hover := Hover {
 		contents = {
 			kind = "plaintext",
@@ -66,7 +66,7 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 			if _, ok := common.keyword_map[ident.name]; ok {
 				hover.contents.kind = "plaintext"
 				hover.range = common.get_token_range(position_context.identifier^, ast_context.file.src)
-				return hover, true
+				return hover, true, true
 			}
 		}
 	}
@@ -93,7 +93,7 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 					}
 
 					hover.contents = write_hover_content(&ast_context, resolved)
-					return hover, true
+					return hover, true, true
 				}
 			}
 		}
@@ -102,7 +102,7 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 		selector, ok = resolve_type_expression(&ast_context, position_context.selector)
 
 		if !ok {
-			return hover, true
+			return hover, false, true
 		}
 
 		field: string
@@ -125,7 +125,7 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 						symbol.pkg = selector.name
 						symbol.signature = common.node_to_string(v.types[i])
 						hover.contents = write_hover_content(&ast_context, symbol)
-						return hover, true
+						return hover, true, true
 					}
 				}
 			}
@@ -135,7 +135,7 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 					ast_context.current_package = selector.pkg
 					if symbol, ok := resolve_type_identifier(&ast_context, ident^); ok {
 						hover.contents = write_hover_content(&ast_context, symbol)
-						return hover, true
+						return hover, true, true
 					}
 				}
 			}
@@ -158,9 +158,9 @@ get_hover_information :: proc(document: ^common.Document, position: common.Posit
 			}
 
 			hover.contents = write_hover_content(&ast_context, resolved)
-			return hover, true
+			return hover, true, true
 		}
 	}
 
-	return hover, true
+	return hover, false, true
 }

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -970,15 +970,21 @@ request_hover :: proc (params: json.Value, id: RequestId, config: ^common.Config
     }
 
 	hover: Hover
-	hover, ok = get_hover_information(document, hover_params.position)
+	valid: bool
+	hover, valid, ok = get_hover_information(document, hover_params.position)
 
 	if !ok {
 		return .InternalError
 	}
 
-	response := make_response_message(params = hover, id = id)
-
-	send_response(response, writer)
+	if valid {
+		response := make_response_message(params = hover, id = id)
+		send_response(response, writer)
+	} 
+	else {
+		response := make_response_message(params = nil, id = id)
+		send_response(response, writer)
+	}
 
 	return .None
 }


### PR DESCRIPTION
These changes fix an issue with neovim that caused the editor to flash a big annoying error whenever you tried to hover over something invalid. Also conforms with the lsp specification slightly better. 