### PR TITLE
Add vscode problem matcher for Odin

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -132,6 +132,21 @@
 			{
 				"language": "odin"
 			}
+		],
+		"problemMatchers": [
+			{
+				"name": "odin",
+                "owner": "odin",
+                "fileLocation": ["absolute"],
+                "pattern": {
+                    "regexp": "^(.+)\\(([0-9]+)\\:([0-9]+)\\) ([^:]+)(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            }
 		]
 	},
 	"scripts": {


### PR DESCRIPTION
Allows parsing odin errors when using the task vscode system