### PR TITLE
More accurately auto complete ObjC procedures

### DIFF
--- a/src/common/ast.odin
+++ b/src/common/ast.odin
@@ -143,13 +143,26 @@ get_attribute_objc_class_name :: proc(
 }
 
 
-get_attribute_objc_class_method :: proc(
+get_attribute_objc_is_class_method :: proc(
 	attributes: []^ast.Attribute,
 ) -> (
 	bool,
-	bool,
 ) {
-	return false, false
+	for attribute in attributes {
+		for elem in attribute.elems {
+			if assign, ok := elem.derived.(^ast.Field_Value); ok {
+				if ident, ok := assign.field.derived.(^ast.Ident);
+				   ok && ident.name == "objc_is_class_method" {
+					if field_value, ok := assign.value.derived.(^ast.Ident);
+					   ok && field_value.name == "true" {
+						return true
+					}
+				}
+
+			}
+		}
+	}
+	return false
 }
 
 unwrap_pointer :: proc(expr: ^ast.Expr) -> (ast.Ident, bool) {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2472,6 +2472,9 @@ make_symbol_procedure_from_ast :: proc(
 
 	if _, ok := common.get_attribute_objc_name(attributes); ok {
 		symbol.flags |= {.ObjC}
+		if common.get_attribute_objc_is_class_method(attributes) {
+			symbol.flags |= {.ObjCIsClassMethod}
+		}
 	}
 
 	return symbol
@@ -2766,6 +2769,9 @@ make_symbol_struct_from_ast :: proc(
 
 	if _, ok := common.get_attribute_objc_class_name(attributes); ok {
 		symbol.flags |= {.ObjC}
+		if common.get_attribute_objc_is_class_method(attributes) {
+			symbol.flags |= {.ObjCIsClassMethod}
+		}
 	}
 
 	if v.poly_params != nil {

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -140,7 +140,7 @@ collect_procedure_fields :: proc(
 		objc_name            = common.get_attribute_objc_name(
 			attributes,
 		) or_else "",
-		objc_is_class_method = common.get_attribute_objc_class_method(
+		objc_is_class_method = common.get_attribute_objc_is_class_method(
 			attributes,
 		) or_else false,
 		*/
@@ -547,6 +547,9 @@ collect_symbols :: proc(
 			if _, is_objc := common.get_attribute_objc_name(expr.attributes);
 			   is_objc {
 				symbol.flags |= {.ObjC}
+				if common.get_attribute_objc_is_class_method(expr.attributes) {
+					symbol.flags |= {.ObjCIsClassMethod}
+				}
 			}
 		case ^ast.Proc_Type:
 			token = v^
@@ -584,6 +587,9 @@ collect_symbols :: proc(
 				expr.attributes,
 			); is_objc {
 				symbol.flags |= {.ObjC}
+				if common.get_attribute_objc_is_class_method(expr.attributes) {
+					symbol.flags |= {.ObjCIsClassMethod}
+				}
 			}
 		case ^ast.Enum_Type:
 			token = v^

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -519,9 +519,19 @@ get_selector_completion :: proc(
 					}
 				}
 
-				if position_context.arrow && symbol.type != .Function {
+				if position_context.arrow {
+					if symbol.type != .Function {
+						continue
+					}
+					if .ObjCIsClassMethod in symbol.flags {
+						assert(.ObjC in symbol.flags)
+						continue
+					}
+				}
+				if !position_context.arrow && .ObjC in symbol.flags {
 					continue
 				}
+
 
 				item := CompletionItem {
 					label         = name,

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -131,6 +131,7 @@ SymbolFlag :: enum {
 	Variable, //Symbols that are variable, this means their value decl was mutable
 	Local,
 	ObjC,
+	ObjCIsClassMethod, // should be set true only when ObjC is enabled
 }
 
 SymbolFlags :: bit_set[SymbolFlag]


### PR DESCRIPTION
Changes:
* Rename `get_attribute_objc_class_method` to `get_attribute_objc_is_class_method`
* Add flag `ObjCIsClassMethod`. This should be set when the attribute `objc_is_class_method=true` is detected.
* Only show objc procedures when using `->`
* Do not show class methods when using `->` (still need completion for it)