### PR TITLE
Fixed build error against latest Odin master version

### DIFF
--- a/src/pdb/pdbStream.odin
+++ b/src/pdb/pdbStream.odin
@@ -68,7 +68,7 @@ parse_pdb_stream :: proc(this: ^BlocksReader) -> (header: PdbStreamHeader, nameM
             //fmt.printf("k: %v, v: %v, vstr: %v\n", kv.key, kv.value, ))
             nameStr : string
             assert(kv.key < nameStringLen, "invalid name key")
-            nameStr = strings.string_from_nul_terminated_ptr(&nameMap.strBuf[kv.key], len(nameMap.strBuf)-int(kv.key))
+            nameStr = strings.string_from_null_terminated_ptr(&nameMap.strBuf[kv.key], len(nameMap.strBuf)-int(kv.key))
             //fmt.printf("bucket#%v [%v:%v], name: %v\n", i, kv.key, kv.value, nameStr)
             nameMap.names[nameIdx] = {nameStr, kv.value }
             nameIdx+=1

--- a/src/pdb/stackTrace.odin
+++ b/src/pdb/stackTrace.odin
@@ -267,7 +267,7 @@ parse_stack_trace :: proc(stackTrace: []StackFrame, sameProcess: bool, srcCodeLo
                         pPdbBase := (^PECodeViewInfoPdb70Base)((stackFrame.imgBaseAddr) + uintptr(dde.rawDataAddr))
                         if pPdbBase.cvSignature != PECodeView_Signature_RSDS do continue
                         pPdbPath := (^byte)(uintptr(pPdbBase) + cast(uintptr)size_of(PECodeViewInfoPdb70Base))
-                        mi.pdbPath = strings.string_from_nul_terminated_ptr(pPdbPath, int(dde.dataSize-size_of(PECodeViewInfoPdb70Base)))
+                        mi.pdbPath = strings.string_from_null_terminated_ptr(pPdbPath, int(dde.dataSize-size_of(PECodeViewInfoPdb70Base)))
                     } else {
                         // otherwise we need to seek to it on disk
                         peStream := os.stream_from_handle(peFile)


### PR DESCRIPTION
The Odin compiler master branch fixed a naming typo from string_from_nul_terminated_ptr to string_from_null_terminated_ptr.