### PR TITLE
add additional completion snippets for dynamic arrays

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1947,6 +1947,56 @@ append_magic_dynamic_array_completion :: proc(
 		append(items, item)
 	}
 
+	// This proc is shared between slices and dynamic arrays.
+	if _, ok := symbol.value.(SymbolDynamicArrayValue); !ok {
+		return
+	}
+
+	//pop
+	{
+		text := fmt.tprintf("pop(&%v)", symbol_str)
+
+		item := CompletionItem {
+			label = "pop",
+			kind = .Function,
+			detail = "pop",
+			textEdit = TextEdit {
+				newText = text,
+				range = {start = range.end, end = range.end},
+			},
+			additionalTextEdits = additionalTextEdits,
+		}
+
+		append(items, item)
+	}
+
+	dynamic_array_builtins := []string {
+		"append",
+		"unordered_remove",
+		"ordered_remove",
+		"resize",
+		"reserve",
+		"shrink",
+		"inject_at",
+		"assign_at",
+	}
+
+	for name in dynamic_array_builtins {
+		item := CompletionItem {
+			label = name,
+			kind = .Snippet,
+			detail = name,
+			additionalTextEdits = additionalTextEdits,
+			textEdit = TextEdit {
+				newText = fmt.tprintf("%s(&%v, $0)", name, symbol_str),
+				range = {start = range.end, end = range.end},
+			},
+			insertTextFormat = .Snippet,
+			InsertTextMode = .adjustIndentation,
+		}
+
+		append(items, item)
+	}
 }
 
 append_magic_union_completion :: proc(

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1952,16 +1952,26 @@ append_magic_dynamic_array_completion :: proc(
 		return
 	}
 
+	prefix := "&"
+	suffix := ""
+	if symbol.pointers > 0 {
+		prefix = ""
+		suffix = common.repeat(
+			"^",
+			symbol.pointers - 1,
+			context.temp_allocator,
+		)
+	}
+	ptr_symbol_str := fmt.tprint(prefix, symbol_str, suffix, sep = "")
+
 	//pop
 	{
-		text := fmt.tprintf("pop(&%v)", symbol_str)
-
 		item := CompletionItem {
 			label = "pop",
 			kind = .Function,
 			detail = "pop",
 			textEdit = TextEdit {
-				newText = text,
+				newText = fmt.tprintf("pop(%v)", ptr_symbol_str),
 				range = {start = range.end, end = range.end},
 			},
 			additionalTextEdits = additionalTextEdits,
@@ -1988,7 +1998,7 @@ append_magic_dynamic_array_completion :: proc(
 			detail = name,
 			additionalTextEdits = additionalTextEdits,
 			textEdit = TextEdit {
-				newText = fmt.tprintf("%s(&%v, $0)", name, symbol_str),
+				newText = fmt.tprintf("%s(%v, $0)", name, ptr_symbol_str),
 				range = {start = range.end, end = range.end},
 			},
 			insertTextFormat = .Snippet,


### PR DESCRIPTION
This commit adds a handful of completion snippets for dynamic arrays from the builtin package.

Some of these are less often used than others, however since the completion entries otherwise should always be empty, I think that filling in all of these should be OK.

The most useful one for me, personally is `append`, however I felt like while I was at it, I might as well add the rest as well :).