### PR TITLE
Fix @(require) import "core:fmt"

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -327,6 +327,13 @@ visit_decl :: proc(
 	case ^Import_Decl:
 		document := move_line(p, decl.pos)
 
+		if len(v.attributes) > 0 {
+			document = cons(
+				document,
+				visit_attributes(p, &v.attributes, v.pos),
+			)
+		}
+
 		if v.name.text != "" {
 			document = cons(
 				document,


### PR DESCRIPTION
`@(require) import "core:fmt"` previously showed a syntax error and that was fixed upstream in `core:odin` in aa27cd4b. Make this work in the OLS formatter as well.

![image](https://github.com/DanielGavin/ols/assets/194614/19a6069b-93b5-4b5d-9d85-3dbfc05a2bea)
