### PR TITLE
Update `.editorconfig` fix accessibility issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
-# editorconfig.org
+# https://editorconfig.org/
 root = true
 
 [*]
-indent_style = tab
-indent_size = 4
-end_of_line = lf
 charset = utf-8
+end_of_line = lf
+indent_style = tab
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Language server for Odin. This project is still in early development.
 
 ## Table Of Contents
 
--   [Installation](#installation)
-    -   [Configuration](#Configuration)
--   [Features](#features)
--   [Clients](#clients)
-    -   [Vs Code](#vs-code)
-    -   [Sublime](#sublime)
-    -   [Vim](#vim)
-    -   [Neovim](#neovim)
-    -   [Emacs](#emacs)
-    -   [Helix](#helix)
-    -   [Micro](#micro)
+- [Installation](#installation)
+  - [Configuration](#Configuration)
+- [Features](#features)
+- [Clients](#clients)
+  - [Vs Code](#vs-code)
+  - [Sublime](#sublime)
+  - [Vim](#vim)
+  - [Neovim](#neovim)
+  - [Emacs](#emacs)
+  - [Helix](#helix)
+  - [Micro](#micro)
 
 ## Installation
 
@@ -34,10 +34,9 @@ cd ols
 
 In order for the language server to index your files, it must know about your collections.
 
-To do that you can either configure ols via an ``ols.json`` file (it should be located at the root of your workspace).
+To do that you can either configure ols via an `ols.json` file (it should be located at the root of your workspace).
 
 Or you can provide the configuration via your editor of choice.
-
 
 Example of `ols.json`:
 
@@ -87,8 +86,7 @@ Example:
 {
 	"$schema": "https://raw.githubusercontent.com/DanielGavin/ols/master/misc/odinfmt.schema.json",
 	"character_width": 80,
-	"tabs": true,
-	"tabs_width": 4
+	"tabs": true
 }
 ```
 
@@ -110,12 +108,12 @@ Options:
 
 Support Language server features:
 
--   Completion
--   Go to definition
--   Semantic tokens(really unstable and unfinished)
--   Document symbols
--   Signature help
--   Hover
+- Completion
+- Go to definition
+- Semantic tokens(really unstable and unfinished)
+- Document symbols
+- Signature help
+- Hover
 
 ## Clients
 

--- a/odinfmt.json
+++ b/odinfmt.json
@@ -1,5 +1,4 @@
 {
 	"character_width": 80,
-	"tabs": true,
-	"tabs_width": 4
+	"tabs": true
 }


### PR DESCRIPTION
This PR makes some minor fixes as the current setting unfortunately creates some confusion in the editor.

It wants to:
- Fix shifting tab widths and misalignments when e.g., switching splits in VSCode or entering buffers in nvim. It also should fix not respecting a users tab width setting.
  ![Screenshot_20230528_230737](https://github.com/vlang/v/assets/34311583/3d15c259-57a9-46de-923c-06746f9ac5ab)

  This issue is due to specifying `indent_size` as an anti-setting for tabs.
  Unlike with spaces, specifying a width is not needed; one tab is always one indentation. Without it we'll get the benefit of increased accessibility and more developer friendliness, so any preferred indent width can be used or dynamically adapted to a given situation. If you check https://editorconfig.org/, you will also see `# Tab indentation (no size specified)`. 
  
  I would further suggest to move towards a more modern setting for indentation for odinfmt that takes either an int or `"tab"` as value `indendation=int|"tab"`. Like e.g. stylelint does https://stylelint.io/user-guide/rules/indentation#options
  
- Extend file support. Yaml unfortunately requires spaces, as my editor didn't behave properly when working on #264, so `.editorconfig` was extended to cover yaml files. 

