### PR TITLE
Improve resolution of poly fields and parameters

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -211,7 +211,7 @@ set_ast_package_from_node_scoped :: proc(ast_context: ^AstContext, node: ast.Nod
 	ast_context.deferred_count += 1
 	pkg := get_package_from_node(node)
 
-	if pkg != "" {
+	if pkg != "" && pkg != "." {
 		ast_context.current_package = pkg
 	} else {
 		ast_context.current_package = ast_context.document_package
@@ -900,7 +900,7 @@ internal_resolve_type_expression :: proc(ast_context: ^AstContext, node: ^ast.Ex
 		return {}, false
 	}
 
-	set_ast_package_scoped(ast_context)
+	set_ast_package_from_node_scoped(ast_context, node)
 
 	if check_node_recursion(ast_context, node) {
 		return {}, false
@@ -1152,7 +1152,6 @@ resolve_selector_expression :: proc(ast_context: ^AstContext, node: ^ast.Selecto
 				)
 				selector_expr.expr = s.return_types[0].type
 				selector_expr.field = node.field
-
 				return internal_resolve_type_expression(ast_context, selector_expr)
 			}
 		case SymbolStructValue:
@@ -1325,6 +1324,7 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 	}
 
 	set_ast_package_scoped(ast_context)
+
 
 	if v, ok := keyword_map[node.name]; ok {
 		//keywords

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -193,6 +193,31 @@ set_ast_package_from_symbol_scoped :: proc(ast_context: ^AstContext, symbol: Sym
 	}
 }
 
+set_ast_package_from_node_deferred :: proc(ast_context: ^AstContext, node: ast.Node) {
+	if ast_context.deferred_count <= 0 {
+		return
+	}
+	ast_context.deferred_count -= 1
+	ast_context.current_package = ast_context.deferred_package[ast_context.deferred_count]
+}
+
+@(deferred_in = set_ast_package_from_node_deferred)
+set_ast_package_from_node_scoped :: proc(ast_context: ^AstContext, node: ast.Node) {
+	if ast_context.deferred_count >= DeferredDepth {
+		return
+	}
+
+	ast_context.deferred_package[ast_context.deferred_count] = ast_context.current_package
+	ast_context.deferred_count += 1
+	pkg := get_package_from_node(node)
+
+	if pkg != "" {
+		ast_context.current_package = pkg
+	} else {
+		ast_context.current_package = ast_context.document_package
+	}
+}
+
 reset_ast_context :: proc(ast_context: ^AstContext) {
 	ast_context.use_locals = true
 	clear(&ast_context.recursion_map)
@@ -1133,6 +1158,7 @@ resolve_selector_expression :: proc(ast_context: ^AstContext, node: ^ast.Selecto
 		case SymbolStructValue:
 			for name, i in s.names {
 				if node.field != nil && name == node.field.name {
+					set_ast_package_from_node_scoped(ast_context, s.types[i])
 					ast_context.field_name = node.field^
 					symbol, ok := internal_resolve_type_expression(ast_context, s.types[i])
 					symbol.type = .Variable

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -562,7 +562,7 @@ get_selector_completion :: proc(
 				continue
 			}
 
-			set_ast_package_from_symbol_scoped(ast_context, selector)
+			set_ast_package_from_node_scoped(ast_context, v.types[i])
 
 			if symbol, ok := resolve_type_expression(ast_context, v.types[i]); ok {
 				if expr, ok := position_context.selector.derived.(^ast.Selector_Expr); ok {

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -562,8 +562,6 @@ get_selector_completion :: proc(
 				continue
 			}
 
-			set_ast_package_from_node_scoped(ast_context, v.types[i])
-
 			if symbol, ok := resolve_type_expression(ast_context, v.types[i]); ok {
 				if expr, ok := position_context.selector.derived.(^ast.Selector_Expr); ok {
 					if expr.op.text == "->" && symbol.type != .Function {

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -274,7 +274,19 @@ write_struct_hover :: proc(ast_context: ^AstContext, sb: ^strings.Builder, v: Sy
 
 	using_index := -1
 
-	strings.write_string(sb, "struct {\n")
+	strings.write_string(sb, "struct")
+	if v.poly != nil {
+		strings.write_string(sb, "(")
+		for field in v.poly.list {
+			for name in field.names {
+				build_string_node(name, sb, false)
+			}
+			strings.write_string(sb, ": ")
+			build_string_node(field.type, sb, false)
+		}
+		strings.write_string(sb, ")")
+	}
+	strings.write_string(sb, " {\n")
 	for i in 0 ..< len(v.names) {
 		if i < len(v.from_usings) {
 			if index := v.from_usings[i]; index != using_index {

--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -493,7 +493,11 @@ resolve_generic_function_symbol :: proc(
 			ast_context.current_package = ast_context.document_package
 
 			if symbol, ok := resolve_type_expression(ast_context, call_expr.args[i]); ok {
-				symbol_expr := symbol_to_expr(symbol, call_expr.args[i].pos.file, context.temp_allocator)
+				file := strings.trim_prefix(symbol.uri, "file://")
+				if file == "" {
+					file = call_expr.args[i].pos.file
+				}
+				symbol_expr := symbol_to_expr(symbol, file, context.temp_allocator)
 
 				if symbol_expr == nil {
 					return {}, false

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -1595,6 +1595,7 @@ ast_hover_distinct_definition_external_package :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "my_package.A: distinct u64")
 }
+
 @(test)
 ast_hover_poly_type :: proc(t: ^testing.T) {
 	source := test.Source {
@@ -1722,6 +1723,19 @@ ast_hover_poly_type_external_package_with_external_type :: proc(t: ^testing.T) {
 	}
 
 	test.expect_hover(t, &source, "test.foo: small_array.Foo :: struct {}")
+}
+
+@(test)
+ast_hover_struct_poly_type :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		F{*}oo :: struct($T: typeid) {
+			foo: T,
+		}
+		`,
+	}
+
+	test.expect_hover(t, &source, "test.Foo: struct($T: typeid) {\n\tfoo: T,\n}")
 }
 /*
 


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/701

There's 2 main improvements here:
1. Before, when resolving a poly parameter of a struct, it would set the current_package to the package of the parapoly struct, rather than the package of the parameter to be resolved (effectively what is outlined in the issue). For this, when resolving the type expression of a node, I set the package to be the package of that node.
2. I noticed similar issues for parapoly procs. For this, when it would "fill" the parameteric type, it would create an expression from the symbol of the matched type, but it would set it's file to the file of the proc, rather than the file of the struct. This will now first try and set the file based on the symbols uri.