### PR TITLE
Do not overwrite brackets for foreign import when value is not a string literal

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -243,7 +243,13 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 			}
 			document = cons(document, text("}"))
 		} else if len(v.fullpaths) == 1 {
-			document = cons_with_nopl(document, visit_expr(p, v.fullpaths[0]))
+			if _, ok := v.fullpaths[0].derived_expr.(^ast.Basic_Lit); ok {
+				document = cons_with_nopl(document, visit_expr(p, v.fullpaths[0]))
+			} else {
+				document = cons_with_nopl(document, text("{"))
+				document = cons(document, visit_expr(p, v.fullpaths[0]))
+				document = cons(document, text("}"))
+			}
 		}
 
 		return document


### PR DESCRIPTION
#fixes #576

Currently odinfmt formats:
```odin
TEST_VALUE :: #config(TEST_VALUE, "false")

foreign import lib {
    TEST_VALUE,
}
```

into

```odin
TEST_VALUE :: #config(TEST_VALUE, "false")

foreign import lib TEST_VALUE
```

But this is invalid foreign import declaration, because the odin compiler requires the brackets when the final expression is not a string literal.

With the changes it will format to:
```odin
TEST_VALUE :: #config(TEST_VALUE, "false")

foreign import lib {TEST_VALUE}
```

For string literals the old behavior is retained since the core libraries follow the rule to not put foreign import with a literal inside brackets.
