### PR TITLE
Update helix configuration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,18 @@ lspconfig.ols.setup({})
 ```
 
 ### Helix
-Guide for installing helix with ols:
-https://github.com/joaocarvalhoopen/Helix_editor_for_the_Odin_programming_Language
+
+Helix supports Odin and OLS by default. One can enable it through their languages.toml. Example config:
+```toml
+# Optional. The default configration requires OLS in PATH env. variable. If not,
+# you can set path to the executable like so:
+# [language-server.ols]
+# command = "path/to/executable"
+
+[[language]]
+name = "odin"
+```
+
 ### Micro
 
 Install the [LSP plugin](https://github.com/AndCake/micro-plugin-lsp)


### PR DESCRIPTION
Link shared for Helix configuration contains lots of unnecessary, opinionated configuration and settings unrelated to Odin & OLS, lots of redundant configuration which is also Helix default and I was getting partial behaviour with it. I've checked the Helix repo, it has default configuration for Odin and OLS. In a nutshell, Helix patches its own languages.toml with user configuration if latter has language entry. So adding an entry with just a name would enable default Helix configuration. So, I updated the README.md according to that, which I think is more concise and solved my issues (I wasn't able to use go definition on core files). Haven't tested it anything other than Windows.

I think you can also add the link below as it also contains some information about how to use Helix in general. Idk, Helix is a niche editor that I'd expect anyone using it would know what they are doing anyway, I guess? In any case, I left that decision up to you 😅