### PR TITLE
Fix issue where hover inside struct construction would resolve to field rather than the RHS

### DIFF
--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -111,15 +111,17 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 	if position_context.field_value != nil && position_context.comp_lit != nil {
 		if comp_symbol, ok := resolve_comp_literal(&ast_context, &position_context); ok {
 			if field, ok := position_context.field_value.field.derived.(^ast.Ident); ok {
-				if v, ok := comp_symbol.value.(SymbolStructValue); ok {
-					for name, i in v.names {
-						if name == field.name {
-							if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
-								symbol.name = name
-								symbol.pkg = comp_symbol.name
-								symbol.signature = common.node_to_string(v.types[i])
-								hover.contents = write_hover_content(&ast_context, symbol)
-								return hover, true, true
+				if position_in_node(field, position_context.position) {
+					if v, ok := comp_symbol.value.(SymbolStructValue); ok {
+						for name, i in v.names {
+							if name == field.name {
+								if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
+									symbol.name = name
+									symbol.pkg = comp_symbol.name
+									symbol.signature = common.node_to_string(v.types[i])
+									hover.contents = write_hover_content(&ast_context, symbol)
+									return hover, true, true
+								}
 							}
 						}
 					}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -412,6 +412,30 @@ ast_hover_union_implicit_selector :: proc(t: ^testing.T) {
 	test.expect_hover(t, &source, "test.Bar: .Foo1")
 }
 
+
+@(test)
+ast_hover_within_struct_declaration :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		get_int :: proc() -> int {
+			return 42
+		}
+
+		Bar :: struct {
+			foo: int
+		}
+
+		main :: proc() {
+			bar := Bar {
+				foo = get_i{*}nt(),
+			}
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.get_int: proc() -> int")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Sorry about the PR spam, I've been really enjoying working on this 😅 .

Basically when you try to retrieve hover information for the rhs of a field assignment, it will fetch the hover information for the field instead.

For example:

```odin
package odin_test

get_int :: proc() -> int {
	return 42
}

Bar :: struct {
	foo: int
}

main :: proc() {
	bar := Bar {
		foo = get{*}_int(),
	}
}
```

This will display hover information for `Bar.foo` rather than `get_int`. This PR ensures that the position is within the field when before fetching the hover information.
