### PR TITLE
Add json-schema files for json config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Language server for Odin. This project is still in early development.
 
 ## Table Of Contents
 
-- [Installation](#installation)
-  - [Configuration](#Configuration)
-- [Features](#features)
-- [Clients](#clients)
-  - [Vs Code](#vs-code)
-  - [Sublime](#sublime)
-  - [Vim](#vim)
-  - [Neovim](#neovim)
-  - [Emacs](#emacs)
+-   [Installation](#installation)
+    -   [Configuration](#Configuration)
+-   [Features](#features)
+-   [Clients](#clients)
+    -   [Vs Code](#vs-code)
+    -   [Sublime](#sublime)
+    -   [Vim](#vim)
+    -   [Neovim](#neovim)
+    -   [Emacs](#emacs)
 
 ## Installation
 
@@ -38,14 +38,15 @@ Example of `ols.json`:
 
 ```json
 {
-  "collections": [
-    { "name": "core", "path": "c:/path/to/Odin/core" },
-    { "name": "shared", "path": "c:/path/to/MyProject/src" }
-  ],
-  "enable_semantic_tokens": false,
-  "enable_document_symbols": true,
-  "enable_hover": true,
-  "enable_snippets": true
+	"$schema": "https://raw.githubusercontent.com/DanielGavin/ols/master/misc/ols.schema.json",
+	"collections": [
+		{ "name": "core", "path": "c:/path/to/Odin/core" },
+		{ "name": "shared", "path": "c:/path/to/MyProject/src" }
+	],
+	"enable_semantic_tokens": false,
+	"enable_document_symbols": true,
+	"enable_hover": true,
+	"enable_snippets": true
 }
 ```
 
@@ -61,7 +62,7 @@ Options:
 
 `enable_document_symbols`: Turns on outline of all your global declarations in your document.
 
-`odin_command`: Allows you to specifiy your Odin location, instead of just relying on the environment path.
+`odin_command`: Allows you to specify your Odin location, instead of just relying on the environment path.
 
 `checker_args`: Pass custom arguments to `odin check`.
 
@@ -75,9 +76,10 @@ Example:
 
 ```json
 {
-  "character_width": 80,
-  "tabs": true,
-  "tabs_width": 4
+	"$schema": "https://raw.githubusercontent.com/DanielGavin/ols/master/misc/odinfmt.schema.json",
+	"character_width": 80,
+	"tabs": true,
+	"tabs_width": 4
 }
 ```
 
@@ -97,12 +99,12 @@ Options:
 
 Support Language server features:
 
-- Completion
-- Go to definition
-- Semantic tokens(really unstable and unfinished)
-- Document symbols
-- Signature help
-- Hover
+-   Completion
+-   Go to definition
+-   Semantic tokens(really unstable and unfinished)
+-   Document symbols
+-   Signature help
+-   Hover
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ols
-Language server for Odin. This project is still in early development. 
+
+Language server for Odin. This project is still in early development.
 
 **Status**: All platforms work.
 
 ## Table Of Contents
+
 - [Installation](#installation)
   - [Configuration](#Configuration)
 - [Features](#features)
@@ -16,34 +18,35 @@ Language server for Odin. This project is still in early development.
 
 ## Installation
 
- ```
- cd ols
+```bash
+cd ols
 
- //for windows
- ./build.bat 
+# for windows
+./build.bat
 
- //for linux
- ./build.sh
- ```
+# for linux
+./build.sh
+```
 
 ### Configuration
 
-All configurations is contained in one json file that must be named ```ols.json``` in your main workspace.
+All configurations is contained in one json file that must be named `ols.json` in your main workspace.
 
-In order for the language server to index your files, the ols.json must contain all the collections in your project.
+In order for the language server to index your files, the `ols.json` must contain all the collections in your project.
 
-Example of ols.json:
+Example of `ols.json`:
 
 ```json
 {
-  "collections": [{ "name": "core", "path": "c:/path/to/Odin/core" },
-                  { "name": "shared", "path": "c:/path/to/MyProject/src" }],
+  "collections": [
+    { "name": "core", "path": "c:/path/to/Odin/core" },
+    { "name": "shared", "path": "c:/path/to/MyProject/src" }
+  ],
   "enable_semantic_tokens": false,
   "enable_document_symbols": true,
   "enable_hover": true,
   "enable_snippets": true
 }
-
 ```
 
 You can also set `ODIN_ROOT` environment variable to the path where ols should look for core and vendor libraries.
@@ -56,27 +59,25 @@ Options:
 
 `enable_semantic_tokens`: Turns on syntax highlighting.
 
-`enable_document_symbols`: Turns on outline of all your global declarations in your document. 
+`enable_document_symbols`: Turns on outline of all your global declarations in your document.
 
 `odin_command`: Allows you to specifiy your Odin location, instead of just relying on the environment path.
 
-`checker_args`: Pass custom arguments to ```odin check```.
+`checker_args`: Pass custom arguments to `odin check`.
 
 `verbose`: Logs warnings instead of just errors.
 
-
-
-
 ### Odinfmt configurations
+
 Odinfmt reads configuration through `odinfmt.json`.
 
 Example:
 
 ```json
 {
-	"character_width": 80,
-	"tabs": true,
-	"tabs_width": 4
+  "character_width": 80,
+  "tabs": true,
+  "tabs_width": 4
 }
 ```
 
@@ -93,22 +94,28 @@ Options:
 `tabs_width`: How many characters one tab represents
 
 ## Features
-  Support Language server features:
-  - Completion
-  - Go to definition
-  - Semantic tokens(really unstable and unfinished)
-  - Document symbols
-  - Signature help
-  - Hover
+
+Support Language server features:
+
+- Completion
+- Go to definition
+- Semantic tokens(really unstable and unfinished)
+- Document symbols
+- Signature help
+- Hover
 
 ## Clients
 
 ### VS Code
+
 Install the extension https://marketplace.visualstudio.com/items?itemName=DanielGavin.ols
+
 ### Sublime
+
 Install the package https://github.com/sublimelsp/LSP
 
 Configuration of the LSP:
+
 ```
 {
 	"clients":
@@ -129,9 +136,11 @@ Configuration of the LSP:
 ```
 
 ### Vim
+
 Install [Coc](https://github.com/neoclide/coc.nvim).
 
 Configuration of the LSP:
+
 ```
 {
   "languageserver": {
@@ -145,18 +154,21 @@ Configuration of the LSP:
 ```
 
 ### Neovim
+
 Neovim has a builtin support for LSP.
 
 There is a plugin that turns easier the setup, called [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). You can
 install it with you prefered package manager.
 
 A simple configuration to use with Odin would be like this:
+
 ```lua
 local lspconfig = require('lspconfig')
 lspconfig.ols.setup({})
 ```
 
 ### Emacs
+
 ```
 ;; With odin-mode (https://github.com/mattt-b/odin-mode) and lsp-mode already added to your init.el of course!.
 (setq-default lsp-auto-guess-root t) ;; if you work with Projectile/project.el this will help find the ols.json file.
@@ -170,6 +182,7 @@ lspconfig.ols.setup({})
 ```
 
 ### Helix
+
 ```
 [[language]]
 name = "odin"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -217,6 +217,7 @@ export function createOlsConfig(ctx: Ctx) {
     const corePath = path.resolve(path.join(path.dirname(odinPath), "core"));
 
     const config = {
+		$schema: "https://raw.githubusercontent.com/DanielGavin/ols/master/misc/ols.schema.json",
         collections: [{ name: "core", path: corePath }],
         enable_document_symbols: true,
         enable_semantic_tokens: false,

--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"character_width": {
+			"type": "integer",
+			"default": 100,
+			"description": "How many characters it takes before it line breaks it."
+		},
+		"spaces": {
+			"type": "integer",
+			"default": 4,
+			"description": "Spaces per indentation"
+		},
+		"newline_limit": {
+			"type": "integer",
+			"default": 2,
+			"description": "The limit of newlines between statements and declarations."
+		},
+		"tabs": {
+			"type": "boolean",
+			"default": true,
+			"description": "Use tabs instead of spaces"
+		},
+		"tabs_width": {
+			"type": "integer",
+			"default": 4,
+			"description": "How many characters one tab represents"
+		},
+		"convert_do": {
+			"type": "boolean",
+			"default": false,
+			"description": "Convert all do statements to brace blocks"
+		},
+		"brace_style": {
+			"type": "string",
+			"enum": ["_1TBS", "Allman", "Stroustrup", "K_And_R"],
+			"default": "_1TBS"
+		},
+		"indent_cases": {
+			"type": "boolean",
+			"default": false
+		},
+		"newline_style": {
+			"type": "string",
+			"enum": ["CRLF", "LF"],
+			"default": "CRLF"
+		}
+	},
+	"required": []
+}

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -1,0 +1,70 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"workspace_folders": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"uri": { "type": "string" }
+				}
+			}
+		},
+		"collections": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"path": { "type": "string" }
+				}
+			}
+		},
+		"completion_support_md": { "type": "boolean" },
+		"hover_support_md": { "type": "boolean" },
+		"signature_offset_support": { "type": "boolean" },
+		"running": { "type": "boolean" },
+		"verbose": {
+			"type": "boolean",
+			"description": "Logs warnings instead of just errors."
+		},
+		"enable_format": { "type": "boolean" },
+		"enable_hover": {
+			"type": "boolean",
+			"description": "Enables hover feature"
+		},
+		"enable_document_symbols": {
+			"type": "boolean",
+			"description": "Turns on outline of all your global declarations in your document."
+		},
+		"enable_semantic_tokens": {
+			"type": "boolean",
+			"description": "Turns on syntax highlighting."
+		},
+		"enable_inlay_hints": { "type": "boolean" },
+		"enable_procedure_context": { "type": "boolean" },
+		"enable_snippets": {
+			"type": "boolean",
+			"description": "Turns on builtin snippets"
+		},
+		"enable_references": { "type": "boolean" },
+		"enable_rename": { "type": "boolean" },
+		"enable_label_details": { "type": "boolean" },
+		"enable_std_references": { "type": "boolean" },
+		"enable_import_fixer": { "type": "boolean" },
+		"disable_parser_errors": { "type": "boolean" },
+		"thread_count": { "type": "integer" },
+		"file_log": { "type": "boolean" },
+		"odin_command": {
+			"type": "string",
+			"description": "Allows you to specify your Odin location, instead of just relying on the environment path."
+		},
+		"checker_args": {
+			"type": "string",
+			"description": "Pass custom arguments to `odin check`."
+		}
+	},
+	"required": []
+}

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -2,16 +2,6 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
 	"properties": {
-		"workspace_folders": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"name": { "type": "string" },
-					"uri": { "type": "string" }
-				}
-			}
-		},
 		"collections": {
 			"type": "array",
 			"items": {
@@ -22,40 +12,31 @@
 				}
 			}
 		},
-		"completion_support_md": { "type": "boolean" },
-		"hover_support_md": { "type": "boolean" },
-		"signature_offset_support": { "type": "boolean" },
-		"running": { "type": "boolean" },
-		"verbose": {
+		"thread_pool_count": { "type": "integer" },
+		"enable_semantic_tokens": {
 			"type": "boolean",
-			"description": "Logs warnings instead of just errors."
-		},
-		"enable_format": { "type": "boolean" },
-		"enable_hover": {
-			"type": "boolean",
-			"description": "Enables hover feature"
+			"description": "Turns on syntax highlighting."
 		},
 		"enable_document_symbols": {
 			"type": "boolean",
 			"description": "Turns on outline of all your global declarations in your document."
 		},
-		"enable_semantic_tokens": {
+		"enable_hover": {
 			"type": "boolean",
-			"description": "Turns on syntax highlighting."
+			"description": "Enables hover feature"
 		},
-		"enable_inlay_hints": { "type": "boolean" },
 		"enable_procedure_context": { "type": "boolean" },
 		"enable_snippets": {
 			"type": "boolean",
 			"description": "Turns on builtin snippets"
 		},
+		"enable_inlay_hints": { "type": "boolean" },
 		"enable_references": { "type": "boolean" },
-		"enable_rename": { "type": "boolean" },
-		"enable_label_details": { "type": "boolean" },
-		"enable_std_references": { "type": "boolean" },
-		"enable_import_fixer": { "type": "boolean" },
 		"disable_parser_errors": { "type": "boolean" },
-		"thread_count": { "type": "integer" },
+		"verbose": {
+			"type": "boolean",
+			"description": "Logs warnings instead of just errors."
+		},
 		"file_log": { "type": "boolean" },
 		"odin_command": {
 			"type": "string",


### PR DESCRIPTION
I've included all fields present in the structs in the source, but maybe they should be limited to those mentioned in the README.

I have no idea if the schema is correct by any standard, but the autocomplete works well:

https://github.com/DanielGavin/ols/assets/24491503/2a0b27ea-ae01-4850-ba6c-1766929b1ecc

