### PR TITLE
Enrich hover information

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3765,7 +3765,7 @@ unwrap_bitset :: proc(ast_context: ^AstContext, bitset_symbol: Symbol) -> (Symbo
 	return {}, false
 }
 
-get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol, was_variable := false) -> string {
+get_signature :: proc(ast_context: ^AstContext, ident: ast.Any_Node, symbol: Symbol, was_variable := false) -> string {
 	if symbol.type == .Function {
 		return symbol.signature
 	}

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3810,27 +3810,26 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 	case SymbolProcedureValue:
 		return "proc"
 	case SymbolStructValue:
+		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)
-		} else {
-			longestNameLen := 0
-			for name in v.names {
-				if len(name) > longestNameLen {
-					longestNameLen = len(name)
-				}
-			}
-			builder := strings.builder_make(ast_context.allocator)
-			strings.write_string(&builder, "struct {\n")
-			for i in 0..<len(v.names) {
-				strings.write_string(&builder, "\t")
-				strings.write_string(&builder, v.names[i])
-				fmt.sbprintf(&builder, ":%*s", longestNameLen - len(v.names[i]) + 1, "")
-				common.build_string_node(v.types[i], &builder, false)
-				strings.write_string(&builder, ",\n")
-			}
-			strings.write_string(&builder, "}")
-			return strings.to_string(builder)
+			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
 		}
