### PR TITLE
Highlight import namespace using semantic tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@
 /ols
 /odinfmt
 ols.json
-
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-		{
+        {
             "type": "cppvsdbg",
             "request": "attach",
             "name": "Attach OLS",
@@ -20,7 +20,7 @@
             "type": "lldb",
             "request": "attach",
             "name": "Attach lldb",
-			"pid": "${command:pickProcess}"
+            "pid": "${command:pickProcess}"
         },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,17 +4,23 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-        {
+		{
             "type": "cppvsdbg",
             "request": "attach",
             "name": "Attach OLS",
             "processId": "${command:pickProcess}"
-        }
+        },
         {
             "type": "cppvsdbg",
             "request": "launch",
             "name": "Run unit",
             "program": "C:\\Users\\Daniel\\Desktop\\Computer_Science\\ols\\test_unit.exe",
-        }
+        },
+        {
+            "type": "lldb",
+            "request": "attach",
+            "name": "Attach lldb",
+			"pid": "${command:pickProcess}"
+        },
     ]
 }

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -256,14 +256,6 @@
 			"beginCaptures": {"0": {"name": "keyword.control.import.odin"}},
 			"end": "(?=^|;)",
 			"patterns": [
-				{	"name": "string.import.odin",
-					"match": "([\"`])([\\w\\.]*[/:])*([A-Za-z_]\\w*)([\"`])",
-					"captures": {
-						"1": {"name": "punctuation.definition.string.begin.odin"},
-						"3": {"name": "entity.name.namespace.odin"},
-						"4": {"name": "punctuation.definition.string.end.odin"}
-					}
-				},
 				{	"name": "entity.name.alias.odin",
 					"begin": "\\b[A-Za-z_]\\w*",
 					"beginCaptures": {"0": {"name": "entity.name.namespace.odin"}},

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -518,29 +518,28 @@ visit_import_decl :: proc(decl: ^ast.Import_Decl, builder: ^SemanticTokenBuilder
 	}
 	else if len(decl.relpath.text) > 2 {
 
-		start, end := 1, len(decl.relpath.text) - 1
-		i := end
+		end := len(decl.relpath.text) - 1
+		pos := end
 
 		for {
-			if i > start {
-				ch, w := utf8.decode_last_rune_in_string(decl.relpath.text[:i])
+			if pos > 1 {
+				ch, w := utf8.decode_last_rune_in_string(decl.relpath.text[:pos])
 	
 				switch ch {
 				case ':', '/': // break
 				case:
-					i -= w
+					pos -= w
 					continue
 				}
 			}
 
-			start = i
 			break
 		}
 
 		write_semantic_at_pos(
 			builder,
-			decl.relpath.pos.offset+start,
-			end-start,
+			decl.relpath.pos.offset+pos,
+			end-pos,
 			.Namespace,
 		)
 	}

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -9,6 +9,7 @@ package server
 
 import "core:fmt"
 import "core:log"
+import "core:unicode/utf8"
 import "core:odin/ast"
 import "core:odin/tokenizer"
 
@@ -353,10 +354,7 @@ visit_node :: proc(node: ^ast.Node, builder: ^SemanticTokenBuilder) {
 	case ^Defer_Stmt:
 		visit_node(n.stmt, builder)
 	case ^Import_Decl:
-		if n.name.text != "" {
-			write_semantic_token(builder, n.name, .Namespace)
-		}
-
+		visit_import_decl(n, builder)
 	case ^Or_Return_Expr:
 		visit_node(n.expr, builder)
 	case ^Or_Else_Expr:
@@ -499,6 +497,53 @@ visit_selector :: proc(selector: ^ast.Selector_Expr, builder: ^SemanticTokenBuil
 	}
 
 	visit_ident(selector.field, selector, {}, builder)
+}
+
+visit_import_decl :: proc(decl: ^ast.Import_Decl, builder: ^SemanticTokenBuilder) {
+	/*
+	hightlight the namespace in the import declaration
+	
+	import "pkg"
+	        ^^^
+	import "core:fmt"
+	             ^^^
+	import "core:odin/ast"
+	                  ^^^
+	import foo "core:fmt"
+	       ^^^
+	*/
+
+	if decl.name.text != "" {
+		write_semantic_token(builder, decl.name, .Namespace)
+	}
+	else if len(decl.relpath.text) > 2 {
+
+		start, end := 1, len(decl.relpath.text) - 1
+		i := end
+
+		for {
+			if i > start {
+				ch, w := utf8.decode_last_rune_in_string(decl.relpath.text[:i])
+	
+				switch ch {
+				case ':', '/': // break
+				case:
+					i -= w
+					continue
+				}
+			}
+
+			start = i
+			break
+		}
+
+		write_semantic_at_pos(
+			builder,
+			decl.relpath.pos.offset+start,
+			end-start,
+			.Namespace,
+		)
+	}
 }
 
 visit_ident :: proc(


### PR DESCRIPTION
Removes highlighting the namespace in import path from tm grammars, and adds it instead to the semantic tokens.

So now it works the same way between editors.