### PR TITLE
Fix check missing newlines

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -215,7 +215,7 @@ check :: proc(paths: []string, writer: ^Writer, config: ^common.Config) {
 				source_pos = s.src_pos
 
 				for scanner.peek(&s) != '\n' {
-					n := scanner.scan(&s)
+					n := scanner.next(&s)
 
 					if n == scanner.EOF {
 						break


### PR DESCRIPTION
The check procedure was missing newlines because `scan` was doing a double `advance`, causing multiple errors to appear in one program line. Using `next` instead should fix that.