### PR TITLE
Resolve type in assignments with or_else, or_continue and or_break

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1779,7 +1779,7 @@ visit_expr :: proc(
 		document = visit_expr(p, v.x)
 		document = cons_with_nopl(document, text_token(p, v.token))
 		document = cons_with_nopl(document, visit_expr(p, v.y))
-	case ^ast.Or_Branch_Expr:
+	case ^Or_Branch_Expr:
 		document = visit_expr(p, v.expr)
 		document = cons_with_nopl(document, text_token(p, v.token))
 		document = cons_with_nopl(document, visit_expr(p, v.label))

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3203,6 +3203,10 @@ get_generic_assignment :: proc(
 	#partial switch v in value.derived {
 	case ^Or_Return_Expr:
 		get_generic_assignment(file, v.expr, ast_context, results, calls)
+	case ^Or_Else_Expr:
+		get_generic_assignment(file, v.x, ast_context, results, calls)
+	case ^Or_Branch_Expr:
+		get_generic_assignment(file, v.expr, ast_context, results, calls)
 	case ^Call_Expr:
 		old_call := ast_context.call
 		ast_context.call = cast(^ast.Call_Expr)value
@@ -5229,22 +5233,22 @@ get_document_position_node :: proc(
 		position_context.implicit = true
 		position_context.implicit_selector_expr = n
 		get_document_position(n.field, position_context)
-	case ^ast.Or_Else_Expr:
+	case ^Or_Else_Expr:
 		get_document_position(n.x, position_context)
 		get_document_position(n.y, position_context)
-	case ^ast.Or_Return_Expr:
+	case ^Or_Return_Expr:
 		get_document_position(n.expr, position_context)
-	case ^ast.Bit_Field_Type:
+	case ^Or_Branch_Expr:
+		get_document_position_label(n.label, position_context)
+		get_document_position(n.expr, position_context)
+	case ^Bit_Field_Type:
 		position_context.bit_field_type = n
 		get_document_position(n.backing_type, position_context)
 		get_document_position(n.fields, position_context)
-	case ^ast.Bit_Field_Field:
+	case ^Bit_Field_Field:
 		get_document_position(n.name, position_context)
 		get_document_position(n.type, position_context)
 		get_document_position(n.bit_size, position_context)
-	case ^ast.Or_Branch_Expr:
-		get_document_position_label(n.label, position_context)
-		get_document_position(n.expr, position_context)
 	case:
 	}
 }

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2284,6 +2284,8 @@ language_keywords: []string = {
 	"using",
 	"or_return",
 	"or_else",
+	"or_continue",
+	"or_break"
 }
 
 swizzle_color_map: map[u8]bool = {

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -510,22 +510,22 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	case ^Map_Type:
 		resolve_node(n.key, data)
 		resolve_node(n.value, data)
-	case ^ast.Or_Else_Expr:
+	case ^Or_Else_Expr:
 		resolve_node(n.x, data)
 		resolve_node(n.y, data)
-	case ^ast.Or_Return_Expr:
+	case ^Or_Return_Expr:
 		resolve_node(n.expr, data)
-	case ^ast.Bit_Field_Type:
+	case ^Or_Branch_Expr:
+		resolve_node(n.expr, data)
+		resolve_node(n.label, data)
+	case ^Bit_Field_Type:
 		data.position_context.bit_field_type = n
 		resolve_node(n.backing_type, data)
 		resolve_nodes(n.fields, data)
-	case ^ast.Bit_Field_Field:
+	case ^Bit_Field_Field:
 		resolve_node(n.name, data)
 		resolve_node(n.type, data)
 		resolve_node(n.bit_size, data)
-	case ^ast.Or_Branch_Expr:
-		resolve_node(n.expr, data)
-		resolve_node(n.label, data)
 	case:
 	}
 

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -374,7 +374,7 @@ visit_node :: proc(node: ^ast.Node, builder: ^SemanticTokenBuilder) {
 	case ^Or_Else_Expr:
 		visit_node(n.x, builder)
 		visit_node(n.y, builder)
-	case ^ast.Or_Branch_Expr:
+	case ^Or_Branch_Expr:
 		visit_node(n.expr, builder)
 		visit_node(n.label, builder)
 	case ^Ternary_If_Expr:

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -338,7 +338,7 @@ expect_hover :: proc(
 
 	if content_without_markdown != expect_hover_string {
 		log.errorf(
-			"Expected hover string:\n\"%v\", but received:\n\"%v\"",
+			"Expected hover string:\n%q, but received:\n%q",
 			expect_hover_string,
 			content_without_markdown,
 		)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -225,9 +225,7 @@ ast_hover_on_union_assertion_with_or_else :: proc(t: ^testing.T) {
 		test :: proc () {
 			Foo :: union {int}
 			foo: Foo = int(0)
-			for {
-				nu{*}m := foo.(int) or_else 0
-			}
+			nu{*}m := foo.(int) or_else 0
 		}
 		`,
 	}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -187,6 +187,96 @@ ast_hover_on_bitset_variable :: proc(t: ^testing.T) {
 }
 
 @(test)
+ast_hover_on_union_assertion :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		test :: proc () {
+			Foo :: union {int}
+			foo: Foo = int(0)
+			nu{*}m, _ := foo.(int)
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.num: int")
+}
+
+@(test)
+ast_hover_on_union_assertion_with_or_continue :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		test :: proc () {
+			Foo :: union {int}
+			foo: Foo = int(0)
+			for {
+				nu{*}m := foo.(int) or_continue
+			}
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.num: int")
+}
+
+@(test)
+ast_hover_on_union_assertion_with_or_else :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		test :: proc () {
+			Foo :: union {int}
+			foo: Foo = int(0)
+			for {
+				nu{*}m := foo.(int) or_else 0
+			}
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.num: int")
+}
+
+@(test)
+ast_hover_on_union_assertion_with_or_return :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		test :: proc () -> bool {
+			Foo :: union {int}
+			foo: Foo = int(0)
+			nu{*}m := foo.(int) or_return
+			return true
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.num: int")
+}
+
+
+
+// @(test)
+// ast_hover_on_array_variable :: proc(t: ^testing.T) {
+// 	source := test.Source {
+// 		main = `package test
+// 		Vec :: [2]f32
+// 		vec: Ve{*}c
+// 		`,
+// 	}
+
+// 	test.expect_hover(t, &source, "test.Vec: [2]f32")
+// }
+
+// @(test)
+// ast_hover_on_array_infer_length_variable :: proc(t: ^testing.T) {
+// 	source := test.Source {
+// 		main = `package test
+// 		ve{*}c :: [?]f32{1, 2, 3}
+// 		`,
+// 	}
+
+// 	test.expect_hover(t, &source, "test.vec: [3]f32")
+// }
+
+@(test)
 ast_hover_struct_field_selector_completion :: proc(t: ^testing.T) {
 
 	packages := make([dynamic]test.Package, context.temp_allocator)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -251,31 +251,6 @@ ast_hover_on_union_assertion_with_or_return :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.num: int")
 }
 
-
-
-// @(test)
-// ast_hover_on_array_variable :: proc(t: ^testing.T) {
-// 	source := test.Source {
-// 		main = `package test
-// 		Vec :: [2]f32
-// 		vec: Ve{*}c
-// 		`,
-// 	}
-
-// 	test.expect_hover(t, &source, "test.Vec: [2]f32")
-// }
-
-// @(test)
-// ast_hover_on_array_infer_length_variable :: proc(t: ^testing.T) {
-// 	source := test.Source {
-// 		main = `package test
-// 		ve{*}c :: [?]f32{1, 2, 3}
-// 		`,
-// 	}
-
-// 	test.expect_hover(t, &source, "test.vec: [3]f32")
-// }
-
 @(test)
 ast_hover_struct_field_selector_completion :: proc(t: ^testing.T) {
 


### PR DESCRIPTION
Fixes hover information for declarations like: `comp_lit := val.derived.(^ast.Comp_Lit) or_continue`