### PR TITLE
Update struct poly params formatting to match proc params and wrap

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1575,7 +1575,21 @@ visit_expr :: proc(
 	case ^Struct_Type:
 		document = text_position(p, "struct", v.pos)
 
-		document = cons(document, visit_poly_params(p, v.poly_params))
+		if v.poly_params != nil {
+			document = cons(document, text("("))
+			document = cons(
+				document,
+				nest(
+					cons(
+						break_with(""),
+						visit_signature_list(p, v.poly_params, false, false, options),
+					),
+				),
+			)
+			document = cons(document, break_with(""), text(")"))
+		} else {
+			document = cons(document, empty())
+		}
 
 		if v.is_packed {
 			document = cons_with_nopl(document, text("#packed"))
@@ -1619,7 +1633,9 @@ visit_expr :: proc(
 				nest(
 					cons(
 						newline_position(p, 1, v.fields.open),
-						visit_struct_field_list(p, v.fields, {.Add_Comma, .Trailing, .Enforce_Newline}),
+						group(
+							visit_struct_field_list(p, v.fields, {.Add_Comma, .Trailing, .Enforce_Newline})
+						),
 					),
 				),
 			)


### PR DESCRIPTION
Address https://github.com/DanielGavin/ols/issues/609. As far as I can tell everything else works as expected. It just updates the struct definitions to follow the conventions of the proc definitions, and it groups the struct fields so they aren't affected by the long lines in the struct parameters.

For example:

```odin
a :: struct($AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: typeid) {
	test:  string,
	test2: int,
}
```

now becomes 

```odin
a :: struct($AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: typeid) {
        test:  string,
        test2: int,
}
```

as expected.

```odin
a :: struct($AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: typeid, $B: typeid) {
	field: int,
	field2: string,
}
```

becomes

```odin
a :: struct(
        $AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: typeid,
        $B: typeid,
)
{
        field:  int,
        field2: string,
}
```
