### PR TITLE
Add symlinking resolution

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -541,6 +541,9 @@ read_ols_initialize_options :: proc(
 			}
 		}
 
+		ok: bool
+		final_path, ok = filepath.abs(final_path, context.temp_allocator)
+		if !ok do return
 		config.collections[strings.clone(it.name)] = final_path
 	}
 
@@ -549,6 +552,9 @@ read_ols_initialize_options :: proc(
 
 	if odin_core_env == "" {
 		if exe_path, ok := common.lookup_in_path("odin"); ok {
+			// ensure that the correct lookup path is found even if symlinked
+			exe_path, ok = filepath.abs(exe_path, context.temp_allocator)
+			if !ok do return
 			odin_core_env = filepath.dir(exe_path, context.temp_allocator)
 		}
 	}


### PR DESCRIPTION
Since the Odin compiler expects all the included libraries to be in the same path, I've been symlinking it and using ODIN_ROOT as a fix. Decided to try and find how to resolve symlinks myself today, turns out odin resolves them for you when you use functions such as `lstat`, `stat` and `abs`. So I'm making paths absolute to resolve them. 

This might potentially fix https://github.com/DanielGavin/ols/issues/325

I've tried it on my end and it's working for my use case at least. Decided to upstream it here. 