### PR TITLE
fixing build.sh

### DIFF
--- a/src/server/marshal.odin
+++ b/src/server/marshal.odin
@@ -419,7 +419,7 @@ marshal_to_writer :: proc(
 	case runtime.Type_Info_Struct:
 		opt_write_start(w, opt, '{') or_return
 
-		for name, i in info.names[0:info.field_count] {
+		for name, i in info.names {
 			id := info.types[i].id
 			data := rawptr(uintptr(v.data) + info.offsets[i])
 

--- a/src/server/unmarshal.odin
+++ b/src/server/unmarshal.odin
@@ -33,7 +33,7 @@ unmarshal :: proc(
 	case json.Object:
 		#partial switch variant in type_info.variant {
 		case Type_Info_Struct:
-			for field, i in variant.names[0:variant.field_count] {
+			for field, i in variant.names {
 				a := any {
 					rawptr(uintptr(v.data) + uintptr(variant.offsets[i])),
 					variant.types[i].id,


### PR DESCRIPTION
Fixes #463

Just removing the useless slicing of `variants.names` in `mashal.odin` and `unmarshal.odin` fixes the issue. `build.sh` no longer fails.