### PR TITLE
[vscode] Add support for syntax highlighting in md

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -114,6 +114,16 @@
 				"language": "odin",
 				"scopeName": "source.odin",
 				"path": "./syntaxes/odin.tmLanguage.json"
+			},
+			{
+				"scopeName": "markdown.odin.codeblock",
+				"path": "./syntaxes/codeblock.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					  "meta.embedded.block.odin": "odin"
+					}
 			}
 		],
 		"breakpoints": [

--- a/editors/vscode/syntaxes/codeblock.json
+++ b/editors/vscode/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+	"comment": "Taken from https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json",
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#fenced_code_block_odin"
+		}
+	],
+	"repository": {
+		"fenced_code_block_odin": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(odin)((\\s+|:|,|\\{|\\?)[^`]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.odin",
+					"patterns": [
+						{
+							"include": "source.odin"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.odin.codeblock"
+}


### PR DESCRIPTION
Small change to add syntax highlighting within mark down fenced code blocks.

It should be possible to do the the same in the live preview but that uses [highlight.js](https://github.com/highlightjs/highlight.js). 
And would need to be done through [markdown-it](https://code.visualstudio.com/api/extension-guides/markdown-extension), just not sure how to add the hljs grammar.