### PR TITLE
Semantic tokens tests

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -1272,17 +1272,18 @@ request_semantic_token_full :: proc(
 		end = common.Position{line = 9000000}, //should be enough
 	}
 
-	symbols: SemanticTokens
+	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
 		resolve_entire_file_cached(document)
 
 		if file, ok := file_resolve_cache.files[document.uri.uri]; ok {
-			symbols = get_semantic_tokens(document, range, file.symbols)
+			tokens := get_semantic_tokens(document, range, file.symbols)
+			tokens_params = semantic_tokens_to_response_params(tokens)
 		}
 	}
 
-	response := make_response_message(params = symbols, id = id)
+	response := make_response_message(params = tokens_params, id = id)
 
 	send_response(response, writer)
 
@@ -1313,21 +1314,22 @@ request_semantic_token_range :: proc(
 		return .InternalError
 	}
 
-	symbols: SemanticTokens
+	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
 		resolve_entire_file_cached(document)
 
 		if file, ok := file_resolve_cache.files[document.uri.uri]; ok {
-			symbols = get_semantic_tokens(
+			tokens := get_semantic_tokens(
 				document,
 				semantic_params.range,
 				file.symbols,
 			)
+			tokens_params = semantic_tokens_to_response_params(tokens)
 		}
 	}
 
-	response := make_response_message(params = symbols, id = id)
+	response := make_response_message(params = tokens_params, id = id)
 
 	send_response(response, writer)
 

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -23,7 +23,7 @@ ResponseParams :: union {
 	CompletionList,
 	SignatureHelp,
 	[]DocumentSymbol,
-	SemanticTokens,
+	SemanticTokensResponseParams,
 	Hover,
 	[]TextEdit,
 	[]InlayHint,

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -1,0 +1,36 @@
+package tests
+
+import "core:fmt"
+import "core:testing"
+
+import "src:server"
+import test "src:testing"
+
+@(test)
+semantic_tokens :: proc(t: ^testing.T) {
+	src := test.Source {
+		main = 
+`package test
+Proc_Type :: proc(a: string) -> int
+my_function :: proc() {
+	a := 2
+	b := a
+	c := 2 + b
+}
+`,
+	}
+
+	test.expect_semantic_tokens(t, &src, {
+		{1, 0, 9,  .Type,      {.ReadOnly}}, // [0]  Proc_Type
+		{0, 18, 1, .Parameter, {}},          // [1]  a
+		{0, 3, 6,  .Type,      {.ReadOnly}}, // [2]  string
+		{0, 11, 3, .Type,      {.ReadOnly}}, // [3]  int
+		{1, 0, 11, .Function,  {.ReadOnly}}, // [4]  my_function
+		{0, 0, 11, .Type,      {.ReadOnly}}, // [5]  !!! WRONG !!!
+		{1, 1, 1,  .Variable,  {}},          // [6]  a
+		{1, 1, 1,  .Variable,  {}},          // [7]  b
+		{0, 5, 1,  .Variable,  {}},          // [8]  a
+		{1, 1, 1,  .Variable,  {}},          // [9]  c
+		{0, 9, 1,  .Variable,  {}},          // [10] b
+	})
+}


### PR DESCRIPTION
Added setup for testing semantic tokens and add one simple test for starters.

But that one test has already revealed some bug that a procedure identifier is receiving both function and type tokens. I wasn't able to find a quick fix yet that didn't break proc type decls.
But the type token is ignored so it's all displayed correctly.

The pr is based on the rename branch to not go through merge conflicts

I'll be adding more test cases later