### PR TITLE
Fix issue with the LSP incorrectly inferring positions if the file started with an empty line

### DIFF
--- a/src/common/position.odin
+++ b/src/common/position.odin
@@ -43,7 +43,7 @@ get_absolute_position :: proc(position: Position, document_text: []u8) -> (Absol
 	}
 
 	line_count := 0
-	index := 1
+	index := 0
 	last := document_text[0]
 
 	if !get_index_at_line(&index, &line_count, &last, document_text, position.line) {

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -446,3 +446,30 @@ ast_goto_variable_field_definition_with_selector_expr :: proc(t: ^testing.T) {
 
 	test.expect_definition_locations(t, &source, {location})
 }
+
+
+@(test)
+ast_goto_struct_definition_with_empty_line_at_top_of_file :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `
+		package test
+
+		Foo :: struct {
+			bar: int,
+		}
+
+		main :: proc() {
+			foo := F{*}oo{}
+		}
+		`
+	}
+
+	location := common.Location {
+		range = {
+			start = {line = 3, character = 2},
+			end = {line = 3, character = 5},
+		},
+	}
+
+	test.expect_definition_locations(t, &source, {location})
+}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -895,6 +895,24 @@ ast_hover_struct_field_use :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "Bar.foo: test.Foo :: struct {\n\tvalue: int,\n}")
 }
+
+@(test)
+ast_hover_empty_line_at_top_of_file :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `
+		package test
+		Foo :: struct {
+			bar: int,
+		}
+
+		main :: proc() {
+			foo := F{*}oo{}
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n}")
+}
 /*
 
 Waiting for odin fix

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -30,6 +30,29 @@ reference_variables_in_function :: proc(t: ^testing.T) {
 }
 
 @(test)
+reference_variables_in_function_with_empty_line_at_top_of_file :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `
+		package test
+		my_function :: proc() {
+			a := 2
+			b := a
+			c := 2 + b{*}
+		}
+		`,
+	}
+
+	test.expect_reference_locations(
+		t,
+		&source,
+		{
+			{range = {start = {line = 4, character = 3}, end = {line = 4, character = 4}}},
+			{range = {start = {line = 5, character = 12}, end = {line = 5, character = 13}}},
+		},
+	)
+}
+
+@(test)
 reference_variables_in_function_parameters :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test


### PR DESCRIPTION
Someone in the discord raised an issue where they were having weird goto definition and hover behaviour, where it would  take them to the symbol above them. They later realised it was due to them having an empty newline at the top of the file. After a quick look into it, it turns out when calculating positions it was starting from the 2nd character, rather than the 1st so it was skipping the newline. 