### PR TITLE
Improve resolution of overloaded procedures

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -73,6 +73,7 @@ get_completion_list :: proc(
 		document.uri.uri,
 		document.fullpath,
 	)
+	ast_context.position_hint = position_context.hint
 
 	get_globals(document.ast, &ast_context)
 

--- a/src/server/definition.odin
+++ b/src/server/definition.odin
@@ -47,13 +47,6 @@ get_definition_location :: proc(document: ^Document, position: common.Position) 
 
 	location: common.Location
 
-	ast_context := make_ast_context(
-		document.ast,
-		document.imports,
-		document.package_name,
-		document.uri.uri,
-		document.fullpath,
-	)
 
 	uri: string
 
@@ -63,6 +56,16 @@ get_definition_location :: proc(document: ^Document, position: common.Position) 
 		log.warn("Failed to get position context")
 		return {}, false
 	}
+
+	ast_context := make_ast_context(
+		document.ast,
+		document.imports,
+		document.package_name,
+		document.uri.uri,
+		document.fullpath,
+	)
+
+	ast_context.position_hint = position_context.hint
 
 	get_globals(document.ast, &ast_context)
 

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -347,6 +347,12 @@ get_references :: proc(document: ^Document, position: common.Position) -> ([]com
 	)
 
 	position_context, ok := get_document_position_context(document, position, .Hover)
+	if !ok {
+		log.warn("Failed to get position context")
+		return {}, false
+	}
+
+	ast_context.position_hint = position_context.hint
 
 	get_globals(document.ast, &ast_context)
 

--- a/src/server/rename.odin
+++ b/src/server/rename.odin
@@ -20,6 +20,11 @@ get_rename :: proc(document: ^Document, new_text: string, position: common.Posit
 	)
 
 	position_context, ok := get_document_position_context(document, position, .Hover)
+	if !ok {
+		log.warn("Failed to get position context")
+		return {}, false
+	}
+	ast_context.position_hint = position_context.hint
 
 	get_globals(document.ast, &ast_context)
 
@@ -70,6 +75,11 @@ get_prepare_rename :: proc(document: ^Document, position: common.Position) -> (c
 	)
 
 	position_context, ok := get_document_position_context(document, position, .Hover)
+	if !ok {
+		log.warn("Failed to get position context")
+		return {}, false
+	}
+	ast_context.position_hint = position_context.hint
 
 	get_globals(document.ast, &ast_context)
 

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -124,10 +124,11 @@ get_signature_information :: proc(document: ^Document, position: common.Position
 	)
 
 	position_context, ok := get_document_position_context(document, position, .SignatureHelp)
-
 	if !ok {
+		log.warn("Failed to get position context")
 		return signature_help, true
 	}
+	ast_context.position_hint = position_context.hint
 
 	//TODO(should probably not be an ast.Expr, but ast.Call_Expr)
 	if position_context.call == nil {


### PR DESCRIPTION
If we consider this example program:

```odin
package main

import "core:strings"

main :: proc() {
	b := strings.builder_make(10)
}
```

If I run "textDocument/hover" on my variable `b` I get the following:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/7b00fa85-011d-4b72-bc8e-c2820b96f00e" />
And if I run it again on the `builder_make` procedure:
<img width="630" alt="image" src="https://github.com/user-attachments/assets/e03da2f3-0931-49c9-ab5e-b57e9d3ed77d" />

Basic the LSP is unable to identify the correct procedure used to infer the return type of our variable.

This change reworks this flow so that it correctly infers which procedure is being used.

With these changes, this looks like:
For `b`:
<img width="863" alt="image" src="https://github.com/user-attachments/assets/37ac7255-9d5b-46a5-9e8a-c8022fd6dd65" />
And for `builder_make`:
<img width="1690" alt="image" src="https://github.com/user-attachments/assets/6ad95c27-8fba-4445-a5f6-5f11ae907fef" />