### PR TITLE
Correctly resolve overloaded call argument types with parametric types

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -707,9 +707,9 @@ resolve_function_overload :: proc(ast_context: ^AstContext, group: ast.Proc_Grou
 						}
 
 						if proc_arg.type != nil {
-							arg_symbol, ok = resolve_type_expression(ast_context, proc_arg.type)
+							arg_symbol, ok = resolve_call_arg_type_expression(ast_context, proc_arg.type)
 						} else {
-							arg_symbol, ok = resolve_type_expression(ast_context, proc_arg.default_value)
+							arg_symbol, ok = resolve_call_arg_type_expression(ast_context, proc_arg.default_value)
 						}
 
 						if !ok {


### PR DESCRIPTION
I was looking around the `parser/parser.odin` code when I encountered an issue here:
```odin
new_from_positions :: proc($T: typeid, pos, end: tokenizer.Pos) -> ^T {}
new_from_pos_and_end_node :: proc($T: typeid, pos: tokenizer.Pos, end: ^Node) -> ^T {}

new :: proc {
	new_from_positions,
	new_from_pos_and_end_node,
}
...
// Fails to resolve
pd := ast.new(ast.Package_Decl, pkg_name.pos, end_pos(p.prev_tok))
```
It was due to the `ast_context.current_package` being updated to `ast` due to the function `ast.new`, causing it to fail when looking for the global `ast` as part of resolving `ast.Package_Decl` as it requires `ast_context.current_package == ast_context.document_package`. 

This PR solves this the same way as in https://github.com/DanielGavin/ols/pull/668

This also resolves issues I had trying to resolve the `append` proc
