### PR TITLE
Fix issue incorrectly identifying locals

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1111,7 +1111,12 @@ get_local :: proc(ast_context: AstContext, ident: ast.Ident) -> (DocumentLocal, 
 		local_stack := locals[ident.name] or_continue
 
 		#reverse for local in local_stack {
-			if local.offset <= ident.pos.offset || local.local_global || local.lhs.pos.offset == ident.pos.offset {
+			if local.local_global {
+				return local, true
+			}
+			// Ensure that if the identifier has a file, the local is also part of the same file
+			correct_file := ident.pos.file == "" || local.lhs.pos.file == ident.pos.file
+			if correct_file && (local.offset <= ident.pos.offset || local.lhs.pos.offset == ident.pos.offset) {
 				// checking equal offsets is a hack to allow matching lhs ident in var decls
 				// because otherwise minimal offset begins after the decl
 				return local, true


### PR DESCRIPTION
Someone in discord flagged an issue with the LSP not being able to identify the `node` variable in the for loop in the example program below:

```odin
package odin_test

import "core:slice"
import "core:strings"
import "vendor:cgltf"

main :: proc() {
    data, result := cgltf.parse_file({}, "")
    for node in data.nodes {
        mesh := node.mesh
        if mesh == nil do continue
    }
}
```

Changing the name of the variable to anything but `node` will make that part work, but then a similar issue would occur with `mesh`.

This was due to the LSP only comparing the offsets for local variables, but not checking if they were defined in the same file.