### PR TITLE
Fix memory leak in tests and replace deprecated `append_bits_128`

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -74,28 +74,7 @@ make_symbol_collection :: proc(allocator := context.allocator, config: ^common.C
 }
 
 delete_symbol_collection :: proc(collection: SymbolCollection) {
-	for k, v in collection.packages {
-		for k2, v2 in v.symbols {
-			free_symbol(v2, collection.allocator)
-		}
-	}
-
-	for k, v in collection.unique_strings {
-		delete(v, collection.allocator)
-	}
-
-	for k, v in collection.packages {
-		for k2, v2 in v.methods {
-			delete(v2)
-		}
-		delete(v.methods)
-		delete(v.objc_structs)
-		delete(v.symbols)
-		delete(v.imports)
-	}
-
-	delete(collection.packages)
-	delete(collection.unique_strings)
+	free_all(collection.allocator)
 }
 
 collect_procedure_fields :: proc(

--- a/src/server/marshal.odin
+++ b/src/server/marshal.odin
@@ -156,13 +156,13 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		if opt.write_uint_as_hex && (opt.spec == .JSON5 || opt.spec == .MJSON) {
 			switch i in a {
 			case u8, u16, u32, u64, u128:
-				s = strconv.append_bits_128(buf[:], u, 16, info.signed, 8 * ti.size, "0123456789abcdef", {.Prefix})
+				s = strconv.write_bits_128(buf[:], u, 16, info.signed, 8 * ti.size, "0123456789abcdef", {.Prefix})
 
 			case:
-				s = strconv.append_bits_128(buf[:], u, 10, info.signed, 8 * ti.size, "0123456789", nil)
+				s = strconv.write_bits_128(buf[:], u, 10, info.signed, 8 * ti.size, "0123456789", nil)
 			}
 		} else {
-			s = strconv.append_bits_128(buf[:], u, 10, info.signed, 8 * ti.size, "0123456789", nil)
+			s = strconv.write_bits_128(buf[:], u, 10, info.signed, 8 * ti.size, "0123456789", nil)
 		}
 
 		io.write_string(w, s) or_return

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -117,18 +117,8 @@ setup :: proc(src: ^Source) {
 
 @(private)
 teardown :: proc(src: ^Source) {
-	//A lot of these deletes are managed by other systems in ols, but to simplify it, we just delete them here in tests.
-
 	server.free_index()
 	server.indexer.index = {}
-
-	delete(src.document.package_name)
-
-	for k, v in server.build_cache.loaded_pkgs {
-		delete(k)
-	}
-
-	delete(server.build_cache.loaded_pkgs)
 
 	common.scratch_allocator_destroy(src.document.allocator)
 }


### PR DESCRIPTION
As I'm sure you're aware, there is a lot of noise in the tests due to memory leaking in the tests. I had a quick look at it, and it seems like all of the `clone_node` leaks are allocated in the `collection.allocator`, along with everything else that is cleaned up in `delete_symbol_collection`. Running `free_all` for the `collection.allocator` in `delete_symbol_collection` and removing the extra cleanup in `teardown` removes all leaks and bad frees in the tests, though I'm unsure if there are any other consequences in the main application.

I also replaced `append_bits_128` with `write_bits_128` as it's been deprecated.