### PR TITLE
fix switch/for references

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2064,7 +2064,7 @@ resolve_symbol_return :: proc(
 		}
 	}
 
-	#partial switch v in &symbol.value {
+	#partial switch &v in symbol.value {
 	case SymbolProcedureGroupValue:
 		if symbol, ok := resolve_function_overload(
 			ast_context,

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2000,7 +2000,7 @@ format_to_label_details :: proc(list: ^CompletionList) {
 	// detail      = left
 	// description = right
 
-	for item in &list.items {
+	for &item in list.items {
 		// log.errorf("item:%v: %v:%v", item.kind, item.label, item.detail)
 		#partial switch item.kind {
 		case .Function:

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -431,7 +431,6 @@ read_ols_initialize_options :: proc(
 
 	config.enable_checker_only_saved =
 		ols_config.enable_checker_only_saved.(bool) or_else config.enable_checker_only_saved
-		
 
 	if ols_config.odin_command != "" {
 		config.odin_command = strings.clone(
@@ -1210,8 +1209,8 @@ notification_did_save :: proc(
 
 	corrected_uri := common.create_uri(fullpath, context.temp_allocator)
 
-	for k, v in &indexer.index.collection.packages {
-		for k2, v2 in &v.symbols {
+	for k, &v in indexer.index.collection.packages {
+		for k2, v2 in v.symbols {
 			if corrected_uri.uri == v2.uri {
 				free_symbol(v2, indexer.index.collection.allocator)
 				delete_key(&v.symbols, k2)


### PR DESCRIPTION
https://github.com/odin-lang/Odin/commit/a344bc4c0e672d9740f5777dae862723fe269973 removed the old switch/for reference semantics. This PR updates for new semantics.