### PR TITLE
Add a symbol for explicit `enum.member` selectors

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1156,6 +1156,10 @@ internal_resolve_type_expression :: proc(
 				} else {
 					return Symbol{}, false
 				}
+			case SymbolEnumValue:
+				// enum members probably require own symbol value
+				selector.type = .EnumMember
+				return selector, true
 			}
 		}
 	case:
@@ -1856,9 +1860,9 @@ resolve_implicit_selector :: proc(
 						proc_value.arg_types[parameter_index].type,
 					)
 				} else if enum_value, ok := symbol.value.(SymbolEnumValue);
-				   ok {
-					return symbol, true
-				}
+				ok {
+				 return symbol, true
+			 }
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that `Enum.Enum_Member` expressions weren't highlighted properly.
Turns out that they weren't added to the symbols map, unlike `package.value` and others.
So I "fixed" that.
But returning a `SymbolEnumValue` for the member is probably wrong, it may need it's own symbol value. Especially since go to definition goes to the whole declaration, not specific member.
I can switch it to "patch" it in semantic_tokens, instead, similarly to how implicit selectors are handled. But thats also wrong, because `.Not_Actually_A_Enum_Member` shouldn't get the semantic highlighting.

I think that ideally, the whole semantic tokens functionality should just be handled by looping over the symbols map and writing those, instead of walking the ast, which was already walked by the analyzer.

Also removed the `selector` field from builder, it looks unused now.