### PR TITLE
Correct collecting symbols for array types

### DIFF
--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -329,18 +329,18 @@ expect_hover :: proc(
 		log.error(t, "Failed get_hover_information")
 	}
 
-	if expect_hover_string == "" && hover.contents.value != "" {
-		log.errorf(
-			"Expected empty hover string, but received %v",
-			hover.contents.value,
-		)
-	}
+	/*
+	```odin\n
+	content\n
+	```
+	*/
+	content_without_markdown := hover.contents.value[8:len(hover.contents.value)-5]
 
-	if !strings.contains(hover.contents.value, expect_hover_string) {
+	if content_without_markdown != expect_hover_string {
 		log.errorf(
-			"Expected hover string %v, but received %v",
+			"Expected hover string:\n\"%v\", but received:\n\"%v\"",
 			expect_hover_string,
-			hover.contents.value,
+			content_without_markdown,
 		)
 	}
 }

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -53,7 +53,7 @@ ast_hover_parameter :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_hover(t, &source, "cool: int")
+	test.expect_hover(t, &source, "test.cool: int")
 }
 
 @(test)
@@ -223,3 +223,24 @@ ast_hover_struct_field_selector_completion :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "my_package.My_Struct: struct")
 }
+
+/*
+TODO: Allow for testing multiple files
+*/
+// @(test)
+// ast_hover_array_type_multiple_files_hover :: proc(t: ^testing.T) {
+// 	source := test.Source {
+// 		main     = \
+// 		`package test
+
+// 		Vec :: [2]f32
+// 		`,
+// 		another_file = \
+// 		`package test
+
+// 		v: Ve{*}c
+// 		`
+// 	}
+
+// 	test.expect_hover(t, &source, "test.Vec: [2]f32")
+// }

--- a/tests/objc_test.odin
+++ b/tests/objc_test.odin
@@ -141,7 +141,7 @@ objc_hover_chained_selector :: proc(t: ^testing.T) {
 	test.expect_hover(
 		t,
 		&source,
-		"Window.initWithContentRect: proc(self: ^Window, contentRect: Rect, styleMask: WindowStyleMask, backing: BackingStoreType, doDefer: BOOL)",
+		"Window.initWithContentRect: proc(self: ^Window, contentRect: Rect, styleMask: WindowStyleMask, backing: BackingStoreType, doDefer: BOOL) -> ^Window",
 	)
 }
 


### PR DESCRIPTION
Fixes #449

Turns out that the `collect_array` and `collect_slice` had swapped bodies.

It wasn't noticeable in the same file because variables from the same file were found in `ast_context.globals` which doesn't use symbols, where variables from other files are resolved by `memory_index_lookup` which uses symbols.

I also changed the symbol types for other type definitions to `.Type` from `.Variable`.

Also corrected the way hover strings are being tested, from `strings.contains` to exact match. I wanted to add a test case for the fix, but that would require to change more about the test setup.