### PR TITLE
Put spaces around braces of single line blocks

### DIFF
--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -56,17 +56,20 @@
 			"default": false,
 			"description": "When statement in the clause contains one simple statement, it will inline the case and statement in one line"
 		},
-
 		"spaces_around_colons": {
 			"type": "boolean",
 			"default": false,
 			"description": "Put a space on both sides of a single colon during variable/field declaration, such as `foo : bar`"
-    },
-
+		},
 		"sort_imports": {
 			"type": "boolean",
 			"default": true,
 			"description": "Sorts imports alphabetically"
+		},
+		"space_single_line_blocks": {
+			"type": "boolean",
+			"default": false,
+			"description": "Put spaces around braces of single-line blocks: `{return 0}` => `{ return 0 }`"
 		}
 	},
 	"required": []

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -41,18 +41,19 @@ Disabled_Info :: struct {
 }
 
 Config :: struct {
-	character_width:         int,
-	spaces:                  int, //Spaces per indentation
-	newline_limit:           int, //The limit of newlines between statements and declarations.
-	tabs:                    bool, //Enable or disable tabs
-	tabs_width:              int,
-	convert_do:              bool, //Convert all do statements to brace blocks
-	brace_style:             Brace_Style,
-	indent_cases:            bool,
-	newline_style:           Newline_Style,
-	sort_imports:            bool,
-	inline_single_stmt_case: bool,
-	spaces_around_colons:    bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
+	character_width:          int,
+	spaces:                   int, //Spaces per indentation
+	newline_limit:            int, //The limit of newlines between statements and declarations.
+	tabs:                     bool, //Enable or disable tabs
+	tabs_width:               int,
+	convert_do:               bool, //Convert all do statements to brace blocks
+	brace_style:              Brace_Style,
+	indent_cases:             bool,
+	newline_style:            Newline_Style,
+	sort_imports:             bool,
+	inline_single_stmt_case:  bool,
+	spaces_around_colons:     bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
+	space_single_line_blocks: bool,
 }
 
 Brace_Style :: enum {

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -940,6 +940,7 @@ visit_stmt :: proc(
 		document = cons(document, cons_with_nopl(text("using"), visit_exprs(p, v.list, {.Add_Comma})))
 	case ^Block_Stmt:
 		uses_do := v.uses_do
+		is_single_line := v.open.line == v.end.line
 
 		if v.label != nil {
 			document = cons(document, visit_expr(p, v.label), text(":"), break_with_space())
@@ -947,6 +948,9 @@ visit_stmt :: proc(
 
 		if !uses_do {
 			document = cons(document, visit_begin_brace(p, v.pos, block_type))
+			if p.config.space_single_line_blocks && is_single_line {
+				document = cons(document, break_with_no_newline())
+			}
 		} else {
 			document = cons(document, text("do"), break_with(" ", false))
 		}
@@ -966,6 +970,9 @@ visit_stmt :: proc(
 		}
 
 		if !uses_do {
+			if p.config.space_single_line_blocks && is_single_line {
+				document = cons(document, break_with_no_newline())
+			}
 			document = cons(document, visit_end_brace(p, v.end))
 		}
 	case ^If_Stmt:


### PR DESCRIPTION
Add an option to put spaces around braces of single line blocks.
For example, `if true {return 0}` => `if true { return 0 }`.