### PR TITLE
Quote file paths when calling odin check

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -131,7 +131,7 @@ check :: proc(
 
 		if code, ok, buffer = common.run_executable(
 			fmt.tprintf(
-				"%v check %s %s %s %s %s %s",
+				"%v check \"%s\" %s %s %s %s %s",
 				command,
 				path,
 				strings.to_string(collection_builder),


### PR DESCRIPTION
`odin check` command currently fails if the path contains spaces.

This PR adds quotes around the path parameter.