### PR TITLE
Check for path length

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -90,6 +90,9 @@ main :: proc() {
 	path := os.args[len(os.args) - 1]
 	if strings.has_prefix(os.args[len(os.args) - 1], "-") {
 		args_to_parse = os.args[1:]
+	}
+
+	if len(path) <= 1 {
 		path = "." // if no file was specified, use current directory as the starting path to look for `odinfmt.json`
 	}
 


### PR DESCRIPTION
On Linux, when running `odinfmt -stdin` it crashes `odinfmt`.

From what investigation I've done in this issue https://github.com/DanielGavin/ols/issues/616
it seems that the `path` variable is just `''` empty character. However, it counts as one character when checking with `len(path)`. Then whatever tries to process that string further in the chain gets upset about it.

I am not entirely sure if this is bug in Odin upstream or in ols, but having this check seems to fix it. I think having the check in general outside of the `strings.has_prefix` check here makes sense.

(First time contributing to Odin project, if there's something silly I've missed let me know :D ) 