### PR TITLE
Resolve assignments before switch statements position context

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1669,17 +1669,16 @@ resolve_implicit_selector :: proc(
 		}
 	}
 
-	if position_context.switch_stmt != nil {
-		return resolve_type_expression(ast_context, position_context.switch_stmt.cond)
-	}
-
 	if position_context.assign != nil && len(position_context.assign.lhs) == len(position_context.assign.rhs) {
-
 		for _, i in position_context.assign.lhs {
 			if position_in_node(position_context.assign.rhs[i], position_context.position) {
 				return resolve_type_expression(ast_context, position_context.assign.lhs[i])
 			}
 		}
+	}
+
+	if position_context.switch_stmt != nil {
+		return resolve_type_expression(ast_context, position_context.switch_stmt.cond)
 	}
 
 	if position_context.binary != nil {

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -353,3 +353,42 @@ ast_goto_implicit_enum_infer_from_function :: proc(t: ^testing.T) {
 
 	test.expect_definition_locations(t, &source, {location})
 }
+
+@(test)
+ast_goto_implicit_enum_infer_from_assignment_within_switch :: proc(t: ^testing.T) {
+	source := test.Source{
+		main = `package test
+		Bar :: enum {
+			Bar1,
+			Bar2,
+		}
+
+		Foo :: enum {
+			Foo1,
+			Foo2,
+		}
+
+
+		main :: proc() {
+			my_foo: Foo
+			my_bar: Bar
+			switch my_foo {
+			case .Foo1:
+				my_bar = .B{*}ar2
+			case .Foo2:
+				my_bar = .Bar1
+			}
+		}
+		`,
+		packages = {},
+	}
+
+	location := common.Location {
+		range = {
+			start = {line = 3, character = 3},
+			end = {line = 3, character = 7},
+		},
+	}
+
+	test.expect_definition_locations(t, &source, {location})
+}


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/644.

When inferring enum assignment within a switch statement, the lsp would set the switch context as `switch_stmt`, see it was dealing with an enum and so assume that it's the enum being switched on rather than assigned to. Simple solution is to just handle assignments before `switch_stmt`. 