### PR TITLE
Fix ObjectiveC-based fields not being shown for completion

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -579,10 +579,9 @@ get_selector_completion :: proc(
 						continue
 					}
 				}
-				if !position_context.arrow && .ObjC in symbol.flags {
+				if !position_context.arrow && .ObjC in selector.flags {
 					continue
 				}
-
 
 				item := CompletionItem {
 					label         = name,


### PR DESCRIPTION
Fixes issue where completion for structs did not return fields that are Objective-C objects.

The issue was caused by the right-hand symbol's flag being checked where it should have been the left-hand symbol's flags.
