### PR TITLE
Update odinfmt with new filepath.Walk_Proc signature

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -60,7 +60,7 @@ format_file :: proc(
 
 files: [dynamic]string
 
-walk_files :: proc(info: os.File_Info, in_err: os.Errno) -> (err: os.Errno, skip_dir: bool) {
+walk_files :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Errno, skip_dir: bool) {
 	if info.is_dir {
 		return 0, false
 	}
@@ -150,7 +150,7 @@ main :: proc() {
 			}
 		}
 	} else if os.is_dir(path) {
-		filepath.walk(path, walk_files)
+		filepath.walk(path, walk_files, nil)
 
 		for file in files {
 			fmt.println(file)


### PR DESCRIPTION
Per https://github.com/odin-lang/Odin/commit/9d50a0490530f8c602ece4c9bd56f316e169b66a

an additional parameter `user_data: rawptr` was added to the `filepath.Walk_Proc` callback.

This commit updates odinfmt to use the new parameter.