### PR TITLE
Remove `vscode:prepublish` and split `build` and `package` scripts

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -118,12 +118,12 @@
 		]
 	},
 	"scripts": {
-		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"lint": "eslint src --ext ts",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",
-		"package": "npm run compile && vsce package -o extension.vsix",
+		"package": "vsce package -o extension.vsix",
+		"build": "npm run compile && npm run package",
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The `vscode:prepublish` script were causing `compile` script to be executed twice when running `npm run package`.

Also I've split `package` to `build` and `package` so that the extension can be quickly rebundled when I've only changed the grammars.

```bash
$ npm run package

> ols@0.1.16 package
> npm run compile && vsce package -o extension.vsix


> ols@0.1.16 compile
> tsc -p ./

Executing prepublish script 'npm run vscode:prepublish'...

> ols@0.1.16 vscode:prepublish
> npm run compile


> ols@0.1.16 compile
> tsc -p ./

This extension consists of 288 files, out of which 211 are JavaScript files. For performance reasons, you should...
```