### PR TITLE
add special coloring for all caps variables

### DIFF
--- a/editors/vscode/syntaxes/odin.tmLanguage.json
+++ b/editors/vscode/syntaxes/odin.tmLanguage.json
@@ -162,7 +162,7 @@
 			"name": "meta.definition.variable.odin",
 			"match": "([A-Za-z_]\\w*)\\s*(:\\s*:)",
 			"captures": {
-				"1": { "name": "variable.other.constant.odin" },
+				"1": { "name": "constant.language.odin" },
 				"2": { "name": "keyword.operator.assignment.odin" }
 			}
 		},
@@ -481,7 +481,7 @@
 					"match": "\\b(context)\\b"
 				},
 				{
-					"name": "variable.other.constant.odin",
+					"name": "constant.other.odin",
 					"match": "\\b(ODIN_ARCH|ODIN_OS)\\b"
 				},
 				{
@@ -491,6 +491,10 @@
 				{
 					"name": "constant.language.odin",
 					"match": "---"
+				},
+				{
+					"name": "constant.other.odin",
+					"match": "\\b([A-Z_0-9])+\\b"
 				},
 				{
 					"name": "constant.numeric.odin",


### PR DESCRIPTION
I use the convention of all caps for variables that I declare as constant, so I like having special coloring for those. In my color scheme ("monokai" in vscode):

Before:
![image](https://github.com/user-attachments/assets/e4a8acef-d64d-4698-8b9e-04811b5243d4)


After:
![image](https://github.com/user-attachments/assets/da713375-11c5-436b-86cc-d1b61c2a5d9f)
