### PR TITLE
Add hover support for substring slices

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1596,6 +1596,11 @@ resolve_slice_expression :: proc(ast_context: ^AstContext, slice_expr: ^ast.Slic
 		expr = v.expr
 	case SymbolDynamicArrayValue:
 		expr = v.expr
+	case SymbolUntypedValue:
+		if v.type == .String {
+			return symbol, true
+		}
+		return {}, false
 	case:
 		return {}, false
 	}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -839,6 +839,20 @@ ast_hover_proc_overload_definition :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "test.foo: proc {\n\tfoo_none :: proc(allocator := context.allocator) -> (_: int, _: bool),\n\tfoo_int :: proc(i: int, allocator := context.allocator) -> (_: int, _: bool),\n}")
 }
+
+@(test)
+ast_hover_sub_string_slices :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			str := "Hello, World!"
+			s{*}ub_str := str[0:5]
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.sub_str: string")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Basically as the title and test suggest, will just now correctly infer the type when using a substring