### PR TITLE
textmate improvements

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -13,6 +13,9 @@
 			"include": "#types"
 		},
 		{
+			"include": "#object-identifiers"
+		},
+		{
 			"include": "#functions-and-declarations"
 		},
 		{
@@ -169,6 +172,17 @@
 				}
 			]
 		},
+		"object-identifiers": {
+			"patterns": [
+				{
+					"captures": {
+						"1": { "name": "variable.other.object" },
+						"2": { "name": "punctuation.accessor.odin" }
+					},
+					"match": "([A-Za-z_][A-Za-z0-9_]*)\\s*(\\.)"
+				}
+			]
+		},
 		"functions-and-declarations": {
 			"patterns": [
 				{
@@ -217,15 +231,6 @@
 						}
 					},
 					"match": "(proc)\\s*([\\(])"
-				},
-				{
-					"captures": {
-						"1": { "name": "variable.other.object" },
-						"2": { "name": "punctuation.accessor.odin" },
-						"3": { "name": "entity.name.function.odin" },
-						"4": { "name": "punctuation.odin" }
-					},
-					"match": "([A-Za-z_][A-Za-z0-9_]*)\\s*(\\.)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*[!]?\\s*([\\(])"
 				},
 				{
 					"captures": {

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -112,8 +112,8 @@
 					"match": "\\b(asm)\\b"
 				},
 				{
-					"name": "keyword.operator.odin",
-					"match": "\\b(distinct|context)\\b"
+					"name": "variable.other.object.odin",
+					"match": "\\b(context)\\b"
 				},
 				{
 					"name": "constant.language.odin",
@@ -133,7 +133,7 @@
 				},
 				{
 					"name": "storage.type.odin",
-					"match": "\\b(struct|enum|union|map|set|bit_set|typeid|matrix)\\b"
+					"match": "\\b(struct|enum|union|distinct|map|set|bit_set|typeid|matrix)\\b"
 				},
 				{
 					"name": "keyword.function.odin",
@@ -205,7 +205,7 @@
 							"name": "punctuation.odin"
 						}
 					},
-					"match": "\\b(len|cap|make|resize|reserve|append|delete|assertf?|panicf?)\\b\\s*(\\()"
+					"match": "\\b(len|cap|make|resize|reserve|append|delete|assert|panic)\\b\\s*(\\()"
 				},
 				{
 					"captures": {
@@ -220,25 +220,28 @@
 				},
 				{
 					"captures": {
-						"1": {
-							"name": "support.function.odin"
-						},
-						"2": {
-							"name": "punctuation.odin"
-						}
+						"1": { "name": "variable.other.object" },
+						"2": { "name": "punctuation.accessor.odin" },
+						"3": { "name": "entity.name.function.odin" },
+						"4": { "name": "punctuation.odin" }
+					},
+					"match": "([A-Za-z_][A-Za-z0-9_]*)\\s*(\\.)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*[!]?\\s*([\\(])"
+				},
+				{
+					"captures": {
+						"1": { "name": "entity.name.function.odin" },
+						"2": { "name": "punctuation.odin" }
 					},
 					"match": "([A-Za-z_][A-Za-z0-9_]*)\\s*[!]?\\s*([\\(])"
 				},
 				{
 					"captures": {
-						"1": {
-							"name": "entity.name.type.odin"
-						},
-						"2": {
-							"name": "storage.type.odin"
-						}
+						"1": { "name": "entity.name.type.odin" },
+						"2": { "name": "keyword.operator.assignment.odin" },
+						"3": { "name": "keyword.operator.assignment.odin" },
+						"4": { "name": "storage.type.odin" }
 					},
-					"match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\s*[:]\\s*[:]\\s*(struct|union|enum|bit_set)"
+					"match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\s*([:])\\s*([:])\\s*(struct|union|enum|bit_set)"
 				}
 			]
 		},


### PR DESCRIPTION
Add `distinct` to `storage.type.odin` as it's used when creating types similarly to `union`, `struct`, etc.
Add `context` to `variable.other.object.odin` as it's pretty much a global object, just like `window` in ts

Remove `assertf` and `panicf` from function builtins (they are from a module)

Add procedure calls to `entity.name.function`. This doesn't include the builtin ones

Add a object property access pattern.

![image](https://github.com/DanielGavin/ols/assets/24491503/bdb281bb-6bf7-421d-81de-d5aca001beb4)