### PR TITLE
Hack for sublime text bug

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1822,7 +1822,7 @@ format_to_label_details :: proc(list: ^CompletionList) {
 		// or if this PR gets merged: https://github.com/sublimelsp/LSP/pull/2293
 		dt:= &item.labelDetails.? or_else nil
 		if dt == nil do continue
-		if strings.contains(dt.detail, "..") || strings.contains(dt.detail, "#") {
+		if strings.contains(dt.detail, "..") && strings.contains(dt.detail, "#") {
 			s, _ := strings.replace_all(dt.detail, "..", "ꓸꓸ",  allocator = context.temp_allocator)
 			dt.detail = s
 		}

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1815,7 +1815,17 @@ format_to_label_details :: proc(list: ^CompletionList) {
 				item.detail = item.label
 			case .Keyword:
 				item.detail = "keyword"
-		}	
+		}
+
+		// hack for sublime text's issue
+		// remove when this issue is fixed: https://github.com/sublimehq/sublime_text/issues/6033
+		// or if this PR gets merged: https://github.com/sublimelsp/LSP/pull/2293
+		dt:= &item.labelDetails.? or_else nil
+		if dt == nil do continue
+		if strings.contains(dt.detail, "..") || strings.contains(dt.detail, "#") {
+			s, _ := strings.replace_all(dt.detail, "..", "ꓸꓸ",  allocator = context.temp_allocator)
+			dt.detail = s
+		}
 	}
 }
 


### PR DESCRIPTION
Sublime text has an issue where it doesn't show completions for items that has both ``..`` and ``#`` in the label detail

https://github.com/sublimehq/sublime_text/issues/6033

This PR is a workaround, it basically replace ``..`` with a visual equivalent ``ꓸꓸ`` https://www.compart.com/en/unicode/U+A4F8

This should be removed once the issue gets fixed in Sublime Text

It hides lot of procs, specially in ``core:fmt`` module, so i think it worth having this hack for now, what do you think?

If not mergeable, I think it worth letting this open, at least as documentation for people who use Sublime Text

Easy to reproduce:

```odin
reproduce_the_bug :: proc(fmt: string, args: ..any, location := #caller_location) {
}
```
