### PR TITLE
Fix extra new lines before brace when using Allman brace style

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1042,7 +1042,9 @@ visit_stmt :: proc(
 		}
 
 		document = cons_with_opl(document, visit_expr(p, v.cond))
+		set_source_position(p, v.body.pos)
 		document = cons_with_nopl(document, visit_stmt(p, v.body, .Switch_Stmt))
+		set_source_position(p, v.body.end)
 	case ^Case_Clause:
 		document = cons(document, text("case"))
 

--- a/tools/odinfmt/tests/allman/.snapshots/switch.odin
+++ b/tools/odinfmt/tests/allman/.snapshots/switch.odin
@@ -1,0 +1,17 @@
+package allman
+
+main :: proc() {
+	num := 1
+
+	switch num {
+	case 0:
+	case 1:
+	}
+
+	switch num {
+	case 0:
+	case 1:
+	}
+
+
+}

--- a/tools/odinfmt/tests/allman/.snapshots/switch.odin
+++ b/tools/odinfmt/tests/allman/.snapshots/switch.odin
@@ -1,14 +1,17 @@
 package allman
 
-main :: proc() {
+main :: proc() 
+{
 	num := 1
 
-	switch num {
+	switch num 
+	{
 	case 0:
 	case 1:
 	}
 
-	switch num {
+	switch num 
+	{
 	case 0:
 	case 1:
 	}

--- a/tools/odinfmt/tests/allman/odinfmt.json
+++ b/tools/odinfmt/tests/allman/odinfmt.json
@@ -1,0 +1,3 @@
+{
+	"brace_style": "Allman"
+}

--- a/tools/odinfmt/tests/allman/switch.odin
+++ b/tools/odinfmt/tests/allman/switch.odin
@@ -1,0 +1,18 @@
+package allman
+
+main :: proc() {
+  num := 1
+
+  switch num
+  {
+          case 0:
+          case 1:
+  }
+
+  switch num  {
+          case 0:
+          case 1:
+  }
+
+  
+}


### PR DESCRIPTION
This fixes #530 

It also changes so the `odinfmt.json` is used for the `odinfmt` tests. The  `odinfmt.json` is read from the same dir as the file under test, if there is no config file default config will be used. This makes it possible to have different configs for each test.