### PR TITLE
Add struct field type to hover information

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1290,7 +1290,7 @@ get_identifier_completion :: proc(
 		ident.name = k
 
 		if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-			symbol.signature = get_signature(ast_context, ident, symbol, short_signature=true)
+			symbol.signature = get_signature(ast_context, symbol, short_signature=true)
 
 			build_procedure_symbol_signature(&symbol)
 
@@ -1331,7 +1331,7 @@ get_identifier_completion :: proc(
 			ident.name = k
 
 			if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
-				symbol.signature = get_signature(ast_context, ident, symbol, short_signature=true)
+				symbol.signature = get_signature(ast_context, symbol, short_signature=true)
 
 				build_procedure_symbol_signature(&symbol)
 

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -125,9 +125,11 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 									&ast_context,
 									position_context.value_decl.names[0],
 								); ok {
+									symbol.type_name = symbol.name
+									symbol.type_pkg = symbol.pkg
 									symbol.pkg = struct_symbol.name
 									symbol.name = identifier.name
-									symbol.signature = get_signature(&ast_context, field.type.derived, symbol)
+									symbol.signature = get_signature(&ast_context, symbol)
 									hover.contents = write_hover_content(&ast_context, symbol)
 									return hover, true, true
 								}
@@ -188,7 +190,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 
 			if position_in_node(base, position_context.position) {
 				if resolved, ok := resolve_type_identifier(&ast_context, ident); ok {
-					resolved.signature = get_signature(&ast_context, &ident, resolved)
+					resolved.signature = get_signature(&ast_context, resolved)
 					resolved.name = ident.name
 
 					if resolved.type == .Variable {
@@ -237,9 +239,11 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 			for name, i in v.names {
 				if name == field {
 					if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
+						symbol.type_name = symbol.name
+						symbol.type_pkg = symbol.pkg
 						symbol.name = name
 						symbol.pkg = selector.name
-						symbol.signature = get_signature(&ast_context, v.types[i].derived, symbol)
+						symbol.signature = get_signature(&ast_context, symbol)
 						hover.contents = write_hover_content(&ast_context, symbol)
 						return hover, true, true
 					}
@@ -269,7 +273,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 						}
 					}
 					if resolved, ok := resolve_type_identifier(&ast_context, ident^); ok {
-						resolved.signature = get_signature(&ast_context, ident, resolved)
+						resolved.signature = get_signature(&ast_context, resolved)
 						resolved.name = ident.name
 
 						if resolved.type == .Variable {
@@ -331,7 +335,7 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 		}
 
 		if resolved, ok := resolve_type_identifier(&ast_context, ident); ok {
-			resolved.signature = get_signature(&ast_context, &ident, resolved)
+			resolved.signature = get_signature(&ast_context, resolved)
 			resolved.name = ident.name
 
 			if resolved.type == .Variable {

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -162,6 +162,8 @@ Symbol :: struct {
 	doc:       string,
 	signature: string, //type signature
 	type:      SymbolType,
+	type_pkg:  string,
+	type_name: string,
 	value:     SymbolValue,
 	pointers:  int, //how many `^` are applied to the symbol
 	flags:     SymbolFlags,

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -491,7 +491,7 @@ ast_hover_foreign_package_name_collision :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "node.bar: struct {\n}")
+	test.expect_hover(t, &source, "node.bar: ^my_package.bar :: struct {}")
 }
 @(test)
 ast_hover_struct :: proc(t: ^testing.T) {
@@ -635,6 +635,26 @@ ast_hover_struct_field_definition :: proc(t: ^testing.T) {
 	}
 
 	test.expect_hover(t, &source, "Foo.bar: int")
+}
+
+@(test)
+ast_hover_struct_field_complex_definition :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Bar :: struct {}
+
+		Foo :: struct {
+			b{*}ar: ^Bar,
+			f: proc(a: int) -> int,
+		}
+
+		foo := Foo{
+			bar = 1
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "Foo.bar: ^test.Bar :: struct {}")
 }
 
 @(test)
@@ -852,6 +872,28 @@ ast_hover_sub_string_slices :: proc(t: ^testing.T) {
 	}
 
 	test.expect_hover(t, &source, "test.sub_str: string")
+}
+
+@(test)
+ast_hover_struct_field_use :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			value: int,
+		}
+
+		Bar :: struct {
+			foo: Foo,
+		}
+
+		main :: proc() {
+			bar := Bar{}
+			bar.fo{*}o.value += 1
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "Bar.foo: test.Foo :: struct {\n\tvalue: int,\n}")
 }
 /*
 


### PR DESCRIPTION
Adds the type of the field correctly when hovering struct fields. 

Before if it was a struct, it would just show you the implementation and not the actual type.

<img width="260" alt="image" src="https://github.com/user-attachments/assets/6b5097d9-a13d-4ac0-9209-f640087c4a88" />


Now it will do both

<img width="337" alt="image" src="https://github.com/user-attachments/assets/7b44d1bf-8952-4f78-b7ae-d91a00fcd8f2" />
