### PR TITLE
Add option for spaces around colons

### DIFF
--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -55,6 +55,11 @@
 			"type": "boolean",
 			"default": false,
 			"description": "When statement in the clause contains one simple statement, it will inline the case and statement in one line"
+		},
+		"spaces_around_colons": {
+			"type": "boolean",
+			"default": false,
+			"description": "Put a space on both sides of a single colon during variable/field declaration, such as `foo : bar`"
 		}
 	},
 	"required": []

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -52,6 +52,7 @@ Config :: struct {
 	newline_style:           Newline_Style,
 	sort_imports:            bool,
 	inline_single_stmt_case: bool,
+	spaces_around_colons:    bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
 }
 
 Brace_Style :: enum {
@@ -91,29 +92,31 @@ Line_Suffix_Option :: enum {
 
 when ODIN_OS == .Windows {
 	default_style := Config {
-		spaces          = 4,
-		newline_limit   = 2,
-		convert_do      = false,
-		tabs            = true,
-		tabs_width      = 4,
-		brace_style     = ._1TBS,
-		indent_cases    = false,
-		newline_style   = .CRLF,
-		character_width = 100,
-		sort_imports    = true,
+		spaces               = 4,
+		newline_limit        = 2,
+		convert_do           = false,
+		tabs                 = true,
+		tabs_width           = 4,
+		brace_style          = ._1TBS,
+		indent_cases         = false,
+		newline_style        = .CRLF,
+		character_width      = 100,
+		sort_imports         = true,
+		spaces_around_colons = false,
 	}
 } else {
 	default_style := Config {
-		spaces          = 4,
-		newline_limit   = 2,
-		convert_do      = false,
-		tabs            = true,
-		tabs_width      = 4,
-		brace_style     = ._1TBS,
-		indent_cases    = false,
-		newline_style   = .LF,
-		character_width = 100,
-		sort_imports    = true,
+		spaces               = 4,
+		newline_limit        = 2,
+		convert_do           = false,
+		tabs                 = true,
+		tabs_width           = 4,
+		brace_style          = ._1TBS,
+		indent_cases         = false,
+		newline_style        = .LF,
+		character_width      = 100,
+		sort_imports         = true,
+		spaces_around_colons = false,
 	}
 }
 

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -304,7 +304,7 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 		lhs = cons(lhs, visit_exprs(p, v.names, {.Add_Comma, .Glue}))
 
 		if v.type != nil {
-			lhs = cons(lhs, text(":"))
+			lhs = cons(lhs, text(" :" if p.config.spaces_around_colons else ":"))
 			lhs = cons_with_nopl(lhs, visit_expr(p, v.type))
 		} else {
 			if !v.is_mutable {
@@ -323,7 +323,7 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 
 			rhs = cons_with_nopl(rhs, visit_exprs(p, v.values, {.Add_Comma}, .Value_Decl))
 		} else if len(v.values) > 0 && v.type != nil {
-			rhs = cons_with_nopl(rhs, cons_with_nopl(text(":"), visit_exprs(p, v.values, {.Add_Comma})))
+			rhs = cons_with_nopl(rhs, cons_with_nopl(text(" :" if p.config.spaces_around_colons else ":"), visit_exprs(p, v.values, {.Add_Comma})))
 		} else {
 			rhs = cons_with_nopl(rhs, visit_exprs(p, v.values, {.Add_Comma}, .Value_Decl))
 		}
@@ -2034,7 +2034,7 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 
 		if field.type != nil {
 			if len(field.names) != 0 {
-				document = cons(document, text(":"), align)
+				document = cons(document, text(" :" if p.config.spaces_around_colons else ":"), align)
 			}
 			document = cons_with_opl(document, visit_expr(p, field.type))
 		} else {
@@ -2352,7 +2352,7 @@ visit_signature_field :: proc(p: ^Printer, field: ^ast.Field, remove_blank := tr
 		document = cons(document, cons_with_nopl(flag, visit_exprs(p, field.names, {.Add_Comma})))
 
 		if len(field.names) != 0 && field.type != nil {
-			document = cons(document, text(":"), break_with_no_newline())
+			document = cons(document, text(" :" if p.config.spaces_around_colons else ":"), break_with_no_newline())
 		}
 	}
 


### PR DESCRIPTION
I wanted an option to add spaces around colons for variable/struct field declarations, such as `foo : bar = baz`, so I added it.