### PR TITLE
Fixed typo in util_winows.odin

### DIFF
--- a/src/common/util_windows.odin
+++ b/src/common/util_windows.odin
@@ -102,10 +102,10 @@ run_executable :: proc(
 		return 0, false, stdout[0:]
 	}
 
-	startup_info: win32.STARTUPINFOW
+	startup_info: win32.STARTUPINFO
 	process_info: win32.PROCESS_INFORMATION
 
-	startup_info.cb = size_of(win32.STARTUPINFOW)
+	startup_info.cb = size_of(win32.STARTUPINFO)
 
 	startup_info.hStdError = stdout_write
 	startup_info.hStdOutput = stdout_write


### PR DESCRIPTION
Lines 105 and 108 had `win32.STARTUPINFOW` which was giving compiler errors. Changed to `win32.STARTUPINFO`

odin version: dev-2023-04-nightly:adcaace0
OS: Windows 11