### PR TITLE
Add `.Nil` member to `SymbolUntypedValue.type` for `nil`

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -344,6 +344,8 @@ is_symbol_same_typed :: proc(
 				case:
 					return false
 				}
+			case .Nil:
+				return false
 			}
 		}
 	}
@@ -1304,24 +1306,21 @@ internal_resolve_type_identifier :: proc(
 		ident := new_type(Ident, node.pos, node.end, ast_context.allocator)
 		ident.name = node.name
 
-		symbol: Symbol
+		symbol: Symbol = {
+			type = .Keyword,
+			signature = node.name,
+			name = ident.name,
+			pkg = ast_context.current_package,
+		}
 
 		switch ident.name {
 		case "true", "false":
-			symbol = Symbol {
-				type = .Keyword,
-				signature = node.name,
-				pkg = ast_context.current_package,
-				value = SymbolUntypedValue{type = .Bool},
-			}
+			symbol.value = SymbolUntypedValue{type = .Bool}
+		case "nil":
+			// TODO get the type of nil from the context and remove .Nil from SymbolUntypedValue
+			symbol.value = SymbolUntypedValue{type = .Nil}
 		case:
-			symbol = Symbol {
-				type = .Keyword,
-				signature = node.name,
-				name = ident.name,
-				pkg = ast_context.current_package,
-				value = SymbolBasicValue{ident = ident},
-			}
+			symbol.value = SymbolBasicValue{ident = ident}
 		}
 
 		return symbol, true
@@ -4386,6 +4385,8 @@ get_signature :: proc(
 			return "bool"
 		case .Integer:
 			return "int"
+		case .Nil:
+			return "" // no obvious type for nil
 		}
 	}
 

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -33,6 +33,8 @@ write_hover_content :: proc(
 			symbol.signature = "float"
 		case .Integer:
 			symbol.signature = "int"
+		case .Nil:
+			// no obvious signature for nil
 		}
 	}
 

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -609,10 +609,11 @@ visit_ident :: proc(
 	     SymbolFixedArrayValue,
 	     SymbolSliceValue,
 	     SymbolMapValue,
-	     SymbolMultiPointer:
+	     SymbolMultiPointer,
+	     SymbolBasicValue:
 		write_semantic_node(builder, ident, .Type, modifiers)
-	case SymbolBasicValue, SymbolUntypedValue:
-	// handled by static syntax analysis
+	case SymbolUntypedValue:
+	// handled by static syntax highlighting
 	case SymbolGenericValue:
 	// unused
 	case:

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -94,6 +94,7 @@ SymbolUntypedValue :: struct {
 		Float,
 		String,
 		Bool,
+		Nil,
 	},
 	tok:  tokenizer.Token,
 }


### PR DESCRIPTION
Change symbol for `nil` from `SymbolBasicValue` to `SymbolUntypedValue`

Enable semantic tokens for identifiers with `SymbolBasicValue` symbol value. Previously I disabled it (in #263) because `nil` was included there, which made it be highlighted as a type.

`.Nil` variant is not entirely correct, because `nil` cannot function as a value with "untyped type".
It needs a concrete type.
So doing it properly would probably mean getting the type from the context.
Not sure.

Maybe instead of adding `.Nil` variant, `nil` shouldn't get any symbol? Since any declaration needs an explicit type, the symbol for the identifier will get it's type, from the type, not value. (Did that in #378)