### PR TITLE
Fix make `ols version` work with GNU sed and BSD/macOS sed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,6 @@ fi
 
 version="$(git describe --tags --abbrev=7)"
 version="${version%-*}:${version##*-}"
-sed -i "" "s|VERSION :: .*|VERSION :: \"${version}\"|g" src/main.odin
+sed "s|VERSION :: .*|VERSION :: \"${version}\"|g" src/main.odin > /tmp/main.odin.build && mv -f /tmp/main.odin.build src/main.odin
 
 odin build src/ -show-timings -collection:src=src -out:ols -microarch:native -no-bounds-check -o:speed $@


### PR DESCRIPTION
since GNU sed and BSD sed behave differently, update VERSION using a temporary file.

tested on Arch Linux and FreeBSD 14.1

P.S. oops, my bad.