### PR TITLE
Format labelDetails for procs that returns and variables/constants

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1797,6 +1797,13 @@ format_to_label_details :: proc(list: ^CompletionList) {
         description = item.detail[type_index+1:]
       }
       item.detail = ""
+    } else if item.kind == .Struct || item.kind == .Enum || item.kind == .Class {
+			type_index := strings.index(item.detail, ":")
+      item.labelDetails = CompletionItemLabelDetails {
+        detail = "",
+        description = item.detail[type_index+1:]
+      }
+      item.detail = ""
     }
 	}
 }

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1772,41 +1772,42 @@ format_to_label_details :: proc(list: ^CompletionList) {
 	// description = right
 	for item in &list.items {
 		// log.errorf("item:%v: %v:%v", item.kind, item.label, item.detail)
-		if item.kind == .Function {
-			proc_index := strings.index(item.detail, ": proc")
-			// check if the function return somrthing
-			proc_return_index := strings.index(item.detail, "->")
-			if proc_return_index > 0 {
-				proc_end_index := strings.index(item.detail[0:proc_return_index], ")")
+		#partial switch item.kind {
+			case .Function:
+				proc_index := strings.index(item.detail, ": proc")
+				// check if the function return somrthing
+				proc_return_index := strings.index(item.detail, "->")
+				if proc_return_index > 0 {
+					proc_end_index := strings.index(item.detail[0:proc_return_index], ")")
+					item.labelDetails = CompletionItemLabelDetails {
+						detail = item.detail[proc_index + 6: proc_return_index],
+						description = item.detail[proc_return_index:]
+					}
+					item.detail = item.label
+				} else {
+					item.labelDetails = CompletionItemLabelDetails {
+						detail = item.detail[proc_index + 6:len(item.detail)],
+						description = ""
+					}
+					item.detail = ""
+				}
+			case .Variable, .Constant, .Field:
+				type_index := strings.index(item.detail, ":")
 				item.labelDetails = CompletionItemLabelDetails {
-					detail = item.detail[proc_index + 6: proc_return_index],
-					description = item.detail[proc_return_index:]
+					detail = "",
+					description = item.detail[type_index+1:]
 				}
 				item.detail = item.label
-			} else {
+			case .Struct, .Enum, .Class:
+				type_index := strings.index(item.detail, ":")
 				item.labelDetails = CompletionItemLabelDetails {
-					detail = item.detail[proc_index + 6:len(item.detail)],
-					description = ""
+					detail = "",
+					description = item.detail[type_index+1:]
 				}
-				item.detail = ""
-			}
-		} else if item.kind == .Variable || item.kind == .Constant {
-			type_index := strings.index(item.detail, ":")
-			item.labelDetails = CompletionItemLabelDetails {
-				detail = "",
-				description = item.detail[type_index+1:]
-			}
-			item.detail = item.label
-		} else if item.kind == .Struct || item.kind == .Enum || item.kind == .Class {
-			type_index := strings.index(item.detail, ":")
-			item.labelDetails = CompletionItemLabelDetails {
-				detail = "",
-				description = item.detail[type_index+1:]
-			}
-			item.detail = item.label
-		} else if item.kind == .Keyword {
-			item.detail = "keyword"
-		}
+				item.detail = item.label
+			case .Keyword:
+				item.detail = "keyword"
+		}	
 	}
 }
 

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1768,14 +1768,36 @@ append_magic_union_completion :: proc(
 
 //Temporary hack to support labeldetails
 format_to_label_details :: proc(list: ^CompletionList) {
+  // detail      = left
+  // description = right
 	for item in &list.items {
+    // log.errorf("item:%v: %v:%v", item.kind, item.label, item.detail)
 		if item.kind == .Function && true {
-			proc_index := strings.index(item.detail, "proc")
-
-			item.labelDetails = CompletionItemLabelDetails {
-				detail = item.detail[proc_index + 4:len(item.detail)],
-			}
-		}
+			proc_index := strings.index(item.detail, ": proc")
+      // check if the function return somrthing
+      proc_return_index := strings.index(item.detail, "->")
+      if proc_return_index > 0 {
+        proc_end_index := strings.index(item.detail[0:proc_return_index], ")")
+        item.labelDetails = CompletionItemLabelDetails {
+          detail = item.detail[proc_index + 6: proc_return_index],
+          description = item.detail[proc_return_index:]
+        }
+        item.detail = item.label
+      } else {
+        item.labelDetails = CompletionItemLabelDetails {
+          detail = item.detail[proc_index + 6:len(item.detail)],
+          description = ""
+        }
+        item.detail = ""
+      }
+		} else if item.kind == .Variable || item.kind == .Constant {
+			type_index := strings.index(item.detail, ":")
+      item.labelDetails = CompletionItemLabelDetails {
+        detail = "",
+        description = item.detail[type_index+1:]
+      }
+      item.detail = ""
+    }
 	}
 }
 

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1768,46 +1768,47 @@ append_magic_union_completion :: proc(
 
 //Temporary hack to support labeldetails
 format_to_label_details :: proc(list: ^CompletionList) {
-  // detail      = left
-  // description = right
+	// detail      = left
+	// description = right
 	for item in &list.items {
-    // log.errorf("item:%v: %v:%v", item.kind, item.label, item.detail)
-		if item.kind == .Function && true {
+		// log.errorf("item:%v: %v:%v", item.kind, item.label, item.detail)
+		if item.kind == .Function {
 			proc_index := strings.index(item.detail, ": proc")
-      // check if the function return somrthing
-      proc_return_index := strings.index(item.detail, "->")
-      if proc_return_index > 0 {
-        proc_end_index := strings.index(item.detail[0:proc_return_index], ")")
-        item.labelDetails = CompletionItemLabelDetails {
-          detail = item.detail[proc_index + 6: proc_return_index],
-          description = item.detail[proc_return_index:]
-        }
-        item.detail = item.label
-      } else {
-        item.labelDetails = CompletionItemLabelDetails {
-          detail = item.detail[proc_index + 6:len(item.detail)],
-          description = ""
-        }
-        item.detail = ""
-      }
+			// check if the function return somrthing
+			proc_return_index := strings.index(item.detail, "->")
+			if proc_return_index > 0 {
+				proc_end_index := strings.index(item.detail[0:proc_return_index], ")")
+				item.labelDetails = CompletionItemLabelDetails {
+					detail = item.detail[proc_index + 6: proc_return_index],
+					description = item.detail[proc_return_index:]
+				}
+				item.detail = item.label
+			} else {
+				item.labelDetails = CompletionItemLabelDetails {
+					detail = item.detail[proc_index + 6:len(item.detail)],
+					description = ""
+				}
+				item.detail = ""
+			}
 		} else if item.kind == .Variable || item.kind == .Constant {
 			type_index := strings.index(item.detail, ":")
-      item.labelDetails = CompletionItemLabelDetails {
-        detail = "",
-        description = item.detail[type_index+1:]
-      }
-      item.detail = ""
-    } else if item.kind == .Struct || item.kind == .Enum || item.kind == .Class {
+			item.labelDetails = CompletionItemLabelDetails {
+				detail = "",
+				description = item.detail[type_index+1:]
+			}
+			item.detail = item.label
+		} else if item.kind == .Struct || item.kind == .Enum || item.kind == .Class {
 			type_index := strings.index(item.detail, ":")
-      item.labelDetails = CompletionItemLabelDetails {
-        detail = "",
-        description = item.detail[type_index+1:]
-      }
-      item.detail = ""
-    }
+			item.labelDetails = CompletionItemLabelDetails {
+				detail = "",
+				description = item.detail[type_index+1:]
+			}
+			item.detail = item.label
+		} else if item.kind == .Keyword {
+			item.detail = "keyword"
+		}
 	}
 }
-
 
 bitset_operators: map[string]bool = {
 	"|"  = true,


### PR DESCRIPTION
It gives a cleaner and less noisy look overall

Some screenshots:

![image](https://github.com/DanielGavin/ols/assets/44361234/b5fa975a-5a7d-46ed-91f1-8e0096c6bdc8)

![image](https://github.com/DanielGavin/ols/assets/44361234/3dccb5e9-aefe-4603-8823-7fa306fa3476)

![image](https://github.com/DanielGavin/ols/assets/44361234/a4a97fed-a6ed-4402-b385-9df05316868f)


![image](https://github.com/DanielGavin/ols/assets/44361234/be3ffe0e-769b-4f2e-8e5b-40e6a85ea7d5)

![image](https://github.com/DanielGavin/ols/assets/44361234/441683cb-1972-4b55-a0b2-567f7f3c2f11)

