### PR TITLE
fixed slash for windows path

### DIFF
--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -22,12 +22,12 @@ lookup_in_path :: proc(name: string) -> (string, bool) {
 
 	for directory in strings.split_iterator(&path, delimiter) {
 		when ODIN_OS == .Windows {
-			name := fmt.tprintf("%v/%v.exe", directory, name)
+			name := filepath.join(elems = {directory, fmt.tprintf("%v.exe", name)}, allocator = context.temp_allocator)
 			if os.exists(name) {
 				return name, true
 			}
 		} else {
-			name := fmt.tprintf("%v/%v", directory, name)
+			name := filepath.join(elems = {directory, name}, allocator = context.temp_allocator)
 			if os.exists(name) {
 				if info, err := os.stat(name, context.temp_allocator); err == os.ERROR_NONE && (File_Mode_User_Executable & info.mode) != 0 {
 					return name, true


### PR DESCRIPTION
due to the hardcoded `/`, paths on windows were having a mix of `\` and `/`. This didn't cause any problems as far as I know, but it confused me at times