### PR TITLE
Highlight namespaces in import declarations

### DIFF
--- a/editors/vscode/.npmrc
+++ b/editors/vscode/.npmrc
@@ -1,0 +1,1 @@
+install-strategy=hoisted

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ols",
-	"version": "0.1.26",
+	"version": "0.1.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ols",
-			"version": "0.1.26",
+			"version": "0.1.27",
 			"dependencies": {
 				"adm-zip": "^0.5.9",
 				"https-proxy-agent": "^5.0.0",

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -4,6 +4,7 @@
 	"name": "Odin",
 	"patterns": [
 		{ "include": "#package-name-declaration" },
+		{ "include": "#import-declaration" },
 		{ "include": "#statements" }
 	],
 	"repository": {
@@ -216,6 +217,32 @@
 				"1": { "name": "keyword.control.odin" },
 				"2": { "name": "entity.name.type.module.odin" }
 			}
+		},
+		"import-declaration": {
+			"name": "meta.import.odin",
+			"begin": "\\b(import|foreign\\s+import)\\b",
+			"beginCaptures": {"0": {"name": "keyword.control.import.odin"}},
+			"end": "(?=^|;)",
+			"patterns": [
+				{	"name": "string.import.odin",
+					"match": "([\"`])([\\w\\.]*[/:])*([A-Za-z_]\\w*)([\"`])",
+					"captures": {
+						"1": {"name": "punctuation.definition.string.begin.odin"},
+						"3": {"name": "entity.name.namespace.odin"},
+						"4": {"name": "punctuation.definition.string.end.odin"}
+					}
+				},
+				{	"name": "entity.name.alias.odin",
+					"begin": "\\b[A-Za-z_]\\w*",
+					"beginCaptures": {"0": {"name": "entity.name.namespace.odin"}},
+					"end": "(?=^|;)",
+					"patterns": [
+						{ "include": "#strings" },
+						{ "include": "#comments" }
+					]
+				},
+				{ "include": "#comments" }
+			]
 		},
 		"map-bitset": {
 			"begin": "\\b(bit_set|map)\\b",

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -237,11 +237,12 @@
 					"beginCaptures": {"0": {"name": "entity.name.namespace.odin"}},
 					"end": "(?=^|;)",
 					"patterns": [
-						{ "include": "#strings" },
-						{ "include": "#comments" }
+						{"include": "#strings"},
+						{"include": "#comments"}
 					]
 				},
-				{ "include": "#comments" }
+				{"include": "#strings"},
+				{"include": "#comments"}
 			]
 		},
 		"map-bitset": {


### PR DESCRIPTION
add `.npmrc` file to enforce hoisted install strategy
`vsce` doesn't seem to work with linked strategy that users might default to (like me)

Add improved grammars for import declarations
highlights namespace that the import provides

so it's a bit easier to see immediately whats available

![image](https://github.com/DanielGavin/ols/assets/24491503/779c9be2-6b9f-46c6-bfcf-37f14b598382)