+		longestNameLen := 0
+		for name in v.names {
+			if len(name) > longestNameLen {
+				longestNameLen = len(name)
+			}
+		}
+		strings.write_string(&builder, "struct {\n")
+		for i in 0..<len(v.names) {
+			strings.write_string(&builder, "\t")
+			strings.write_string(&builder, v.names[i])
+			fmt.sbprintf(&builder, ":%*s", longestNameLen - len(v.names[i]) + 1, "")
+			common.build_string_node(v.types[i], &builder, false)
+			strings.write_string(&builder, ",\n")
+		}
+		strings.write_string(&builder, "}")
+		return strings.to_string(builder)
 	case SymbolUnionValue:
 		if is_variable {
 			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3805,7 +3805,17 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 		if is_variable {
 			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)
 		} else {
-			return "struct"
+			builder := strings.builder_make(ast_context.allocator)
+			strings.write_string(&builder, "struct {\n")
+			for i in 0..<len(v.names) {
+				strings.write_string(&builder, "\t")
+				strings.write_string(&builder, v.names[i])
+				strings.write_string(&builder, ": ")
+				common.build_string_node(v.types[i], &builder, false)
+				strings.write_string(&builder, ",\n")
+			}
+			strings.write_string(&builder, "}")
+			return strings.to_string(builder)
 		}
 	case SymbolUnionValue:
 		if is_variable {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3765,6 +3765,16 @@ unwrap_bitset :: proc(ast_context: ^AstContext, bitset_symbol: Symbol) -> (Symbo
 	return {}, false
 }
 
+append_variable_full_name :: proc(sb: ^strings.Builder,ast_context: ^AstContext, symbol: Symbol, pointer_prefix: string) {
+	pkg_name := get_symbol_pkg_name(ast_context, symbol)
+	if pkg_name == "" {
+		fmt.sbprintf(sb, "%s%s :: ", pointer_prefix, symbol.name)
+		return
+	}
+	fmt.sbprintf(sb, "%s%s.%s :: ", pointer_prefix, pkg_name, symbol.name)
+	return
+}
+
 get_signature :: proc(ast_context: ^AstContext, ident: ast.Any_Node, symbol: Symbol, was_variable := false) -> string {
 	if symbol.type == .Function {
 		return symbol.signature
@@ -3791,7 +3801,7 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Any_Node, symbol: Sym
 	case SymbolEnumValue:
 		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
+			append_variable_full_name(&builder, ast_context, symbol, pointer_prefix)
 		}
 		strings.write_string(&builder, "enum {\n")
 		for i in 0..<len(v.names) {
@@ -3811,7 +3821,7 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Any_Node, symbol: Sym
 	case SymbolStructValue:
 		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
+			append_variable_full_name(&builder, ast_context, symbol, pointer_prefix)
 		}
 		longestNameLen := 0
 		for name in v.names {
@@ -3832,7 +3842,7 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Any_Node, symbol: Sym
 	case SymbolUnionValue:
 		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
+			append_variable_full_name(&builder, ast_context, symbol, pointer_prefix)
 		}
 		strings.write_string(&builder, "union {\n")
 		for i in 0..<len(v.types) {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3792,7 +3792,15 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 		if is_variable {
 			return symbol.name
 		} else {
-			return "enum"
+			builder := strings.builder_make(ast_context.allocator)
+			strings.write_string(&builder, "enum {\n")
+			for i in 0..<len(v.names) {
+				strings.write_string(&builder, "\t")
+				strings.write_string(&builder, v.names[i])
+				strings.write_string(&builder, ",\n")
+			}
+			strings.write_string(&builder, "}")
+			return strings.to_string(builder)
 		}
 	case SymbolMapValue:
 		return strings.concatenate(
@@ -3827,7 +3835,15 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 		if is_variable {
 			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)
 		} else {
-			return "union"
+			builder := strings.builder_make(ast_context.allocator)
+			strings.write_string(&builder, "union {\n")
+			for i in 0..<len(v.types) {
+				strings.write_string(&builder, "\t")
+				common.build_string_node(v.types[i], &builder, false)
+				strings.write_string(&builder, ",\n")
+			}
+			strings.write_string(&builder, "}")
+			return strings.to_string(builder)
 		}
 	case SymbolBitFieldValue:
 		if is_variable {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3805,12 +3805,18 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 		if is_variable {
 			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)
 		} else {
+			longestNameLen := 0
+			for name in v.names {
+				if len(name) > longestNameLen {
+					longestNameLen = len(name)
+				}
+			}
 			builder := strings.builder_make(ast_context.allocator)
 			strings.write_string(&builder, "struct {\n")
 			for i in 0..<len(v.names) {
 				strings.write_string(&builder, "\t")
 				strings.write_string(&builder, v.names[i])
-				strings.write_string(&builder, ": ")
+				fmt.sbprintf(&builder, ":%*s", longestNameLen - len(v.names[i]) + 1, "")
 				common.build_string_node(v.types[i], &builder, false)
 				strings.write_string(&builder, ",\n")
 			}

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3789,19 +3789,18 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 			allocator = ast_context.allocator,
 		)
 	case SymbolEnumValue:
+		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			return symbol.name
-		} else {
-			builder := strings.builder_make(ast_context.allocator)
-			strings.write_string(&builder, "enum {\n")
-			for i in 0..<len(v.names) {
-				strings.write_string(&builder, "\t")
-				strings.write_string(&builder, v.names[i])
-				strings.write_string(&builder, ",\n")
-			}
-			strings.write_string(&builder, "}")
-			return strings.to_string(builder)
+			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
 		}
+		strings.write_string(&builder, "enum {\n")
+		for i in 0..<len(v.names) {
+			strings.write_string(&builder, "\t")
+			strings.write_string(&builder, v.names[i])
+			strings.write_string(&builder, ",\n")
+		}
+		strings.write_string(&builder, "}")
+		return strings.to_string(builder)
 	case SymbolMapValue:
 		return strings.concatenate(
 			a = {pointer_prefix, "map[", common.node_to_string(v.key), "]", common.node_to_string(v.value)},
@@ -3831,19 +3830,18 @@ get_signature :: proc(ast_context: ^AstContext, ident: ast.Ident, symbol: Symbol
 		strings.write_string(&builder, "}")
 		return strings.to_string(builder)
 	case SymbolUnionValue:
+		builder := strings.builder_make(ast_context.allocator)
 		if is_variable {
-			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)
-		} else {
-			builder := strings.builder_make(ast_context.allocator)
-			strings.write_string(&builder, "union {\n")
-			for i in 0..<len(v.types) {
-				strings.write_string(&builder, "\t")
-				common.build_string_node(v.types[i], &builder, false)
-				strings.write_string(&builder, ",\n")
-			}
-			strings.write_string(&builder, "}")
-			return strings.to_string(builder)
+			fmt.sbprintf(&builder, "%s%s.%s :: ", get_symbol_pkg_name(ast_context, symbol), pointer_prefix, symbol.name)
 		}
+		strings.write_string(&builder, "union {\n")
+		for i in 0..<len(v.types) {
+			strings.write_string(&builder, "\t")
+			common.build_string_node(v.types[i], &builder, false)
+			strings.write_string(&builder, ",\n")
+		}
+		strings.write_string(&builder, "}")
+		return strings.to_string(builder)
 	case SymbolBitFieldValue:
 		if is_variable {
 			return strings.concatenate({pointer_prefix, symbol.name}, ast_context.allocator)

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1289,7 +1289,7 @@ get_identifier_completion :: proc(
 		ident.name = k
 
 		if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-			symbol.signature = get_signature(ast_context, ident, symbol)
+			symbol.signature = get_signature(ast_context, ident, symbol, short_signature=true)
 
 			build_procedure_symbol_signature(&symbol)
 
@@ -1330,7 +1330,7 @@ get_identifier_completion :: proc(
 			ident.name = k
 
 			if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-				symbol.signature = get_signature(ast_context, ident, symbol)
+				symbol.signature = get_signature(ast_context, ident, symbol, short_signature=true)
 
 				build_procedure_symbol_signature(&symbol)
 

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1289,7 +1289,7 @@ get_identifier_completion :: proc(
 		ident.name = k
 
 		if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-			symbol.signature = get_signature(ast_context, ident^, symbol)
+			symbol.signature = get_signature(ast_context, ident, symbol)
 
 			build_procedure_symbol_signature(&symbol)
 
@@ -1330,7 +1330,7 @@ get_identifier_completion :: proc(
 			ident.name = k
 
 			if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-				symbol.signature = get_signature(ast_context, ident^, symbol)
+				symbol.signature = get_signature(ast_context, ident, symbol)
 
 				build_procedure_symbol_signature(&symbol)
 

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -228,7 +228,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 					if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
 						symbol.name = name
 						symbol.pkg = selector.name
-						symbol.signature = common.node_to_string(v.types[i])
+						symbol.signature = get_signature(&ast_context, v.types[i].derived, symbol)
 						hover.contents = write_hover_content(&ast_context, symbol)
 						return hover, true, true
 					}
@@ -250,6 +250,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 			if position_context.field != nil {
 				if ident, ok := position_context.field.derived.(^ast.Ident); ok {
 					if symbol, ok := resolve_type_identifier(&ast_context, ident^); ok {
+						symbol.signature = get_signature(&ast_context, ident, symbol)
 						hover.contents = write_hover_content(&ast_context, symbol)
 						return hover, true, true
 					}

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -651,7 +651,7 @@ ast_for_in_identifier_completion :: proc(t: ^testing.T) {
 	}
 
 
-	test.expect_completion_details(t, &source, "", {"test.my_element: My_Struct"})
+	test.expect_completion_details(t, &source, "", {"test.my_element: test.My_Struct :: struct"})
 }
 
 @(test)
@@ -675,7 +675,7 @@ ast_for_in_call_expr_completion :: proc(t: ^testing.T) {
 	}
 
 
-	test.expect_completion_details(t, &source, ".", {"test.zstep: Step"})
+	test.expect_completion_details(t, &source, ".", {"test.zstep: test.Step :: struct"})
 }
 
 
@@ -1661,7 +1661,7 @@ ast_new_clone_completion :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_completion_details(t, &source, "", {"test.adzz: ^Foo"})
+	test.expect_completion_details(t, &source, "", {"test.adzz: ^test.Foo :: struct"})
 }
 
 @(test)
@@ -1735,7 +1735,7 @@ ast_index_proc_parameter_completion :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_completion_details(t, &source, ".", {"my_package.param: My_Struct"})
+	test.expect_completion_details(t, &source, ".", {"my_package.param: my_package.My_Struct :: struct"})
 }
 
 @(test)
@@ -2534,7 +2534,7 @@ ast_poly_struct_with_poly :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_completion_details(t, &source, "", {"test.first: ^Animal"})
+	test.expect_completion_details(t, &source, "", {"test.first: ^test.Animal :: struct"})
 }
 
 @(test)
@@ -3013,7 +3013,7 @@ ast_enumerated_array_range_completion :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_completion_details(t, &source, "", {"test.indezx: Enum"})
+	test.expect_completion_details(t, &source, "", {"test.indezx: test.Enum :: enum"})
 }
 
 @(test)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -425,9 +425,88 @@ ast_hover_struct :: proc(t: ^testing.T) {
 		`
 	}
 
-	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n\tf: proc(a: int) -> int,\n}")
+	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n\tf:   proc(a: int) -> int,\n}")
 }
 
+@(test)
+ast_hover_struct_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			bar: int,
+			f: proc(a: int) -> int,
+		}
+
+		fo{*}o := Foo{}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.foo: test.Foo :: struct {\n\tbar: int,\n\tf:   proc(a: int) -> int,\n}")
+}
+
+@(test)
+ast_hover_enum :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			Foo1,
+			Foo2,
+		}
+
+		foo: F{*}oo
+		`
+	}
+
+	test.expect_hover(t, &source, "test.Foo: enum {\n\tFoo1,\n\tFoo2,\n}")
+}
+
+@(test)
+ast_hover_enum_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			Foo1,
+			Foo2,
+		}
+
+		f{*}oo: Foo
+		`
+	}
+
+	test.expect_hover(t, &source, "test.foo: test.Foo :: enum {\n\tFoo1,\n\tFoo2,\n}")
+}
+
+@(test)
+ast_hover_union :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: union {
+			string,
+			int,
+		}
+
+		foo: F{*}oo
+		`
+	}
+
+	test.expect_hover(t, &source, "test.Foo: union {\n\tstring,\n\tint,\n}")
+}
+
+@(test)
+ast_hover_union_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: union {
+			string,
+			int,
+		}
+
+		f{*}oo: Foo
+		`
+	}
+
+	test.expect_hover(t, &source, "test.foo: test.Foo :: union {\n\tstring,\n\tint,\n}")
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -507,6 +507,24 @@ ast_hover_union_variable :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "test.foo: test.Foo :: union {\n\tstring,\n\tint,\n}")
 }
+
+@(test)
+ast_hover_struct_field_definition :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			b{*}ar: int,
+			f: proc(a: int) -> int,
+		}
+
+		foo := Foo{
+			bar = 1
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "Foo.bar: int")
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -412,6 +412,22 @@ ast_hover_union_implicit_selector :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.Bar: .Foo1")
 }
 
+@(test)
+ast_hover_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			bar: int,
+			f: proc(a: int) -> int,
+		}
+
+		foo := F{*}oo{}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n\tf: proc(a: int) -> int,\n}")
+}
+
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -83,7 +83,37 @@ ast_hover_external_package_parameter :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "test.cool: My_Struct")
+	test.expect_hover(t, &source, "test.cool: my_package.My_Struct :: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int,\n}")
+}
+
+@(test)
+ast_hover_external_package_parameter_pointer :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+		My_Struct :: struct {
+			one: int,
+			two: int,
+			three: int,
+		}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+		main :: proc(cool: ^my_package.My_Struct) {
+			cool{*}
+		}
+		`,
+		packages = packages[:],
+	}
+
+	test.expect_hover(t, &source, "test.cool: ^my_package.My_Struct :: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int,\n}")
 }
 
 @(test)
