### PR TITLE
Remove writing semantic nodes for untyped and basic value symbols

### DIFF
--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -1,9 +1,9 @@
 package server
 
-import "core:odin/tokenizer"
-import "core:odin/ast"
-import "core:log"
 import "core:fmt"
+import "core:log"
+import "core:odin/ast"
+import "core:odin/tokenizer"
 
 import "shared:common"
 
@@ -343,22 +343,6 @@ visit_node :: proc(
 					node,
 					ast_context.file.src,
 					.Function,
-					modifier,
-				)
-			case SymbolUntypedValue:
-				write_semantic_node(
-					builder,
-					node,
-					ast_context.file.src,
-					.Type,
-					modifier,
-				)
-			case SymbolBasicValue:
-				write_semantic_node(
-					builder,
-					node,
-					ast_context.file.src,
-					.Type,
 					modifier,
 				)
 			case SymbolMatrixValue:


### PR DESCRIPTION
The result semantic token types were often incorrect for constants and literals like `nil`, `true` and `false`.
Syntax grammars have better results here, but were being overridden by the semantic tokens.

I'm not yet familiar enough with the codebase to fix this properly, instead of just removing it.