### PR TITLE
Improvements to local variable references

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1287,7 +1287,7 @@ get_identifier_completion :: proc(
 		}
 	}
 
-	for _, local in ast_context.locals {
+	#reverse for local in ast_context.locals {
 		for k, v in local {
 			if position_context.global_lhs_stmt {
 				break

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -391,6 +391,7 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	case ^Defer_Stmt:
 		resolve_node(n.stmt, data)
 	case ^Case_Clause:
+		local_scope(data, n)
 		resolve_nodes(n.list, data)
 		resolve_nodes(n.body, data)
 	case ^Type_Switch_Stmt:

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -104,7 +104,6 @@ resolve_decl :: proc(
 @(private = "file")
 local_scope_deferred :: proc(data: ^FileResolveData, stmt: ^ast.Stmt) {
 	pop_local_group(data.ast_context)
-	data.ast_context.local_id -= 1
 }
 
 @(deferred_in = local_scope_deferred)
@@ -113,8 +112,6 @@ local_scope :: proc(data: ^FileResolveData, stmt: ^ast.Stmt) {
 	if stmt == nil {
 		return
 	}
-
-	data.ast_context.local_id += 1
 
 	add_local_group(data.ast_context)
 

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -103,7 +103,7 @@ resolve_decl :: proc(
 
 @(private = "file")
 local_scope_deferred :: proc(data: ^FileResolveData, stmt: ^ast.Stmt) {
-	clear_local_group(data.ast_context, data.ast_context.local_id)
+	pop_local_group(data.ast_context)
 	data.ast_context.local_id -= 1
 }
 
@@ -116,7 +116,7 @@ local_scope :: proc(data: ^FileResolveData, stmt: ^ast.Stmt) {
 
 	data.ast_context.local_id += 1
 
-	add_local_group(data.ast_context, data.ast_context.local_id)
+	add_local_group(data.ast_context)
 
 	data.position_context.position = stmt.end.offset
 	data.position_context.nested_position = data.position_context.position

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -416,3 +416,39 @@ ast_reference_cast_proc_param_with_param_expr :: proc (t: ^testing.T) {
 
 	test.expect_reference_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_reference_variable_in_switch_case :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Bar :: enum {
+			Bar1,
+			Bar2,
+		}
+
+		Foo :: struct {
+			foo1: int,
+		}
+
+		main :: proc() {
+			bar: Bar
+
+			#partial switch bar {
+			case .Bar1:
+				foo := Foo{}
+				f{*}oo.foo1 = 2
+			}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 17, character = 4}, end = {line = 17, character = 7}}},
+		{range = {start = {line = 17, character = 4}, end = {line = 17, character = 7}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}
+
+

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -451,4 +451,82 @@ ast_reference_variable_in_switch_case :: proc (t: ^testing.T) {
 	test.expect_reference_locations(t, &source, locations[:])
 }
 
+@(test)
+ast_reference_shouldnt_reference_variable_outside_body :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
 
+		Foo :: struct {
+			foo1: int,
+		}
+
+		main :: proc() {
+			foo: Foo
+			{
+				fo{*}o := Foo{}
+				foo.foo1 = 2
+			}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 9, character = 4}, end = {line = 9, character = 7}}},
+		{range = {start = {line = 10, character = 4}, end = {line = 10, character = 7}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}
+
+@(test)
+ast_reference_shouldnt_reference_variable_inside_body :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			foo1: int,
+		}
+
+		main :: proc() {
+			fo{*}o: Foo
+			{
+				foo := Foo{}
+				foo.foo1 = 2
+			}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 7, character = 3}, end = {line = 7, character = 6}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}
+
+
+@(test)
+ast_reference_should_reference_variable_inside_body :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			foo1: int,
+		}
+
+		main :: proc() {
+			fo{*}o: Foo
+			{
+				foo.foo1 = 2
+			}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 7, character = 3}, end = {line = 7, character = 6}}},
+		{range = {start = {line = 9, character = 4}, end = {line = 9, character = 7}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}


### PR DESCRIPTION
At first I noticed when working in the code for `get_signature` (https://github.com/DanielGavin/ols/blob/master/src/server/documentation.odin#L21), I was unable to rename or find references to `builder` in the switch statements. I was able to easily fix that by just adding a `local_scope` for case_clauses, however after that if I added a `builder` variable before the switch statement, it would break again when referencing `builder` inside the switch statement, and when referencing the `builder` outside the switch statement if would match to all the `builder`s inside all of the cases. This also happened for all bodies as far as I could tell.

To fix this I've turned the `AstContext.locals` into a stack that we iterate in reverse order, rather than a map that gets iterated in a random order. After making that change, the `local_id` was no longer needed so I removed that. 

I'm not sure if there are some unintended consequences from this, but everything seems to be working as far as I can tell. And all of the nested reference cases are now working.