### PR TITLE
Fix crash caused by slicing incomplete import

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -854,7 +854,8 @@ get_package_mapping :: proc(
 		if len(imp.fullpath) < 2 {
 			continue
 		}
-		if i := strings.index(imp.fullpath, ":"); i != -1 {
+
+		if i := strings.index(imp.fullpath, ":"); i != -1 && i != len(imp.fullpath) - 1 {
 			collection := imp.fullpath[1:i]
 			p := imp.fullpath[i + 1:len(imp.fullpath) - 1]
 


### PR DESCRIPTION
This PR fixes a bug where the LSP would crash if a `didSave` event was sent with an import line that was not complete, i.e.

```odin
package main

import "core:
```

This was due to the slice attempted a couple lines down.