### PR TITLE
Feat/enrich hover overload definition

### DIFF
--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -34,7 +34,7 @@ write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupC
 		}
 	}
 
-	build_procedure_symbol_signature(&symbol)
+	build_procedure_symbol_signature(&symbol, false)
 
 	cat := concatenate_symbol_information(ast_context, symbol, false)
 

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -49,43 +49,61 @@ ParameterInformation :: struct {
 /*
 	Lazily build the signature and returns from ast.Nodes
 */
-build_procedure_symbol_signature :: proc(symbol: ^Symbol) {
+build_procedure_symbol_signature :: proc(symbol: ^Symbol, short_signature := true) {
 	if value, ok := symbol.value.(SymbolProcedureValue); ok {
 		builder := strings.builder_make(context.temp_allocator)
-
-		strings.write_string(&builder, "proc")
-		strings.write_string(&builder, "(")
-		for arg, i in value.orig_arg_types {
-			strings.write_string(&builder, common.node_to_string(arg))
-			if i != len(value.orig_arg_types) - 1 {
-				strings.write_string(&builder, ", ")
-			}
-		}
-		strings.write_string(&builder, ")")
-
-		if len(value.orig_return_types) != 0 {
-			strings.write_string(&builder, " -> ")
-
-			if len(value.orig_return_types) > 1 {
-				strings.write_string(&builder, "(")
-			}
-
-			for arg, i in value.orig_return_types {
-				strings.write_string(&builder, common.node_to_string(arg))
-				if i != len(value.orig_return_types) - 1 {
-					strings.write_string(&builder, ", ")
-				}
-			}
-
-			if len(value.orig_return_types) > 1 {
-				strings.write_string(&builder, ")")
-			}
-		} else if value.diverging {
-			strings.write_string(&builder, " -> !")
-		}
+		write_procedure_symbol_signature(&builder, &value)
 		symbol.signature = strings.to_string(builder)
 	} else if value, ok := symbol.value.(SymbolAggregateValue); ok {
-		symbol.signature = "proc"
+		if short_signature {
+			symbol.signature = "proc"
+			return
+		}
+
+		builder := strings.builder_make(context.temp_allocator)
+		strings.write_string(&builder, "proc {\n")
+		for symbol in value.symbols {
+			if value, ok := symbol.value.(SymbolProcedureValue); ok {
+				fmt.sbprintf(&builder, "\t%s :: ",symbol.name)
+				write_procedure_symbol_signature(&builder, &value)
+				strings.write_string(&builder, ",\n")
+			}
+		}
+		strings.write_string(&builder, "}")
+		symbol.signature = strings.to_string(builder)
+	}
+}
+
+write_procedure_symbol_signature :: proc(sb: ^strings.Builder, value: ^SymbolProcedureValue) {
+	strings.write_string(sb, "proc")
+	strings.write_string(sb, "(")
+	for arg, i in value.orig_arg_types {
+		strings.write_string(sb, common.node_to_string(arg))
+		if i != len(value.orig_arg_types) - 1 {
+			strings.write_string(sb, ", ")
+		}
+	}
+	strings.write_string(sb, ")")
+
+	if len(value.orig_return_types) != 0 {
+		strings.write_string(sb, " -> ")
+
+		if len(value.orig_return_types) > 1 {
+			strings.write_string(sb, "(")
+		}
+
+		for arg, i in value.orig_return_types {
+			strings.write_string(sb, common.node_to_string(arg))
+			if i != len(value.orig_return_types) - 1 {
+				strings.write_string(sb, ", ")
+			}
+		}
+
+		if len(value.orig_return_types) > 1 {
+			strings.write_string(sb, ")")
+		}
+	} else if value.diverging {
+		strings.write_string(sb, " -> !")
 	}
 }
 

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -491,7 +491,7 @@ ast_hover_foreign_package_name_collision :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "node.bar: ^bar")
+	test.expect_hover(t, &source, "node.bar: struct {\n}")
 }
 @(test)
 ast_hover_struct :: proc(t: ^testing.T) {
@@ -813,6 +813,31 @@ ast_hover_proc_overloading_return_value_from_package :: proc(t: ^testing.T) {
 	}
 
 	test.expect_hover(t, &source, "test.result: int")
+}
+
+@(test)
+ast_hover_proc_overload_definition :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		foo_none :: proc( allocator := context.allocator) -> (int, bool) {
+			return 1, false
+		}
+		foo_int :: proc(i: int, allocator := context.allocator) -> (int, bool) {
+			return 2, true
+		}
+		fo{*}o :: proc {
+			foo_none,
+			foo_int,
+		}
+
+		main :: proc() {
+			result, ok := foo(10, 10)
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.foo: proc {\n\tfoo_none :: proc(allocator := context.allocator) -> (_: int, _: bool),\n\tfoo_int :: proc(i: int, allocator := context.allocator) -> (_: int, _: bool),\n}")
 }
 /*
 


### PR DESCRIPTION
Adds the overloaded procedure definitions to the `textDocument/hover` information

As an example, looking at `strings.builder_make()`
Before:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/77255fb1-03b8-43f9-ac5a-b8b04235283a" />


After:
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/ab5b24c8-70d3-462f-b963-aab4d8ae8ff6" />
