### PR TITLE
Improve resolution of symbols for references and renames

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1717,7 +1717,7 @@ resolve_comp_literal :: proc(
 	symbol: Symbol,
 	ok: bool,
 ) {
-	if position_context.parent_comp_lit.type != nil {
+	if position_context.parent_comp_lit != nil && position_context.parent_comp_lit.type != nil {
 		symbol = resolve_type_expression(ast_context, position_context.parent_comp_lit.type) or_return
 	} else if position_context.call != nil {
 		if call_expr, ok := position_context.call.derived.(^ast.Call_Expr); ok {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1906,7 +1906,7 @@ resolve_implicit_selector :: proc(
 				if s, ok := comp_symbol.value.(SymbolStructValue); ok {
 					set_ast_package_set_scoped(ast_context, comp_symbol.pkg)
 
-					//We can either have the final 
+					//We can either have the final
 					elem_index := -1
 
 					for elem, i in comp_lit.elems {
@@ -1934,7 +1934,7 @@ resolve_implicit_selector :: proc(
 				} else if s, ok := comp_symbol.value.(SymbolBitFieldValue); ok {
 					set_ast_package_set_scoped(ast_context, comp_symbol.pkg)
 
-					//We can either have the final 
+					//We can either have the final
 					elem_index := -1
 
 					for elem, i in comp_lit.elems {
@@ -2756,17 +2756,9 @@ make_symbol_enum_from_ast :: proc(
 	ranges := make([dynamic]common.Range, ast_context.allocator)
 
 	for n in v.fields {
-		append(&ranges, common.get_token_range(n, ast_context.file.src))
-
-		if ident, ok := n.derived.(^ast.Ident); ok {
-			append(&names, ident.name)
-		} else if field, ok := n.derived.(^ast.Field_Value); ok {
-			if ident, ok := field.field.derived.(^ast.Ident); ok {
-				append(&names, ident.name)
-			} else if binary, ok := field.field.derived.(^ast.Binary_Expr); ok {
-				append(&names, binary.left.derived.(^ast.Ident).name)
-			}
-		}
+		name, range := get_enum_field_name_and_range(n, ast_context.file.src)
+		append(&names, name)
+		append(&ranges, range)
 	}
 
 	symbol.value = SymbolEnumValue {
@@ -2775,6 +2767,20 @@ make_symbol_enum_from_ast :: proc(
 	}
 
 	return symbol
+}
+
+get_enum_field_name_and_range :: proc(n: ^ast.Expr, document_text: string) -> (string, common.Range) {
+	if ident, ok := n.derived.(^ast.Ident); ok {
+		return ident.name, common.get_token_range(ident, document_text)
+	}
+	if field, ok := n.derived.(^ast.Field_Value); ok {
+		if ident, ok := field.field.derived.(^ast.Ident); ok {
+			return ident.name, common.get_token_range(ident, document_text)
+		} else if binary, ok := field.field.derived.(^ast.Binary_Expr); ok {
+			return binary.left.derived.(^ast.Ident).name, common.get_token_range(binary, document_text)
+		}
+	}
+	return "", {}
 }
 
 make_symbol_bitset_from_ast :: proc(

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -308,14 +308,20 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	case ^Ellipsis:
 		resolve_node(n.expr, data)
 	case ^Comp_Lit:
+		// We only want to resolve the values, not the types
+		resolve_node(n.type, data)
+
 		//only set this for the parent comp literal, since we will need to walk through it to infer types.
+		set := false
 		if data.position_context.parent_comp_lit == nil {
+			set = true
 			data.position_context.parent_comp_lit = n
+		}
+		defer if set {
+			data.position_context.parent_comp_lit = nil
 		}
 
 		data.position_context.comp_lit = n
-
-		resolve_node(n.type, data)
 		resolve_nodes(n.elems, data)
 	case ^Tag_Expr:
 		resolve_node(n.expr, data)

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -462,7 +462,10 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 				for name in field.names {
 					data.symbols[cast(uintptr)name] = SymbolAndNode {
 						node = name,
-						symbol = Symbol{range = common.get_token_range(name, string(data.document.text))},
+						symbol = Symbol{
+							range = common.get_token_range(name, string(data.document.text)),
+							uri = strings.clone(common.create_uri(field.pos.file, data.ast_context.allocator).uri, data.ast_context.allocator),
+						},
 					}
 				}
 			}

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -93,8 +93,27 @@ prepare_references :: proc(
 					resolve_flag = .Field
 					break done_enum
 				}
-			}
+			} else if value, ok := field.derived.(^ast.Field_Value); ok {
+				if position_in_node(value.field, position_context.position) {
+					symbol = Symbol {
+						range = common.get_token_range(value.field, string(document.text)),
+					}
+					found = true
+					resolve_flag = .Field
+					break done_enum
+				} else if position_in_node(value.value, position_context.position) {
+					if ident, ok := value.value.derived.(^ast.Ident); ok {
+						symbol, ok = resolve_location_identifier(ast_context, ident^)
+						if !ok {
+							return
+						}
 
+						found = true
+						resolve_flag = .Identifier
+						break done_enum
+					}
+				}
+			}
 		}
 		if !found {
 			return

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -57,6 +57,7 @@ prepare_references :: proc(
 				if position_in_node(name, position_context.position) {
 					symbol = Symbol {
 						range = common.get_token_range(name, ast_context.file.src),
+						pkg = ast_context.current_package,
 					}
 					found = true
 					resolve_flag = .Field
@@ -104,6 +105,7 @@ prepare_references :: proc(
 				if position_in_node(value.field, position_context.position) {
 					symbol = Symbol {
 						range = common.get_token_range(value.field, ast_context.file.src),
+						pkg = ast_context.current_package,
 					}
 					found = true
 					resolve_flag = .Field
@@ -324,7 +326,7 @@ resolve_references :: proc(
 						node_uri := common.create_uri(v.node.pos.file, ast_context.allocator)
 
 						location := common.Location {
-							range = common.get_token_range(v.node^, ast_context.file.src),
+							range = common.get_token_range(v.node^, string(document.text)),
 							uri   = strings.clone(node_uri.uri, ast_context.allocator),
 						}
 						append(&locations, location)

--- a/src/server/rename.odin
+++ b/src/server/rename.odin
@@ -106,27 +106,34 @@ prepare_rename :: proc(
 	ok = false
 	pkg := ""
 
-	if position_context.label != nil {
-		return
-	} else if position_context.struct_type != nil {
+	if position_context.struct_type != nil {
 		found := false
 		done_struct: for field in position_context.struct_type.fields.list {
 			for name in field.names {
 				if position_in_node(name, position_context.position) {
 					symbol = Symbol {
-						range = common.get_token_range(name, string(document.text)),
+						range = common.get_token_range(name, ast_context.file.src),
 					}
 					found = true
 					break done_struct
 				}
 			}
 			if position_in_node(field.type, position_context.position) {
-				symbol = Symbol {
-					range = common.get_token_range(field.type, string(document.text)),
-				}
+				if ident, ok := field.type.derived.(^ast.Ident); ok {
+					symbol = Symbol {
+						range = common.get_token_range(field.type, ast_context.file.src),
+					}
 
-				found = true
-				break done_struct
+					found = true
+					break done_struct
+				} else if selector, ok := field.type.derived.(^ast.Selector_Expr); ok {
+					symbol = Symbol {
+						range = common.get_token_range(selector.field, ast_context.file.src),
+					}
+
+					found = true
+					break done_struct
+				}
 			}
 		}
 		if !found {
@@ -138,13 +145,26 @@ prepare_rename :: proc(
 			if ident, ok := field.derived.(^ast.Ident); ok {
 				if position_in_node(ident, position_context.position) {
 					symbol = Symbol {
-						range = common.get_token_range(ident, string(document.text)),
+						range = common.get_token_range(ident, ast_context.file.src),
+					}
+					found = true
+					break done_enum
+				}
+			} else if value, ok := field.derived.(^ast.Field_Value); ok {
+				if position_in_node(value.field, position_context.position) {
+					symbol = Symbol {
+						range = common.get_token_range(value.field, ast_context.file.src),
+					}
+					found = true
+					break done_enum
+				} else if position_in_node(value.value, position_context.position) {
+					symbol = Symbol {
+						range = common.get_token_range(value.value, ast_context.file.src),
 					}
 					found = true
 					break done_enum
 				}
 			}
-
 		}
 		if !found {
 			return
@@ -155,19 +175,11 @@ prepare_rename :: proc(
 		found := false
 		for variant in position_context.union_type.variants {
 			if position_in_node(variant, position_context.position) {
-				if ident, ok := variant.derived.(^ast.Ident); ok {
-					symbol, ok = resolve_location_identifier(ast_context, ident^)
-
-					if !ok {
-						return
-					}
-
-					found = true
-
-					break
-				} else {
-					return
+				symbol = Symbol {
+					range = common.get_token_range(variant, ast_context.file.src),
 				}
+				found = true
+				break
 			}
 		}
 		if !found {
@@ -178,12 +190,9 @@ prepare_rename :: proc(
 	   position_context.comp_lit != nil &&
 	   !is_expr_basic_lit(position_context.field_value.field) &&
 	   position_in_node(position_context.field_value.field, position_context.position) {
-		symbol, ok = resolve_location_comp_lit_field(ast_context, position_context)
-
-		if !ok {
-			return
+		symbol = Symbol {
+			range = common.get_token_range(position_context.field_value.field, ast_context.file.src)
 		}
-
 	} else if position_context.selector_expr != nil {
 		if position_in_node(position_context.selector, position_context.position) &&
 		   position_context.identifier != nil {
@@ -194,33 +203,26 @@ prepare_rename :: proc(
 			if !ok {
 				return
 			}
-
 		} else {
 			symbol, ok = resolve_location_selector(ast_context, position_context.selector_expr)
-			symbol.flags -= {.Local}
 			if selector, ok := position_context.selector_expr.derived.(^ast.Selector_Expr); ok {
 				symbol.range = common.get_token_range(selector.field.expr_base, ast_context.file.src)
 			}
 
 		}
 	} else if position_context.implicit {
-		symbol, ok = resolve_location_implicit_selector(
-			ast_context,
-			position_context,
-			position_context.implicit_selector_expr,
-		)
-
-		if !ok {
-			return
+		range := common.get_token_range(position_context.implicit_selector_expr, ast_context.file.src)
+		// Skip the `.`
+		range.start.character += 1
+		symbol = Symbol{
+			range = range,
 		}
+
 	} else if position_context.identifier != nil {
 		ident := position_context.identifier.derived.(^ast.Ident)
 
-		symbol, ok = resolve_location_identifier(ast_context, ident^)
-		symbol.range = common.get_token_range(position_context.identifier^, string(document.text))
-
-		if !ok {
-			return
+		symbol = Symbol {
+			range = common.get_token_range(position_context.identifier^, ast_context.file.src)
 		}
 	} else {
 		return

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -356,6 +356,25 @@ expect_reference_locations :: proc(t: ^testing.T, src: ^Source, expect_locations
 	}
 }
 
+expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: common.Range) {
+	setup(src)
+	defer teardown(src)
+
+	range, ok := server.get_prepare_rename(src.document, src.position)
+	if !ok {
+		log.error("Failed to find range")
+	}
+
+	if range != expect_range {
+		ok = false
+		log.errorf("Failed to match with range: %v", expect_range)
+	}
+
+	if !ok {
+		log.error("Received: %v\n", range)
+	}
+}
+
 expect_semantic_tokens :: proc(t: ^testing.T, src: ^Source, expected: []server.SemanticToken) {
 	setup(src)
 	defer teardown(src)

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -549,3 +549,32 @@ ast_reference_should_reference_variable_inside_body :: proc(t: ^testing.T) {
 
 	test.expect_reference_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_reference_struct_within_proc :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			foo1: int,
+		}
+
+		main :: proc() {
+			InnerFoo :: struct {
+				foo: Fo{*}o,
+			}
+			foo := Foo{}
+
+			ifoo := InnerFoo {foo = foo}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 2}, end = {line = 2, character = 5}}},
+		{range = {start = {line = 8, character = 9}, end = {line = 8, character = 12}}},
+		{range = {start = {line = 10, character = 10}, end = {line = 10, character = 13}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -578,3 +578,48 @@ ast_reference_struct_within_proc :: proc (t: ^testing.T) {
 
 	test.expect_reference_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_reference_enum_field_list :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: enum {
+			a = 1,
+		}
+
+		main :: proc() {
+			foo: Foo
+			foo = .a{*}
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 3, character = 3}, end = {line = 3, character = 4}}},
+		{range = {start = {line = 8, character = 10}, end = {line = 8, character = 11}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}
+
+@(test)
+ast_reference_enum_field_list_with_constant :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		one :: 1
+
+		Foo :: enum {
+			a = on{*}e,
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 2}, end = {line = 2, character = 5}}},
+		{range = {start = {line = 5, character = 7}, end = {line = 5, character = 10}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}

--- a/tests/rename_test.odin
+++ b/tests/rename_test.odin
@@ -1,0 +1,205 @@
+package tests
+
+import "core:fmt"
+import "core:testing"
+
+import "src:common"
+
+import test "src:testing"
+
+@(test)
+ast_prepare_rename_enum_field_list :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: enum {
+			a = 1,
+		}
+
+		main :: proc() {
+			foo: Foo
+			foo = .a{*}
+		}
+		`,
+	}
+	range := common.Range{start = {line = 8, character = 10}, end = {line = 8, character = 11}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_enum_field_list_with_constant :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		one :: 1
+
+		Foo :: enum {
+			a = on{*}e,
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 5, character = 7}, end = {line = 5, character = 10}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_struct_field :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			bar: int,
+		}
+
+		main :: proc() {
+			foo := Foo{
+				b{*}ar = 1,
+			}
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 8, character = 4}, end = {line = 8, character = 7}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_struct_field_selector :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			bar: int,
+		}
+
+		main :: proc() {
+			foo := Foo{}
+			foo.ba{*}r = 1
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 8, character = 7}, end = {line = 8, character = 10}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_struct :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			bar: int,
+		}
+
+		main :: proc() {
+			foo := Fo{*}o{}
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 7, character = 10}, end = {line = 7, character = 13}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_struct_field_type :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Bar :: struct {}
+
+		Foo :: struct {
+			bar: B{*}ar,
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 5, character = 8}, end = {line = 5, character = 11}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_struct_field_type_package :: proc (t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+		My_Struct :: struct {}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+
+		Foo :: struct {
+			bar: my_package.My_Stru{*}ct,
+		}
+		`,
+		packages = packages[:],
+	}
+
+	range := common.Range{start = {line = 4, character = 19}, end = {line = 4, character = 28}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_union_type :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Foo :: struct {
+			bar: int,
+		}
+		
+		Bar :: struct {}
+
+		Foo_Bar :: union {
+			Fo{*}o,
+			Bar,
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 9, character = 3}, end = {line = 9, character = 6}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_symbol_behind_for :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		
+		main :: proc() {
+			foos := [5]int{1,2,3,4,5}
+			for f{*}oo in foos {
+			}
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 4, character = 7}, end = {line = 4, character = 10}}
+	test.expect_prepare_rename_range(t, &source, range)
+}
+
+@(test)
+ast_prepare_rename_symbol_behind_for_with_label :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		
+		main :: proc() {
+			foos := [5]int{1,2,3,4,5}
+			my_for: for f{*}oo in foos {
+			}
+		}
+		`,
+	}
+
+	range := common.Range{start = {line = 4, character = 15}, end = {line = 4, character = 18}}
+	test.expect_prepare_rename_range(t, &source, range)
+}


### PR DESCRIPTION
Improves finding references of symbols across files and packages. I've been using it to rename random symbols across ols and so far it seems pretty good. I imagine there are probably some corner cases that are not covered, but for common things such as renaming types, enums, procs, struct fields etc it works pretty well.

I've also updated the prepare rename code so that it returns to location of the symbol in the current file so that it gets displayed correctly when you prompt a rename, as before it would return the location of the base declaration, but the prompt would should the text of that location in the current file, which would often just be gibberish.

It also should resolve https://github.com/DanielGavin/ols/issues/440 Edit: I see there's still some issues with this actually when renaming across files.