### PR TITLE
Fix extraneous .Type semantic tokens

### DIFF
--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -602,30 +602,30 @@ visit_ident :: proc(
 		}
 	case .EnumMember:
 		write_semantic_node(builder, ident, .EnumMember, modifiers)
-	}
-
-	/* type idents */
-	switch v in symbol.value {
-	case SymbolPackageValue:
-		write_semantic_node(builder, ident, .Namespace, modifiers)
-	case SymbolStructValue, SymbolBitFieldValue:
-		write_semantic_node(builder, ident, .Struct, modifiers)
-	case SymbolEnumValue, SymbolUnionValue:
-		write_semantic_node(builder, ident, .Enum, modifiers)
-	case SymbolProcedureValue,
-	     SymbolMatrixValue,
-	     SymbolBitSetValue,
-	     SymbolDynamicArrayValue,
-	     SymbolFixedArrayValue,
-	     SymbolSliceValue,
-	     SymbolMapValue,
-	     SymbolMultiPointer,
-	     SymbolBasicValue:
-		write_semantic_node(builder, ident, .Type, modifiers)
-	case SymbolUntypedValue:
-	// handled by static syntax highlighting
-	case SymbolGenericValue, SymbolProcedureGroupValue, SymbolAggregateValue:
-	// unused
 	case:
+		/* type idents */
+		switch v in symbol.value {
+		case SymbolPackageValue:
+			write_semantic_node(builder, ident, .Namespace, modifiers)
+		case SymbolStructValue, SymbolBitFieldValue:
+			write_semantic_node(builder, ident, .Struct, modifiers)
+		case SymbolEnumValue, SymbolUnionValue:
+			write_semantic_node(builder, ident, .Enum, modifiers)
+		case SymbolProcedureValue,
+		     SymbolMatrixValue,
+		     SymbolBitSetValue,
+		     SymbolDynamicArrayValue,
+		     SymbolFixedArrayValue,
+		     SymbolSliceValue,
+		     SymbolMapValue,
+		     SymbolMultiPointer,
+		     SymbolBasicValue:
+			write_semantic_node(builder, ident, .Type, modifiers)
+		case SymbolUntypedValue:
+		// handled by static syntax highlighting
+		case SymbolGenericValue, SymbolProcedureGroupValue, SymbolAggregateValue:
+		// unused
+		case:
+		}
 	}
 }

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -26,11 +26,10 @@ my_function :: proc() {
 		{0, 3, 6,  .Type,      {.ReadOnly}}, // [2]  string
 		{0, 11, 3, .Type,      {.ReadOnly}}, // [3]  int
 		{1, 0, 11, .Function,  {.ReadOnly}}, // [4]  my_function
-		{0, 0, 11, .Type,      {.ReadOnly}}, // [5]  !!! WRONG !!!
-		{1, 1, 1,  .Variable,  {}},          // [6]  a
-		{1, 1, 1,  .Variable,  {}},          // [7]  b
-		{0, 5, 1,  .Variable,  {}},          // [8]  a
-		{1, 1, 1,  .Variable,  {}},          // [9]  c
-		{0, 9, 1,  .Variable,  {}},          // [10] b
+		{1, 1, 1,  .Variable,  {}},          // [5]  a
+		{1, 1, 1,  .Variable,  {}},          // [6]  b
+		{0, 5, 1,  .Variable,  {}},          // [7]  a
+		{1, 1, 1,  .Variable,  {}},          // [8]  c
+		{0, 9, 1,  .Variable,  {}},          // [9] b
 	})
 }


### PR DESCRIPTION
This PR has the following changes:
- Avoid generating extraneous semantic tokens when visiting identifiers;
- Change a test to accomodate this fix.

These were causing issues on ST4 with LSP 2.2.0.