### PR TITLE
Add more builtin procedures

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -64,7 +64,7 @@
 						"1": { "name": "support.function.builtin.odin" },
 						"2": { "name": "punctuation.odin" }
 					},
-					"match": "\\b(len|cap|size_of|align_of|offset_of_selector|offset_of_member|offset_of|offset_of_by_string|type_of|type_info_of|typeid_of|swizzle|complex|quaternion|real|imag|jmag|kmag|conj|expand_values|min|max|abs|clamp|soa_zip|soa_unzip|make|resize|reserve|append|delete|assert|panic)\\b\\s*(\\()"
+					"match": "(?<!\\.)\\b(len|cap|size_of|align_of|offset_of_selector|offset_of_member|offset_of|offset_of_by_string|type_of|type_info_of|typeid_of|swizzle|complex|quaternion|real|imag|jmag|kmag|conj|expand_values|min|max|abs|clamp|soa_zip|soa_unzip|make|resize|reserve|append|delete|assert|panic)\\b\\s*(\\()"
 				},
 				{
 					"captures": {

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -61,16 +61,10 @@
 			"patterns": [
 				{
 					"captures": {
-						"1": { "name": "keyword.function.odin" }
-					},
-					"match": "\\b(size_of|align_of|offset_of|type_of|type_info_of|typeid_of)\\b\\s*\\("
-				},
-				{
-					"captures": {
 						"1": { "name": "support.function.builtin.odin" },
 						"2": { "name": "punctuation.odin" }
 					},
-					"match": "\\b(len|cap|make|resize|reserve|append|delete|assert|panic)\\b\\s*(\\()"
+					"match": "\\b(len|cap|size_of|align_of|offset_of_selector|offset_of_member|offset_of|offset_of_by_string|type_of|type_info_of|typeid_of|swizzle|complex|quaternion|real|imag|jmag|kmag|conj|expand_values|min|max|abs|clamp|soa_zip|soa_unzip|make|resize|reserve|append|delete|assert|panic)\\b\\s*(\\()"
 				},
 				{
 					"captures": {


### PR DESCRIPTION
Adds some of the missing procedures from the `builtin` package.
Also it moves the ones that were in `keyword.function.odin` to `support.function.builtin.odin` as I don't see why they should have a different scope — they come from the same package.