### PR TITLE
Fix typo in misc/ols.schema.json

### DIFF
--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -10,7 +10,7 @@
 					"name": { "type": "string" },
 					"path": { "type": "string" }
 				},
-				"required": ["name", "checker_path"],
+				"required": ["name", "path"],
 				"additionalProperties": false
 			}
 		},


### PR DESCRIPTION
Hello,

I noticed that my linter was complaining about my `ols.json` files.
It seems that there's a typo in the required propertis of the collections schema (`checker_path` -> `path`)