### PR TITLE
Fix Struct_Type breakage following Odin changes

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1574,9 +1574,9 @@ visit_expr :: proc(
 			document = cons_with_nopl(document, visit_expr(p, v.align))
 		}
 
-		if v.field_align != nil {
+		if v.min_field_align != nil {
 			document = cons_with_nopl(document, text("#field_align"))
-			document = cons_with_nopl(document, visit_expr(p, v.field_align))
+			document = cons_with_nopl(document, visit_expr(p, v.min_field_align))
 		}
 
 		document = cons_with_nopl(document, visit_where_clauses(p, v.where_clauses))


### PR DESCRIPTION
#field_align has been deprecated in favor of #min_field_align in https://github.com/odin-lang/Odin/commit/a7d7c92a5302a9d0db503af37fe96c737a536544