### PR TITLE
Improve resolution of parameteric types with external types

### DIFF
--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -110,7 +110,7 @@ resolve_poly :: proc(
 			found := false
 			for arg in p.args {
 				if poly_type, ok := arg.derived.(^ast.Poly_Type); ok {
-					if poly_type.type == nil || struct_value.poly == nil || len(struct_value.args) <= arg_index {
+					if poly_type.type == nil || len(struct_value.args) <= arg_index {
 						return false
 					}
 


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/693

I'm just not sure what the `struct_value.poly == nil` check was there for originally, so I'm not sure if there's something else that would break with this.