### PR TITLE
Multiple improvements to semantic tokens feature

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -788,32 +788,6 @@ request_initialize :: proc(
 	signatureTriggerCharacters := []string{"(", ","}
 	signatureRetriggerCharacters := []string{","}
 
-	token_type := type_info_of(SemanticTokenTypes).variant.(runtime.Type_Info_Named).base.variant.(runtime.Type_Info_Enum)
-	token_modifier := type_info_of(SemanticTokenModifiers).variant.(runtime.Type_Info_Named).base.variant.(runtime.Type_Info_Enum)
-
-	token_types := make(
-		[]string,
-		len(token_type.names),
-		context.temp_allocator,
-	)
-	token_modifiers := make(
-		[]string,
-		len(token_modifier.names),
-		context.temp_allocator,
-	)
-
-	for name, i in token_type.names {
-		if name == "EnumMember" {
-			token_types[i] = "enumMember"
-		} else {
-			token_types[i] = strings.to_lower(name, context.temp_allocator)
-		}
-	}
-
-	for name, i in token_modifier.names {
-		token_modifiers[i] = strings.to_lower(name, context.temp_allocator)
-	}
-
 	response := make_response_message(
 		params = ResponseInitializeParams {
 			capabilities = ServerCapabilities {
@@ -839,8 +813,8 @@ request_initialize :: proc(
 					range = config.enable_semantic_tokens,
 					full = config.enable_semantic_tokens,
 					legend = SemanticTokensLegend {
-						tokenTypes = token_types,
-						tokenModifiers = token_modifiers,
+						tokenTypes = semantic_token_type_names,
+						tokenModifiers = semantic_token_modifier_names,
 					},
 				},
 				inlayHintProvider = config.enable_inlay_hints,

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -46,7 +46,8 @@ SymbolProcedureGroupValue :: struct {
 	group: ^ast.Expr,
 }
 
-//runtime temp symbol value
+// currently only used for proc group references
+// TODO needs a better name
 SymbolAggregateValue :: struct {
 	symbols: []Symbol,
 }
@@ -65,6 +66,7 @@ SymbolDynamicArrayValue :: struct {
 	expr: ^ast.Expr,
 }
 
+// TODO rename to SymbolMultiPointerValue
 SymbolMultiPointer :: struct {
 	expr: ^ast.Expr,
 }


### PR DESCRIPTION
- Removed the reflection mechanism mentioned in #366
- Made `SemanticTokenModifiers` into a `bit_set`. Since modifiers allow multiple flags.
- Removed all semantic tokens for keywords, as they WILL be highlighted by the syntax highlighter.
- Added a bunch of missing semantic tokens in `visit_node` and `visit_selector`
- Added a bit_set visit code to `visit_node`
- Added readonly modifiers to value declarations