### PR TITLE
sort imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Options:
 
 `tabs_width`: How many characters one tab represents
 
+`sort_imports`: A boolean that defaults to true, which can be set to false to disable sorting imports.
+
 ## Features
 
 Support Language server features:


### PR DESCRIPTION
This PR adds sorting imports to the formatter.

It only has to check for imports on the top level declarations of a file since odin enforces them to only be there.
Then it keeps track of the index of imports it sees.
When a different declaration is found or when an import is found but it is preceded by an empty line, it sorts the declarations by the full import path and inserts them into the document.

Also adds a new key into the `odinfmt.json` called `sort_imports` which can be set to `false` to turn this off.

Something like this will be kept in tact, because of the grouping with an empty line:
```odin
import "core:mem"
import "core:odin/parser"
import "core:path/filepath"

import "core:intrinsics"
import "core:os"
import "shared:common"
```

Example diff:

```diff
-import "shared:odin/printer"
-import "core:odin/parser"
-import "core:odin/ast"
 import "core:encoding/json"
+import "core:fmt"
+import "core:odin/ast"
+import "core:odin/parser"
 import "core:os"
 import "core:path/filepath"
-import "core:fmt"
+import "shared:odin/printer"
```