### PR TITLE
Add hover support for implicit selector expr

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3727,9 +3727,10 @@ unwrap_super_enum :: proc(
 
 	for type in symbol_union.types {
 		symbol := resolve_type_expression(ast_context, type) or_return
-		value := symbol.value.(SymbolEnumValue) or_return
-		append(&names, ..value.names)
-		append(&ranges, ..value.ranges)
+		if value, ok := symbol.value.(SymbolEnumValue); ok {
+			append(&names, ..value.names)
+			append(&ranges, ..value.ranges)
+		}
 	}
 
 	ret_value.names = names[:]

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -241,8 +241,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 			case SymbolEnumValue:
 				for name, i in v.names {
 					if strings.compare(name, implicit_selector.field.name) == 0 {
-						symbol.pkg = symbol.name
-						symbol.name = name
+						symbol.signature = fmt.tprintf(".%s", name)
 						hover.contents = write_hover_content(&ast_context, symbol)
 						return hover, true, true
 					}
@@ -251,8 +250,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 				if enum_value, ok := unwrap_super_enum(&ast_context, v); ok {
 					for name, i in enum_value.names {
 						if strings.compare(name, implicit_selector.field.name) == 0 {
-							symbol.pkg = symbol.name
-							symbol.name = name
+							symbol.signature = fmt.tprintf(".%s", name)
 							hover.contents = write_hover_content(&ast_context, symbol)
 							return hover, true, true
 						}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -402,7 +402,7 @@ ast_hover_union_implicit_selector :: proc(t: ^testing.T) {
 			Foo2,
 		}
 
-		Bar :: union { Foo }
+		Bar :: union { Foo, int }
 
 		bar: Bar
 		bar = .Fo{*}o1

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -376,6 +376,42 @@ ast_hover_proc_with_proc_parameter_with_return :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.aa: proc(p: proc() -> int)")
 }
 
+@(test)
+ast_hover_enum_implicit_selector :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			Foo1,
+			Foo2,
+		}
+
+		foo: Foo
+		foo = .Fo{*}o1
+		`
+	}
+
+	test.expect_hover(t, &source, "Foo.Foo1")
+}
+
+@(test)
+ast_hover_union_implicit_selector :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			Foo1,
+			Foo2,
+		}
+
+		Bar :: union { Foo }
+
+		bar: Bar
+		bar = .Fo{*}o1
+		`
+	}
+
+	test.expect_hover(t, &source, "Bar.Foo1")
+}
+
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -390,7 +390,7 @@ ast_hover_enum_implicit_selector :: proc(t: ^testing.T) {
 		`
 	}
 
-	test.expect_hover(t, &source, "Foo.Foo1")
+	test.expect_hover(t, &source, "test.Foo: .Foo1")
 }
 
 @(test)
@@ -409,7 +409,7 @@ ast_hover_union_implicit_selector :: proc(t: ^testing.T) {
 		`
 	}
 
-	test.expect_hover(t, &source, "Bar.Foo1")
+	test.expect_hover(t, &source, "test.Bar: .Foo1")
 }
 
 /*


### PR DESCRIPTION
Add hover support to the implicit selector enum and union expressions as it was something I was doing to remind myself of the underlying enum type. 

I'm not sure what the desired value for this should be but I've gone with simply `<pkg>.<name>: .<value>` as that's generally what I'm after. Let me know what you think.

Currently for unions it only works if it's the union of enum types. I noticed this also applies to `textDocument/definition` so I might take a look at that at a later point. Edit: I had a quick look at this and it seems a very straightforward fix so I just added it to this PR.