### PR TITLE
Update basic-types grammar

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -442,59 +442,59 @@
 		"basic-types": {
 			"patterns": [
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(i8|i16|i32|i64|i128|int)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(u8|u16|u32|u64|u128|uint|uintptr)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(u16le|u32le|u64le|u128le|i16le|i32le|i64le|i128le)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(i16be|i32be|i64be|i128be|u16be|u32be|u64be|u128be)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(f16|f32|f64)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(f16le|f32le|f64le)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(f16be|f32be|f64be)\\b"
 				},
 				{
-					"name": "storage.type.numberic.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(complex32|complex64|complex128)\\b"
 				},
 				{
-					"name": "storage.type.quaternion.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(quaternion64|quaternion128|quaternion256)\\b"
 				},
 				{
-					"name": "storage.type.boolean.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(bool|b8|b16|b32|b64)\\b"
 				},
 				{
-					"name": "storage.type.string.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(string|cstring|rune)\\b"
 				},
 				{
-					"name": "storage.type.address.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(rawptr)\\b"
 				},
 				{
-					"name": "storage.type.odin",
+					"name": "support.type.primitive",
 					"match": "\\b(any|typeid)\\b"
 				},
 				{
-					"name": "storage.type.byte.odin",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(byte)\\b"
 				}
 			]

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -490,7 +490,7 @@
 					"match": "\\b(rawptr)\\b"
 				},
 				{
-					"name": "support.type.primitive",
+					"name": "support.type.primitive.odin",
 					"match": "\\b(any|typeid)\\b"
 				},
 				{

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -384,7 +384,7 @@
 					"match": "\\&"
 				},
 				{
-					"name": "keyword.operator.pointer.odin",
+					"name": "keyword.operator.address.odin",
 					"match": "\\^"
 				},
 				{
@@ -442,24 +442,60 @@
 		"basic-types": {
 			"patterns": [
 				{
-					"name": "support.type.primitive.odin",
-					"match": "\\b((i8|i16|i32|i64|i128|int)|(u8|u16|u32|u64|u128|uint|uintptr))\\b"
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(i8|i16|i32|i64|i128|int)\\b"
 				},
 				{
-					"name": "support.type.primitive.odin",
-					"match": "\\b((f16|f32|f64)|(complex32|complex64|complex128)|(quaternion64|quaternion128|quaternion256))\\b"
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(u8|u16|u32|u64|u128|uint|uintptr)\\b"
 				},
 				{
-					"name": "support.type.primitive.odin",
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(u16le|u32le|u64le|u128le|i16le|i32le|i64le|i128le)\\b"
+				},
+				{
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(i16be|i32be|i64be|i128be|u16be|u32be|u64be|u128be)\\b"
+				},
+				{
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(f16|f32|f64)\\b"
+				},
+				{
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(f16le|f32le|f64le)\\b"
+				},
+				{
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(f16be|f32be|f64be)\\b"
+				},
+				{
+					"name": "storage.type.numberic.odin",
+					"match": "\\b(complex32|complex64|complex128)\\b"
+				},
+				{
+					"name": "storage.type.quaternion.odin",
+					"match": "\\b(quaternion64|quaternion128|quaternion256)\\b"
+				},
+				{
+					"name": "storage.type.boolean.odin",
 					"match": "\\b(bool|b8|b16|b32|b64)\\b"
 				},
 				{
-					"name": "support.type.primitive.odin",
-					"match": "\\b(string|rune|rawptr|any)\\b"
+					"name": "storage.type.string.odin",
+					"match": "\\b(string|cstring|rune)\\b"
 				},
 				{
-					"name": "support.type.primitive.odin",
-					"match": "\\b(byte|cstring)\\b"
+					"name": "storage.type.address.odin",
+					"match": "\\b(rawptr)\\b"
+				},
+				{
+					"name": "storage.type.odin",
+					"match": "\\b(any|typeid)\\b"
+				},
+				{
+					"name": "storage.type.byte.odin",
+					"match": "\\b(byte)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
Add missing basic types

Also change the the scope of `^` to be the same as `&`