### PR TITLE
Minor fixes to tm grammars

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -503,7 +503,7 @@
 					"match": "@|(\\||\\!|:|\\+|-|\\*|/|%|\\<\\<?|\\>\\>?|\\~)=?|=|: : ?|\\.\\.|\\$"
 				},
 				{
-					"name": "keyword.other.odin",
+					"name": "entity.name.tag.odin",
 					"match": "#[A-Za-z_]\\w*"
 				}
 			]

--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -284,8 +284,8 @@
 		},
 		"case-clause": {
 			"name": "meta.case-clause.expr.odin",
-			"begin": "case",
-			"beginCaptures": { "0": { "name": "keyword.control.case.odin" } },
+			"begin": "\\b(case)\\b",
+			"beginCaptures": { "1": { "name": "keyword.control.case.odin" } },
 			"end": ":",
 			"endCaptures": { "0": { "name": "punctuation.definition.section.case-statement.odin" } },
 			"patterns": [ { "include": "#expressions" } ]
@@ -435,7 +435,7 @@
 					"match": "\\b(auto_cast|distinct|using)\\b"
 				},
 				{
-					"name": "variable.other.object.odin",
+					"name": "keyword.context.odin",
 					"match": "\\b(context)\\b"
 				},
 				{
@@ -618,7 +618,7 @@
 			"patterns": [
 				{
 					"name": "punctuation.odin",
-					"match": "\\(|\\)|\\{|\\}|;|\\[|\\]|\\.|,"
+					"match": "\\(|\\)|\\{|\\}|;|\\[|\\]|\\.|,|\\\\"
 				}
 			]
 		}


### PR DESCRIPTION
- add `\` to punctuation
- change scope for `context` to a `keyword.context.odin`
- fix edge case with `case` being matched in struct declarations
- Change scope for tags to `entity.name.tag.odin`