### PR TITLE
odinfmt: Refactor how the test outputs are compared with their respective snapshots

### DIFF
--- a/tools/odinfmt/snapshot/snapshot.odin
+++ b/tools/odinfmt/snapshot/snapshot.odin
@@ -64,11 +64,11 @@ snapshot_file :: proc(path: string) -> bool {
 			scanner.init(&snapshot_scanner, string(snapshot_data))
 			formatted_scanner := scanner.Scanner {}
 			scanner.init(&formatted_scanner, string(formatted))
-			cmp: for {
+			for {
 				s_ch := scanner.next(&snapshot_scanner)
 				f_ch := scanner.next(&formatted_scanner)
 				if s_ch == scanner.EOF || f_ch == scanner.EOF {
-					break cmp
+					break
 				}
 
 				if s_ch == '\r' {


### PR DESCRIPTION
When comparing the two results, it is now scanning over the strings, treating `\r\n` as `\n` and exiting if anything else is not equal.