### PR TITLE
Add sort_imports to schema

### DIFF
--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -55,6 +55,11 @@
 			"type": "boolean",
 			"default": false,
 			"description": "When statement in the clause contains one simple statement, it will inline the case and statement in one line"
+		},
+		"sort_imports": {
+			"type": "boolean",
+			"default": true,
+			"description": "Sorts imports alphabetically"
 		}
 	},
 	"required": []


### PR DESCRIPTION
I noticed `sort_imports` is not in the schema, but works as expected when you add it manually to `odinfmt.json`. This remedies this.