### PR TITLE
Add a .Type SymbolType enum

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2659,7 +2659,7 @@ make_symbol_array_from_ast :: proc(
 ) -> Symbol {
 	symbol := Symbol {
 		range = common.get_token_range(v.node, ast_context.file.src),
-		type  = .Constant,
+		type  = .Type,
 		pkg   = get_package_from_node(v.node),
 		name  = name.name,
 	}
@@ -2685,7 +2685,7 @@ make_symbol_dynamic_array_from_ast :: proc(
 ) -> Symbol {
 	symbol := Symbol {
 		range = common.get_token_range(v.node, ast_context.file.src),
-		type  = .Constant,
+		type  = .Type,
 		pkg   = get_package_from_node(v.node),
 		name  = name.name,
 	}
@@ -2704,7 +2704,7 @@ make_symbol_matrix_from_ast :: proc(
 ) -> Symbol {
 	symbol := Symbol {
 		range = common.get_token_range(v.node, ast_context.file.src),
-		type  = .Constant,
+		type  = .Type,
 		pkg   = get_package_from_node(v.node),
 		name  = name.name,
 	}
@@ -2726,7 +2726,7 @@ make_symbol_multi_pointer_from_ast :: proc(
 ) -> Symbol {
 	symbol := Symbol {
 		range = common.get_token_range(v.node, ast_context.file.src),
-		type  = .Constant,
+		type  = .Type,
 		pkg   = get_package_from_node(v.node),
 		name  = name.name,
 	}
@@ -2745,7 +2745,7 @@ make_symbol_map_from_ast :: proc(
 ) -> Symbol {
 	symbol := Symbol {
 		range = common.get_token_range(v.node, ast_context.file.src),
-		type  = .Constant,
+		type  = .Type,
 		pkg   = get_package_from_node(v.node),
 		name  = name.name,
 	}

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -562,25 +562,20 @@ visit_ident :: proc(
 		modifiers += {.ReadOnly}
 	}
 
-	if .Distinct in symbol.flags && symbol.type == .Constant {
-		write_semantic_node(builder, ident, .Type)
-		return
-	}
-
+	/* variable idents */
 	#partial switch symbol.type {
-	case .Variable, .Constant:
+	case .Variable, .Constant, .Function:
 		#partial switch _ in symbol.value {
-		case SymbolProcedureValue:
+		case SymbolProcedureValue, SymbolProcedureGroupValue, SymbolAggregateValue:
 			write_semantic_node(builder, ident, .Function, modifiers)
 		case:
 			write_semantic_node(builder, ident, .Variable, modifiers)
 		}
-	case .Type_Function:
-		write_semantic_node(builder, ident, .Type, modifiers)
 	case .EnumMember:
 		write_semantic_node(builder, ident, .EnumMember, modifiers)
 	}
 
+	/* type idents */
 	switch v in symbol.value {
 	case SymbolPackageValue:
 		write_semantic_node(builder, ident, .Namespace, modifiers)
@@ -588,9 +583,8 @@ visit_ident :: proc(
 		write_semantic_node(builder, ident, .Struct, modifiers)
 	case SymbolEnumValue, SymbolUnionValue:
 		write_semantic_node(builder, ident, .Enum, modifiers)
-	case SymbolProcedureValue, SymbolProcedureGroupValue, SymbolAggregateValue:
-		write_semantic_node(builder, ident, .Function, modifiers)
-	case SymbolMatrixValue,
+	case SymbolProcedureValue,
+	     SymbolMatrixValue,
 	     SymbolBitSetValue,
 	     SymbolDynamicArrayValue,
 	     SymbolFixedArrayValue,
@@ -601,7 +595,7 @@ visit_ident :: proc(
 		write_semantic_node(builder, ident, .Type, modifiers)
 	case SymbolUntypedValue:
 	// handled by static syntax highlighting
-	case SymbolGenericValue:
+	case SymbolGenericValue, SymbolProcedureGroupValue, SymbolAggregateValue:
 	// unused
 	case:
 	// log.errorf("Unexpected symbol value: %v", symbol.value);

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -176,6 +176,7 @@ SymbolType :: enum {
 	Struct        = 22,
 	Type_Function = 23,
 	Union         = 7,
+	Type		  = 8, //For maps, arrays, slices, dyn arrays, matrixes, etc
 	Unresolved    = 1, //Use text if not being able to resolve it.
 }
 
@@ -279,6 +280,8 @@ symbol_type_to_completion_kind :: proc(
 		return .Enum
 	case .Unresolved:
 		return .Text
+	case .Type:
+		return .Constant
 	case:
 		return .Text
 	}


### PR DESCRIPTION
Add a .Type SymbolType enum

Not sure if `Type` is the best name for something in a `SymbolType` enum,
But it's meant to be a generic variant for all types, besides the ones separately specified.
Basically for all the maps, arrays, slices, dyn arrays, matrixes, etc
To not have a symbol for each individual type, but a single one for all of them.
Basically everything that wasn’t covered by existing enum, but is a type, not just any constant.

Also I cleaned up the `visit_ident` proc, to have a clear split between handling types and variables.

![before_after](https://github.com/DanielGavin/ols/assets/24491503/f5091948-6830-4774-a954-349e8794d32b)

now all the types are consistently correct
and all the constants consistently broken
but fixing that requires more work (and deeper changes)