### PR TITLE
Fix column off-by-1 error in check

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -268,7 +268,7 @@ check :: proc(paths: []string, writer: ^Writer, config: ^common.Config) {
 					severity = .Error,
 					range =  {
 						start =  {
-							character = error.column,
+							character = error.column - 1,
 							line = error.line - 1,
 						},
 						end = {character = 0, line = error.line},


### PR DESCRIPTION
I noticed this was happening with missing imports, where the LSP would indicate the correct line but skipped the first character of `import "some-missing-package"`.