### PR TITLE
Move packages to new base collection

### DIFF
--- a/src/common/allocator.odin
+++ b/src/common/allocator.odin
@@ -1,7 +1,8 @@
 package common
 
+import "base:runtime"
+
 import "core:mem"
-import "core:runtime"
 
 Scratch_Allocator :: struct {
 	data:               []byte,

--- a/src/main.odin
+++ b/src/main.odin
@@ -1,5 +1,7 @@
 package main
 
+import "base:intrinsics"
+
 import "core:encoding/json"
 import "core:fmt"
 import "core:log"
@@ -11,8 +13,6 @@ import "core:strconv"
 import "core:strings"
 import "core:sync"
 import "core:thread"
-
-import "core:intrinsics"
 
 import "src:common"
 import "src:server"

--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -1,5 +1,7 @@
 package server
 
+import "base:runtime"
+
 import "core:fmt"
 import "core:log"
 import "core:mem"
@@ -9,7 +11,6 @@ import "core:odin/tokenizer"
 import "core:os"
 import "core:path/filepath"
 import path "core:path/slashpath"
-import "core:runtime"
 import "core:strings"
 import "core:time"
 

--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -1,14 +1,15 @@
 package server
 
+import "base:intrinsics"
+import "base:runtime"
+
 import "core:encoding/json"
 import "core:fmt"
-import "core:intrinsics"
 import "core:log"
 import "core:mem"
 import "core:os"
 import "core:path/filepath"
 import path "core:path/slashpath"
-import "core:runtime"
 import "core:slice"
 import "core:strconv"
 import "core:strings"

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -1,13 +1,15 @@
 package server
 
+import "base:intrinsics"
+
 import "core:fmt"
-import "core:intrinsics"
 import "core:log"
 import "core:mem"
 import "core:odin/ast"
 import "core:odin/tokenizer"
 import "core:reflect"
 import "core:strings"
+
 _ :: intrinsics
 
 new_type :: proc(

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -1,5 +1,7 @@
 package server
 
+import "base:intrinsics"
+
 import "core:fmt"
 import "core:log"
 import "core:mem"
@@ -10,8 +12,6 @@ import "core:os"
 import "core:path/filepath"
 import path "core:path/slashpath"
 import "core:strings"
-
-import "core:intrinsics"
 
 import "src:common"
 

--- a/src/server/marshal.odin
+++ b/src/server/marshal.odin
@@ -1,8 +1,9 @@
 package server
 
+import "base:runtime"
+
 import "core:mem"
 import "core:math/bits"
-import "core:runtime"
 import "core:strconv"
 import "core:strings"
 import "core:reflect"

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -1,7 +1,6 @@
 package server
 
-
-import "src:common"
+import "base:runtime"
 
 import "core:fmt"
 import "core:log"
@@ -11,8 +10,9 @@ import "core:odin/parser"
 import "core:os"
 import "core:path/filepath"
 import path "core:path/slashpath"
-import "core:runtime"
 import "core:strings"
+
+import "src:common"
 
 fullpaths: [dynamic]string
 

--- a/src/server/rename.odin
+++ b/src/server/rename.odin
@@ -1,12 +1,13 @@
 package server
 
-import "src:common"
+import "base:runtime"
 
 import "core:log"
 import "core:mem"
 import "core:odin/ast"
-import "core:runtime"
 import "core:strings"
+
+import "src:common"
 
 get_rename :: proc(
 	document: ^Document,

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -1,8 +1,10 @@
 package server
 
+import "base:intrinsics"
+import "base:runtime"
+
 import "core:encoding/json"
 import "core:fmt"
-import "core:intrinsics"
 import "core:log"
 import "core:mem"
 import "core:odin/ast"
@@ -18,8 +20,6 @@ import "core:thread"
 import "core:time"
 
 import "src:common"
-
-import "base:runtime"
 
 Header :: struct {
 	content_length: int,

--- a/src/server/unmarshal.odin
+++ b/src/server/unmarshal.odin
@@ -1,8 +1,9 @@
 package server
 
+import "base:runtime"
+
 import "core:encoding/json"
 import "core:strings"
-import "core:runtime"
 import "core:mem"
 import "core:fmt"
 

--- a/tools/odinfmt/flag/flag.odin
+++ b/tools/odinfmt/flag/flag.odin
@@ -1,6 +1,7 @@
 package flag
 
-import "core:runtime"
+import "base:runtime"
+
 import "core:strings"
 import "core:reflect"
 import "core:fmt"


### PR DESCRIPTION
This PR moves packages that were formerly assigned to `core`, into `base`, per https://github.com/odin-lang/Odin/pull/3147.