### PR TITLE
Switch static arena to growing arena

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -75,7 +75,7 @@ try_build_package :: proc(pkg_name: string) {
 
 
 
-	defer mem_virtual.arena_free_all(&temp_arena)
+	defer mem_virtual.arena_destroy(&temp_arena)
 
 	{
 		context.allocator = mem_virtual.arena_allocator(&temp_arena)

--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -12,6 +12,7 @@ import path "core:path/slashpath"
 import "core:runtime"
 import "core:strings"
 import "core:time"
+import mem_virtual "core:mem/virtual"
 
 import "src:common"
 
@@ -68,16 +69,16 @@ try_build_package :: proc(pkg_name: string) {
 		return
 	}
 
-	temp_arena: mem.Arena
+	temp_arena: mem_virtual.Arena
 
-	mem.arena_init(
-		&temp_arena,
-		make([]byte, mem.Megabyte * 25, runtime.default_allocator()),
-	)
-	defer delete(temp_arena.data)
+	allocator_err := mem_virtual.arena_init_growing(&temp_arena, mem.Megabyte * 16);
+
+
+
+	defer mem_virtual.arena_free_all(&temp_arena)
 
 	{
-		context.allocator = mem.arena_allocator(&temp_arena)
+		context.allocator = mem_virtual.arena_allocator(&temp_arena)
 
 		for fullpath in matches {
 			if skip_file(filepath.base(fullpath)) {

--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -70,11 +70,7 @@ try_build_package :: proc(pkg_name: string) {
 	}
 
 	temp_arena: mem_virtual.Arena
-
 	allocator_err := mem_virtual.arena_init_growing(&temp_arena, mem.Megabyte * 16);
-
-
-
 	defer mem_virtual.arena_destroy(&temp_arena)
 
 	{


### PR DESCRIPTION
Quite a few of us at JangaFX rely on OLS, and we have quite a few very large files which will cause OLS to crash given the arena is fixed to 25mb.

this PR makes a trivial change: switching from the built-in arena to the built-in growing-arena, the characteristics of the code and the code itself remain the same but the edge case of large files is now handled correctly and do not result in a crash.