### PR TITLE
fix trailing whitespace in matrix formatting

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1938,7 +1938,11 @@ visit_matrix_comp_lit :: proc(p: ^Printer, comp_lit: ^ast.Comp_Lit, matrix_type:
 	for row := 0; row < row_count; row += 1 {
 		for column := 0; column < column_count; column += 1 {
 			document = cons(document, visit_expr(p, comp_lit.elems[column + row * column_count]))
-			document = cons(document, text(", "))
+			if column_count - 1 != column {
+				document = cons(document, text(", "))
+			} else {
+				document = cons(document, text(","))
+			}
 		}
 
 		if row_count - 1 != row {

--- a/tools/odinfmt/tests/.snapshots/calls.odin
+++ b/tools/odinfmt/tests/.snapshots/calls.odin
@@ -143,12 +143,12 @@ calls :: proc() {
 	_ = vk.CreateInsance(Composite{1, 2, 3, 4})
 	_ = vk.CreateInsance(Composite{1, 2, 3, 4})
 	_ = vk.CreateInsance(matrix[2, 2]i32{
-			1, 2, 
-			3, 4, 
+			1, 2,
+			3, 4,
 		})
 	_ = vk.CreateInsance(matrix[2, 2]i32{
-			1, 2, 
-			3, 4, 
+			1, 2,
+			3, 4,
 		})
 
 	test_2(

--- a/tools/odinfmt/tests/random/.snapshots/demo.odin
+++ b/tools/odinfmt/tests/random/.snapshots/demo.odin
@@ -2391,8 +2391,8 @@ matrix_type :: proc() {
 		m: matrix[2, 3]f32
 
 		m = matrix[2, 3]f32{
-			1, 9, -13, 
-			20, 5, -6, 
+			1, 9, -13,
+			20, 5, -6,
 		}
 
 		// Element types of integers, float, and complex numbers are supported by matrices.
@@ -2418,14 +2418,14 @@ matrix_type :: proc() {
 
 	{ 	// Matrices support multiplication between matrices
 		a := matrix[2, 3]f32{
-			2, 3, 1, 
-			4, 5, 0, 
+			2, 3, 1,
+			4, 5, 0,
 		}
 
 		b := matrix[3, 2]f32{
-			1, 2, 
-			3, 4, 
-			5, 6, 
+			1, 2,
+			3, 4,
+			5, 6,
 		}
 
 		fmt.println("a", a)
@@ -2438,10 +2438,10 @@ matrix_type :: proc() {
 
 	{ 	// Matrices support multiplication between matrices and arrays
 		m := matrix[4, 4]f32{
-			1, 2, 3, 4, 
-			5, 5, 4, 2, 
-			0, 1, 3, 0, 
-			0, 1, 4, 1, 
+			1, 2, 3, 4,
+			5, 5, 4, 2,
+			0, 1, 3, 0,
+			0, 1, 4, 1,
 		}
 
 		v := [4]f32{1, 5, 4, 3}
@@ -2454,8 +2454,8 @@ matrix_type :: proc() {
 
 		// Support with non-square matrices
 		s := matrix[2, 4]f32{ 	// [4][2]f32
-			2, 4, 3, 1, 
-			7, 8, 6, 5, 
+			2, 4, 3, 1,
+			7, 8, 6, 5,
 		}
 
 		w := [2]f32{1, 2}
@@ -2468,13 +2468,13 @@ matrix_type :: proc() {
 		// Not support for '/', '%', or '%%' operations
 
 		a := matrix[2, 2]i32{
-			1, 2, 
-			3, 4, 
+			1, 2,
+			3, 4,
 		}
 
 		b := matrix[2, 2]i32{
-			-5, 1, 
-			9, -7, 
+			-5, 1,
+			9, -7,
 		}
 
 		c0 := a + b


### PR DESCRIPTION
This is a fix for trailing whitespace in matrices. Currently there is trailing whitespace after each row:

```
m: matrix[2, 3]f32
m = matrix[2, 3]f32{
	1, 9, -13, // <- trailing whitespace here
	20, 5, -6, // <- and here
}
```