@@ -426,6 +456,36 @@ ast_hover_struct :: proc(t: ^testing.T) {
 	}
 
 	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n\tf:   proc(a: int) -> int,\n}")
+}
+
+@(test)
+ast_hover_proc_param_with_struct_from_another_package :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+		My_Struct :: struct {
+			one: int,
+			two: int,
+			three: int,
+		}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+		main :: proc(cool: my_package.My{*}_Struct) {
+			cool
+		}
+		`,
+		packages = packages[:],
+	}
+
+	test.expect_hover(t, &source, "test.cool: My_Struct :: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int\n}")
 }
 
 @(test)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -332,7 +332,7 @@ ast_hover_struct_field_selector_completion :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "my_package.My_Struct: struct")
+	test.expect_hover(t, &source, "my_package.My_Struct: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int,\n}")
 }
 
 @(test)
@@ -485,7 +485,7 @@ ast_hover_proc_param_with_struct_from_another_package :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "test.cool: My_Struct :: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int\n}")
+	test.expect_hover(t, &source, "my_package.My_Struct: struct {\n\tone:   int,\n\ttwo:   int,\n\tthree: int,\n}")
 }
 
 @(test)


### PR DESCRIPTION
This PR is to enrich the information displayed by `textDocument/hover`, in particular with structs, enums and unions. It essentially adds the full definition similarly to what is seen in other languages. For example, for a simple program:
```odin
package main

T :: struct {
    a: int,
    b: string,
}

main :: proc() {
   t{*} := T{}
}
```
will show up in my IDE like
<img width="297" alt="image" src="https://github.com/user-attachments/assets/711de73c-f7b2-4fd5-966a-cad682b4bd1b" />
and similarly for unions and enums. 

I haven't spent much time cleaning it up yet, but it's been working well for me so it's good for some feedback if this is something you would like added to the LSP.

I could add this behind a configuration flag as well.

Thanks!