### PR TITLE
Update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Language server for Odin. This project is still in early development.
 
-**Status**: You have to use `odin` commit 886d0de to build. Project can't compile with the latest llvm 17 update.
-
 ## Table Of Contents
 
 -   [Installation](#installation)
@@ -26,7 +24,7 @@ cd ols
 # for windows
 ./build.bat
 
-# for linux
+# for linux and macos
 ./build.sh
 ```
 


### PR DESCRIPTION
`README.md` is misleading. It demands that the user use a commit of Odin that is too old to build the latest versions of ols. This commit removes this requirement.

It also declares `build.sh` as executable in MacOS.