### PR TITLE
Fix proc param with no return display arrow in hover contents

### DIFF
--- a/src/common/ast.odin
+++ b/src/common/ast.odin
@@ -1115,8 +1115,11 @@ build_string_node :: proc(node: ^ast.Node, builder: ^strings.Builder, remove_poi
 	case ^Proc_Type:
 		strings.write_string(builder, "proc(")
 		build_string(n.params, builder, remove_pointers)
-		strings.write_string(builder, ") -> ")
-		build_string(n.results, builder, remove_pointers)
+		strings.write_string(builder, ")")
+		if n.results != nil {
+			strings.write_string(builder, " -> ")
+			build_string(n.results, builder, remove_pointers)
+		}
 	case ^Pointer_Type:
 		if !remove_pointers {
 			strings.write_string(builder, "^")

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -354,6 +354,27 @@ ast_hover_proc_group :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.add: proc(a, b: int) -> int")
 }
 
+@(test)
+ast_hover_proc_with_proc_parameter :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		a{*}a :: proc(p: proc()) {}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.aa: proc(p: proc())")
+}
+
+@(test)
+ast_hover_proc_with_proc_parameter_with_return :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		a{*}a :: proc(p: proc() -> int) {}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.aa: proc(p: proc() -> int)")
+}
 
 /*
 


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/645. 

Basically just removes the `->` from the proc parameter when it doesn't have a return, as demonstrated in the tests.