### PR TITLE
Adjust `sed` call in `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,6 @@ fi
 
 version="$(git describe --tags --abbrev=7)"
 version="${version%-*}:${version##*-}"
-sed -i "s|VERSION :: .*|VERSION :: \"${version}\"|g" src/main.odin
+sed -i "" "s|VERSION :: .*|VERSION :: \"${version}\"|g" src/main.odin
 
 odin build src/ -show-timings -collection:src=src -out:ols -microarch:native -no-bounds-check -o:speed $@


### PR DESCRIPTION
On macOS the `-i` parameter value is mandatory starting in macOS 15, unlike in the GNU variants of `sed`.

This PR adds a value for the `-i` parameter in the `sed` call in `build.sh` to avoid the call failing on macOS-based machines running macOS 15 or later.

Link to the StackOverflow answer that solved the mystery for me as to why this started mysteriously failing on one of my systems: https://stackoverflow.com/a/79086763