### PR TITLE
add format placeholders to vscode syntax

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -652,6 +652,14 @@
 					"match": "\\\\(\\\\|[abefnrutv''\"]|x\\h{2}|u\\h{4}|U\\h{8}|[0-7]{3})"
 				},
 				{
+					"name": "constant.character.escape.placeholders.odin",
+					"match": "%(v|w|T|%|t|b|c|r|o|d|i|z|x|X|U|e|E|f|F|g|G|h|H|m|M|s|q|x|X|p|p|s)"
+				},
+				{
+					"name": "constant.character.escape.placeholders-floats.odin",
+					"match": "%(\\d*\\.?\\d*f)"
+				},
+				{
 					"name": "invalid.illegal.unknown-escape.odin",
 					"match": "\\\\."
 				}


### PR DESCRIPTION
all the % formats for printf, as specified here https://pkg.odin-lang.org/core/fmt/
This is only for coloring purposes (ignore the fact that these screenshots don't show printf)

before:
![image](https://github.com/user-attachments/assets/137893f7-61ec-4b2f-9b71-b33cbd5ef575)


after this change:
![image](https://github.com/user-attachments/assets/99cbfa9d-66a2-471c-aec1-dd4e9f868ace)
