### PR TITLE
Add mention of ODIN_ROOT to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example of ols.json:
 
 ```
 
+You can also set `ODIN_ROOT` environment variable to the path where ols should look for core and vendor libraries.
 
 Options:
 


### PR DESCRIPTION
I think mention of this variable should be included in the readme since it's quite important for multi-user projects where each can have the libraries on different paths.