### PR TITLE
Fix variable names in value declarations not having symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 *node_modules
 /ols
 /odinfmt
+tests/tests
 ols.json
 .vscode/settings.json

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -172,3 +172,39 @@ ast_goto_bit_field_field_in_proc :: proc(t: ^testing.T) {
 
 	test.expect_definition_locations(t, &source, {location})
 }
+
+@(test)
+ast_goto_shadowed_value_decls :: proc(t: ^testing.T) {
+	source0 := test.Source {
+		main     = `package test
+			main :: proc() {
+				foo := 1
+				
+				{
+					fo{*}o := 2
+				}
+			}
+		`,
+		packages = {},
+	}
+	source1 := test.Source {
+		main     = `package test
+			main :: proc() {
+				foo := 1
+				
+				{
+					foo := 2
+					fo{*}o
+				}
+			}
+		`,
+		packages = {},
+	}
+
+	location := common.Location {
+		range = {{line = 5, character = 5}, {line = 5, character = 8}},
+	}
+
+	test.expect_definition_locations(t, &source0, {location})
+	test.expect_definition_locations(t, &source1, {location})
+}

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -187,6 +187,12 @@ ast_goto_shadowed_value_decls :: proc(t: ^testing.T) {
 		`,
 		packages = {},
 	}
+	test.expect_definition_locations(
+		t,
+		&source0,
+		{{range = {{line = 5, character = 5}, {line = 5, character = 8}}}},
+	)
+
 	source1 := test.Source {
 		main     = `package test
 			main :: proc() {
@@ -200,11 +206,27 @@ ast_goto_shadowed_value_decls :: proc(t: ^testing.T) {
 		`,
 		packages = {},
 	}
+	test.expect_definition_locations(
+		t,
+		&source1,
+		{{range = {{line = 5, character = 5}, {line = 5, character = 8}}}},
+	)
 
-	location := common.Location {
-		range = {{line = 5, character = 5}, {line = 5, character = 8}},
+	source3 := test.Source {
+		main     = `package test
+			main :: proc() {
+				foo := 1
+				
+				{
+					foo := fo{*}o
+				}
+			}
+		`,
+		packages = {},
 	}
-
-	test.expect_definition_locations(t, &source0, {location})
-	test.expect_definition_locations(t, &source1, {location})
+	test.expect_definition_locations(
+		t,
+		&source3,
+		{{range = {{line = 2, character = 4}, {line = 2, character = 7}}}},
+	)
 }


### PR DESCRIPTION
I was trying to fix a bug where local variables did not get any symbols in their own declarations.
e.g. in `foo := 123`, `foo` would get a symbol if it was declared globally, but not when declared in a proc scope.

The reason was that the offset of the `foo` ident in the decl was too low. The `get_local` proc only matched idents with locals if they were after the declaration.
So I added another hacky condition to match offsets with the `lhs` expression directly.
Kinda like matching pointers I guess.
But I couldn't use a pointer because `ast.Ident` was getting passed around as a value instead.

This solution doesn't feel correct because it is too indirect. I was thinking I could just use a simple `is_in_declaration` flag, to simplify it, but it turns out the walker in analysis doesn't even know if the ident is in a declaration or not?

This also partially fixes #374
But only the case where both the shadowed and shadowing variables are mutable.

Also `get_local` had some weird conditions in it
`i < 0` couldn't ever happened
and this one:

```odin
ret := local_stack[i].rhs
if ident, ok := ret.derived.(^ast.Ident);
	ok && ident.name == name {
	if i - 1 < 0 {
		return {}, false
	}
}
```

I'm guessing it has to do with doing `foo := foo`?
But I couldn't ever hit it.
Especially when it required `i` to be `0`