### PR TITLE
Skip zero (None) case when sending list of token modifiers

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -798,7 +798,7 @@ request_initialize :: proc(
 	)
 	token_modifiers := make(
 		[]string,
-		len(token_modifier.names),
+		len(token_modifier.names)-1, // skip zero case
 		context.temp_allocator,
 	)
 
@@ -810,7 +810,7 @@ request_initialize :: proc(
 		}
 	}
 
-	for name, i in token_modifier.names {
+	for name, i in token_modifier.names[1:] {
 		token_modifiers[i] = strings.to_lower(name, context.temp_allocator)
 	}
 

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -261,7 +261,7 @@ visit_node :: proc(
 		if symbol_and_node, ok := builder.symbols[cast(uintptr)node]; ok {
 			if symbol_and_node.symbol.type == .Constant ||
 			   symbol_and_node.symbol.type != .Variable {
-				//modifier = .ReadOnly
+				modifier = .ReadOnly
 			}
 
 			if .Distinct in symbol_and_node.symbol.flags &&


### PR DESCRIPTION
The tokens modifiers should contain only the non-zero values. No modifier is applied when the value is zero by default.

Sending `"none"` as the first item was causing the modifiers to be shifted by one.

(I'm guessing that the `modifier = .ReadOnly` line was commented out because of this bug)

btw how about just making `token_types` and `token_modifiers` into global variables with their values inlined? Instead of relying on type introspection to generate strings array from the types and guessing what it produces. I don't expect it to change too much.
like so:
```odin
semantic_token_types: []string = {
	"namespace",
	"type",
	"enum",
	"struct",
	"parameter",
	"variable",
	"enumMember",
	"function",
	"member",
	"keyword",
	"modifier",
	"comment",
	"string",
	"number",
	"operator",
	"property",
	"method",
}

semantic_token_modifiers: []string = {
	"declaration",
	"definition",
	"deprecated",
	"readonly",
}
```