### PR TITLE
Add `unreachable` to `builtin/builtin.odin`

### DIFF
--- a/builtin/builtin.odin
+++ b/builtin/builtin.odin
@@ -32,6 +32,8 @@ conj       :: proc(value: Complex_Or_Quaternion) -> Complex_Or_Quaternion ---
 @builtin abs   :: proc(value: T) -> T ---
 @builtin clamp :: proc(value, minimum, maximum: T) -> T ---
 
+@builtin unreachable :: proc() -> ! ---
+
 /*
 	This is interally from the compiler
 */


### PR DESCRIPTION
was recently added to odin in https://github.com/odin-lang/Odin/commit/451dc645df9f12058267d7d5ae0f8ac8a1fb8998

btw, why do some procs in `builtin.odin` have `@builtin` attr, and some don't?