### PR TITLE
Improve resolution of comp literals

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -211,6 +211,14 @@ resolve_type_comp_literal :: proc(
 	^ast.Comp_Lit,
 	bool,
 ) {
+	// If the symbol is a MultiPointerValue, we retrieve the symbol of the underlying expression and
+	// retry with that.
+	if s, ok := current_symbol.value.(SymbolMultiPointerValue); ok {
+		if symbol, ok := resolve_type_expression(ast_context, s.expr); ok {
+			return resolve_type_comp_literal(ast_context, position_context, symbol, current_comp_lit)
+		}
+	}
+
 	if position_context.comp_lit == current_comp_lit {
 		return current_symbol, current_comp_lit, true
 	} else if current_comp_lit == nil {

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -3245,6 +3245,8 @@ ast_completion_multi_pointer_nested :: proc(t: ^testing.T) {
 
 		S2 :: struct {
 			field: S3,
+			i: int,
+			s: int,
 		}
 
 		S3 :: struct {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -946,6 +946,38 @@ ast_hover_empty_line_at_top_of_file :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "test.Foo: struct {\n\tbar: int,\n}")
 }
+
+@(test)
+ast_hover_inside_multi_pointer_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+
+		S1 :: struct {
+			s2_ptr: [^]S2,
+		}
+
+		S2 :: struct {
+			field: S3,
+			i: int,
+			s: int,
+		}
+
+		S3 :: struct {
+			s3: int,
+		}
+
+		main :: proc() {
+			x := S1 {
+				s2_ptr = &S2 {
+					fi{*}eld = S3 {}
+				}
+			}
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "S2.field: S3")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
After the changes made in https://github.com/DanielGavin/ols/pull/665, I realised that it didn't entirely solve the issue as in the nested example 

```odin
package main

S1 :: struct {
	s2_ptr: [^]S2,
}

S2 :: struct {
	field: S3,
	i: int,
	s: int,
}

S3 :: struct {
	s3: int,
}

main :: proc() {
	x := S1 {
		s2_ptr = &S2 {
			field = S3 {
				{*}
			}
		}
	}
}
```
It would provide the fields for both `S3` and `S2`. I also noticed that the hover was not working when hovering on `field`. This PR moves the fix to the shared analysis function and ensures any `SymbolMultiPointerValue` symbols get resolved to their underlying type.