### PR TITLE
Add documentation for enabling references and fix enable_rename config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Options:
 
 `enable_checker_only_saved`: Turns on only calling the checker on the package being saved. 
 
+`enable_references`: Turns on finding references for a symbol.
+
+`enable_rename`: Turns on renaming a symbol.
+
 `odin_command`: Allows you to specify your Odin location, instead of just relying on the environment path.
 
 `checker_args`: Pass custom arguments to `odin check`.

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -425,7 +425,7 @@ read_ols_initialize_options :: proc(
 	config.verbose = ols_config.verbose.(bool) or_else config.verbose
 	config.file_log = ols_config.file_log.(bool) or_else config.file_log
 	config.enable_rename =
-		ols_config.enable_references.(bool) or_else config.enable_rename
+		ols_config.enable_rename.(bool) or_else config.enable_rename
 
 	config.enable_procedure_snippet =
 		ols_config.enable_procedure_snippet.(bool) or_else config.enable_procedure_snippet

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -354,6 +354,7 @@ OlsConfig :: struct {
 	enable_inlay_hints_params:         Maybe(bool),
 	enable_inlay_hints_default_params: Maybe(bool),
 	enable_references:                 Maybe(bool),
+	enable_rename:                     Maybe(bool),
 	enable_fake_methods:               Maybe(bool),
 	enable_procedure_snippet:          Maybe(bool),
 	enable_checker_only_saved:         Maybe(bool),


### PR DESCRIPTION
Whilst I was playing around with odin and ols in neovim, I noticed I was unable to go-to-references as neovim was saying the "textDocument/references" was unsupported for the server, even though the documentation seemed to indicate this should be supported.
After a bit of investigation, I realised that "textDocument/references" is actually behind a feature flag.

So this simple PR is just to document that in the README.

I also noticed that the `enable_rename` flag was actually using `ols_config.enable_references`. Not sure if this was intentional, but I also fixed that. 