### PR TITLE
Add //ols:private directive to skip parsing private sections of docum…

### DIFF
--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -410,7 +410,8 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 		pkg.kind = .Runtime
 	}
 
-	doc_end := document.used_text if document.private_scope == -1 else document.private_scope
+	doc_end = document.used_text if document.private_scope == -1 else min(document.private_scope, document.used_text)
+
 	document.ast = ast.File {
 		fullpath = document.fullpath,
 		src      = string(document.text[:doc_end]),

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -410,7 +410,7 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 		pkg.kind = .Runtime
 	}
 
-	doc_end = document.used_text if document.private_scope == -1 else min(document.private_scope, document.used_text)
+	doc_end := document.used_text if document.private_scope == -1 else min(document.private_scope, document.used_text)
 
 	document.ast = ast.File {
 		fullpath = document.fullpath,


### PR DESCRIPTION
Odin’s import system is convenient since you don’t have to specify imports within a folder, but it results in LSP completion being cluttered with too many symbols, which make browsing difficult.

Using @(private) on each symbol isn’t ideal either, because these sections aren’t truly private API, I just want to exclude certain sections of files from LSP parsing.
