### PR TITLE
neovim definitions for conform

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Configuration of the LSP:
 
 Neovim has a builtin support for LSP.
 
-There is a plugin that makes the setup easier, called [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). You can install it with your prefered package manager.
+There is a plugin that makes the setup easier, called [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). You can install it with your preferred package manager.
 
 A simple configuration that uses the default `ols` settings would be like this:
 
@@ -224,6 +224,32 @@ require'lspconfig'.ols.setup {
 		},
 	},
 }
+```
+
+Neovim can run Odinfmt on save using the [conform](https://github.com/stevearc/conform.nvim) plugin. Here is a sample configuration using the [lazy.nvim](https://github.com/folke/lazy.nvim) package manager:
+
+```lua
+local M = {
+   "stevearc/conform.nvim",
+   opts = {
+      notify_on_error = false,
+      -- Odinfmt gets its configuration from odinfmt.json. It defaults
+      -- writing to stdout but needs to be told to read from stdin.
+      formatters = {
+         odinfmt = {
+            -- Change where to find the command if it isn't in your path.
+            command = "odinfmt",
+            args = { "-stdin" },
+            stdin = true,
+         },
+      },
+      -- and instruct conform to use odinfmt.
+      formatters_by_ft = {
+         odin = { "odinfmt" },
+      },
+   },
+}
+return M
 ```
 
 ### Emacs

--- a/editors/neovim/.stylua.toml
+++ b/editors/neovim/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 3
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"

--- a/editors/neovim/conform.lua
+++ b/editors/neovim/conform.lua
@@ -1,0 +1,25 @@
+-- This is a definition to add to your code formatter in Neovim.
+-- "stevearc/conform.nvim" can be configured to format on save,
+-- here is a definition of odinfmt for conform using the lazy.nvim
+-- plugin manager.
+local M = {
+   "stevearc/conform.nvim",
+   opts = {
+      notify_on_error = false,
+      -- Odinfmt gets its configuration from odinfmt.json. It defaults
+      -- writing to stdout but needs to be told to read from stdin.
+      formatters = {
+         odinfmt = {
+            -- Change where to find the command if it isn't in your path.
+            command = "odinfmt",
+            args = { "-stdin" },
+            stdin = true,
+         },
+      },
+      -- and instruct conform to use odinfmt.
+      formatters_by_ft = {
+         odin = { "odinfmt" },
+      },
+   },
+}
+return M


### PR DESCRIPTION
I've used Odinfmt with Neovim via the Conform plugin at https://github.com/stevearc/conform.nvim. Here are the definitions one would add to their configuration.