### PR TITLE
Add missing op token when building string for unary expr node

### DIFF
--- a/src/common/ast.odin
+++ b/src/common/ast.odin
@@ -1086,6 +1086,7 @@ build_string_node :: proc(
 	case ^Tag_Expr:
 		build_string(n.expr, builder, remove_pointers)
 	case ^Unary_Expr:
+		strings.write_string(builder, n.op.text)
 		build_string(n.expr, builder, remove_pointers)
 	case ^Binary_Expr:
 		build_string(n.left, builder, remove_pointers)

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -180,7 +180,13 @@ clone_node :: proc(
 	case ^Tag_Expr:
 		r.expr = clone_type(r.expr, allocator, unique_strings)
 	case ^Unary_Expr:
+		n := node.derived.(^Unary_Expr)
 		r.expr = clone_type(r.expr, allocator, unique_strings)
+		if unique_strings == nil {
+			r.op.text = strings.clone(n.op.text, allocator)
+		} else {
+			r.op.text = get_index_unique_string(unique_strings, allocator, n.op.text)
+		}
 	case ^Binary_Expr:
 		n := node.derived.(^Binary_Expr)
 		r.left = clone_type(r.left, allocator, unique_strings)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -171,6 +171,28 @@ ast_hover_on_sliced_result :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.slice: []byte")
 }
 
+@(test)
+ast_hover_on_array_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Vec :: [2]f32
+		vec: Ve{*}c
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.Vec: [2]f32")
+}
+
+@(test)
+ast_hover_on_array_infer_length_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		ve{*}c :: [?]f32{1, 2, 3}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.vec: [?]f32")
+}
 
 @(test)
 ast_hover_on_bitset_variable :: proc(t: ^testing.T) {


### PR DESCRIPTION
Fixes #345 

It would be cool to actually infer the length of the array in the future and display it as `[4]` instead of `[?]` but that doesn't look too easy by how the printing is currently setup.