### PR TITLE
Don't make a symbol for `nil`

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1304,27 +1304,25 @@ internal_resolve_type_identifier :: proc(
 		ident := new_type(Ident, node.pos, node.end, ast_context.allocator)
 		ident.name = node.name
 
-		symbol: Symbol
-
 		switch ident.name {
+		case "nil":
+			return {}, false
 		case "true", "false":
-			symbol = Symbol {
+			return {
 				type = .Keyword,
 				signature = node.name,
 				pkg = ast_context.current_package,
 				value = SymbolUntypedValue{type = .Bool},
-			}
+			}, true
 		case:
-			symbol = Symbol {
+			return {
 				type = .Keyword,
 				signature = node.name,
 				name = ident.name,
 				pkg = ast_context.current_package,
 				value = SymbolBasicValue{ident = ident},
-			}
+			}, true
 		}
-
-		return symbol, true
 	}
 
 	if local, ok := get_local(ast_context, node.pos.offset, node.name);

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -609,10 +609,11 @@ visit_ident :: proc(
 	     SymbolFixedArrayValue,
 	     SymbolSliceValue,
 	     SymbolMapValue,
-	     SymbolMultiPointer:
+	     SymbolMultiPointer,
+	     SymbolBasicValue:
 		write_semantic_node(builder, ident, .Type, modifiers)
-	case SymbolBasicValue, SymbolUntypedValue:
-	// handled by static syntax analysis
+	case SymbolUntypedValue:
+	// handled by static syntax highlighting
 	case SymbolGenericValue:
 	// unused
 	case:


### PR DESCRIPTION
Alternative for #377 since a symbol for nil doesn't have much value now.

Don't make a symbol for `nil` and enable semantic tokens for `SymbolBasicValue`