### PR TITLE
Add grammar for ansi color sequences in strings

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -549,6 +549,10 @@
 		"string-escaped-char": {
 			"patterns": [
 				{
+					"name": "constant.character.escape.ansi-color-sequence.odin",
+					"match": "\\\\(x1b|e|033)\\[[0-9;]*m"
+				},
+				{
 					"name": "constant.character.escape.odin",
 					"match": "\\\\(\\\\|[abfnrutv''\"]|x\\h{2}|u\\h{4}|U\\h{8}|[0-7]{3})"
 				},


### PR DESCRIPTION
Before
![image](https://github.com/DanielGavin/ols/assets/24491503/0ada9cd5-f560-4f22-9c10-f4004e12b441)

After
![image](https://github.com/DanielGavin/ols/assets/24491503/91d19ae4-f2c6-474e-a6c4-002a431d7ede)
