### PR TITLE
update for switch _ in

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1154,7 +1154,12 @@ visit_stmt :: proc(
 
 		//If the switch contains `switch in v`
 		if exprs_contain_empty_idents(v.lhs) && block_type == .Switch_Stmt {
-			assign_document = cons(document, text(v.op.text))
+			assign_document = cons(
+				document,
+				text("_"),
+				break_with_space(),
+				text(v.op.text),
+			)
 		} else {
 			assign_document = cons(
 				document,

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -94,7 +94,7 @@ clone_node :: proc(
 		align = elem.align
 	}
 
-	#partial switch in node.derived {
+	#partial switch _ in node.derived {
 	case ^Package, ^File:
 		panic("Cannot clone this node type")
 	}


### PR DESCRIPTION
With https://github.com/odin-lang/Odin/commit/cd74cdfdaf5157704b836c8de1c32b5a03dddcae, `switch in` is now an error, but ols was autoformatting `switch_ in` to `switch in`.

Fix autoformatting so `switch _ in` autoformats to `switch _ in`.