### PR TITLE
translate logger level to diagnostic level

### DIFF
--- a/src/main.odin
+++ b/src/main.odin
@@ -89,7 +89,7 @@ main :: proc() {
 	reader := server.make_reader(os_read, cast(rawptr)&os.stdin)
 	writer := server.make_writer(os_write, cast(rawptr)&os.stdout)
 
-	context.logger = server.create_lsp_logger(&writer, log.Level.Error)
+	context.logger = server.create_lsp_logger(&writer, log.Level.Info)
 	/*
 	fh, err := os.open("log.txt", os.O_RDWR|os.O_CREATE) 
 	

--- a/src/server/log.odin
+++ b/src/server/log.odin
@@ -34,11 +34,19 @@ lsp_logger_proc :: proc(logger_data: rawptr, level: log.Level, text: string, opt
 
 	message := fmt.tprintf("%s", text)
 
+	message_type: DiagnosticSeverity
+	switch level {
+		case .Debug: message_type = DiagnosticSeverity.Hint
+		case .Info: message_type = DiagnosticSeverity.Information
+		case .Warning: message_type = DiagnosticSeverity.Warning
+		case .Error, .Fatal: message_type = DiagnosticSeverity.Error
+	}
+	
 	notification := Notification {
 		jsonrpc = "2.0",
 		method = "window/logMessage",
 		params = NotificationLoggingParams {
-			type = 1,
+			type = message_type,
 			message = message,
 		},
 	}

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -49,7 +49,7 @@ ResponseError :: struct {
 }
 
 NotificationLoggingParams :: struct {
-	type:    int,
+	type:    DiagnosticSeverity,
 	message: string,
 }
 


### PR DESCRIPTION
the client wasn't showing the correct log levels because it was always passing the error level

but with this change, the `Starting Odin Language Server` message won't show up because it's info, not error, so maybe the min log level should be info, like:
```
context.logger = server.create_lsp_logger(&writer, log.Level.Info)
```

the only other log.info is:
```
log.infof("document_close: %v", uri_string)
```
i don't know how much noise that causes, but if it's noisy it could be made debug