### PR TITLE
Look for intrinsics in base instead of core

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -772,7 +772,7 @@ collect_symbols :: proc(
 			symbol.pkg = "$builtin"
 		} else if strings.contains(uri, "intrinsics.odin") {
 			path := filepath.join(
-				elems = {common.config.collections["core"], "/intrinsics"},
+				elems = {common.config.collections["base"], "/intrinsics"},
 				allocator = context.temp_allocator,
 			)
 


### PR DESCRIPTION
This PR tells the LSP to look for intrinsics in the base collection, instead of core, which should fix issues with trying to find function definitions in the module.