### PR TITLE
Feat/add lookup odin root for builtin

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -274,11 +274,19 @@ setup_index :: proc() {
 	indexer.index = make_memory_index(symbol_collection)
 
 	dir_exe := common.get_executable_path(context.temp_allocator)
-
 	builtin_path := path.join({dir_exe, "builtin"}, context.temp_allocator)
 
+	if os.exists(builtin_path) {
+		try_build_package(builtin_path)
+		return
+	}
+
+	root_path := os.get_env("ODIN_ROOT", context.temp_allocator)
+	root_builtin_path := path.join({root_path, "/base/builtin"}, context.temp_allocator)
+
 	if !os.exists(builtin_path) {
-		log.errorf("Failed to find the builtin folder at %v", builtin_path)
+		log.errorf("Failed to find the builtin folder at `%v` or `%v`", builtin_path, root_builtin_path)
+		return
 	}
 
 	try_build_package(builtin_path)

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2072,7 +2072,7 @@ format_to_label_details :: proc(list: ^CompletionList) {
 			proc_info_split := strings.split_n(proc_info, " proc", 2)
 			if len(proc_info_split) == 1 {
 				// No proc declaration (eg for a proc group)
-				proc_info = ""
+				proc_info = "(..)"
 			} else if len(proc_info_split) == 2 {
 				proc_info = proc_info_split[1]
 			}


### PR DESCRIPTION
Looks for the `builtin` folder when indexing within `ODIN_ROOT` before looking at the path relative to the executable. Just for the cases where the exe isn't kept at the root of the repo.

I've also added the (..) to match how other languages handle things like proc groups in vscode. It should completely resolve https://github.com/DanielGavin/ols/issues/548 now: 
<img width="877" alt="image" src="https://github.com/user-attachments/assets/e921c3ed-2bd4-4bbc-a832-8edde01b7fdf" />
 