### PR TITLE
Add force_inline to basic completion.

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -199,6 +199,7 @@ get_directive_completion :: proc(
 		"procedure",
 		"load",
 		"partial",
+		"force_inline",
 	}
 
 	for elem in directive_list {


### PR DESCRIPTION
This PR just adds the `#force_inline` procedure directive to the completion list.