### PR TITLE
Improve inlay hints

### DIFF
--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -139,7 +139,7 @@ get_inlay_hints :: proc(
 
 							hint := InlayHint {
 								kind     = .Parameter,
-								label    = fmt.tprintf("%s%v := %v", needs_leading_comma ? ", " : "", label, value),
+								label    = fmt.tprintf("%s%v = %v", needs_leading_comma ? ", " : "", label, value),
 								position = position,
 							}
 							append(&hints, hint)

--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -139,7 +139,7 @@ get_inlay_hints :: proc(
 
 							hint := InlayHint {
 								kind     = .Parameter,
-								label    = fmt.tprintf("%s %v := %v", needs_leading_comma ? "," : "", label, value),
+								label    = fmt.tprintf("%s%v := %v", needs_leading_comma ? ", " : "", label, value),
 								position = position,
 							}
 							append(&hints, hint)

--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -57,123 +57,122 @@ get_inlay_hints :: proc(
 
 
 	loop: for node_call in &data.calls {
-		symbol_arg_count := 0
-		is_selector_call := false
+
 		is_ellipsis := false
 		has_added_default := false
 
 		call := node_call.derived.(^ast.Call_Expr)
 
-		if selector, ok := call.expr.derived.(^ast.Selector_Expr); ok && selector.op.kind == .Arrow_Right {
-			is_selector_call = true
+		selector, is_selector_call := call.expr.derived.(^ast.Selector_Expr)
+		is_selector_call &&= selector.op.kind == .Arrow_Right
+
+		end_pos := common.token_pos_to_position(call.close, string(document.text))
+
+		symbol_and_node := symbols[cast(uintptr)call.expr] or_continue
+		symbol_call := symbol_and_node.symbol.value.(SymbolProcedureValue) or_continue
+		
+		positional_arg_idx := 0
+
+		expr_name :: proc (node: ^ast.Node) -> (name: string, ok: bool) {
+			#partial switch v in node.derived {
+			case ^ast.Ident:
+				return v.name, true
+			case ^ast.Poly_Type:
+				ident := v.type.derived.(^ast.Ident) or_return
+				return ident.name, true
+			case:
+				return
+			}
 		}
+		
+		for arg, arg_type_idx in symbol_call.arg_types {
+			if arg_type_idx == 0 && is_selector_call {
+				continue
+			}
 
-		if symbol_and_node, ok := symbols[cast(uintptr)call.expr]; ok {
-			if symbol_call, ok := symbol_and_node.symbol.value.(SymbolProcedureValue); ok {
-				for arg, i in symbol_call.arg_types {
-					if i == 0 && is_selector_call {
-						continue
+			for name, name_idx in arg.names {
+
+				arg_call_idx := arg_type_idx + name_idx
+				if is_selector_call do arg_call_idx -= 1
+
+				label := expr_name(name) or_continue loop
+
+				is_provided_named, is_provided_positional: bool
+				call_arg: ^ast.Expr
+
+				for a, a_i in call.args[positional_arg_idx:] {
+					call_arg_idx := a_i + positional_arg_idx
+					// provided as named
+					if field_value, ok := a.derived.(^ast.Field_Value); ok {
+						ident := field_value.field.derived.(^ast.Ident) or_break
+						if ident.name == label {
+							is_provided_named = true
+							call_arg = a
+						}
+						break
+					} // provided as positional
+					else if arg_call_idx == call_arg_idx {
+						is_provided_positional = true
+						positional_arg_idx += 1
+						call_arg = a
+						break
+					}
+				}
+
+				if is_ellipsis || (!is_provided_named && !is_provided_positional) {
+					// This parameter is not provided, so it should use default value
+					if arg.default_value == nil {
+						continue loop
 					}
 
-					for name in arg.names {
-						label := ""
-						is_current_ellipsis := false
+					if !config.enable_inlay_hints_default_params {
+						continue loop
+					}
 
-						if arg.type != nil {
-							if ellipsis, ok := arg.type.derived.(^ast.Ellipsis); ok {
-								is_current_ellipsis = true
-							}
-						}
+					value := node_to_string(arg.default_value)
 
-						#partial switch v in name.derived {
-						case ^ast.Ident:
-							label = v.name
-						case ^ast.Poly_Type:
-							if ident, ok := v.type.derived.(^ast.Ident); ok {
-								label = ident.name
-							} else {
-								continue loop
-							}
-						case:
-							continue loop
-						}
+					needs_leading_comma := arg_call_idx > 0
 
-						if is_ellipsis || symbol_arg_count >= len(call.args) {
-							if arg.default_value == nil {
-								continue loop
-							}
-
-							if !config.enable_inlay_hints_default_params {
-								continue loop
-							}
-
-							value := node_to_string(arg.default_value)
-
-							call_range := common.get_token_range(call, string(document.text))
-
-							position: common.Position
-							position = call_range.end
-							position.character -= 1
-
-							needs_leading_comma := i > 0
-
-							if !has_added_default && needs_leading_comma {
-								till_end := string(document.text[:call.close.offset])
-								#reverse for ch in till_end {
-									switch ch {
-									case ' ', '\t', '\n':
-										continue
-									case ',':
-										needs_leading_comma = false
-									}
-									break
-								}
-							}
-
-							hint := InlayHint {
-								kind     = .Parameter,
-								label    = fmt.tprintf("%s%v = %v", needs_leading_comma ? ", " : "", label, value),
-								position = position,
-							}
-							append(&hints, hint)
-
-							has_added_default = true
-						} else if config.enable_inlay_hints_params {
-
-							// if is already provided as a named argument
-							if _, ok := call.args[symbol_arg_count].derived.(^ast.Field_Value); ok {
-								symbol_arg_count += 1
+					if !has_added_default && needs_leading_comma {
+						till_end := string(document.text[:call.close.offset])
+						#reverse for ch in till_end {
+							switch ch {
+							case ' ', '\t', '\n':
 								continue
+							case ',':
+								needs_leading_comma = false
 							}
-
-							// if the arg name and param name are the same, don't add it.
-							same_name: bool
-							#partial switch v in call.args[symbol_arg_count].derived_expr {
-							case ^ast.Ident:
-								same_name = label == v.name
-							case ^ast.Poly_Type:
-								if ident, ok := v.type.derived.(^ast.Ident); ok {
-									same_name = label == ident.name
-								}
-							}
-
-							if !same_name {
-								range := common.get_token_range(call.args[symbol_arg_count], string(document.text))
-								hint := InlayHint {
-									kind     = .Parameter,
-									label    = fmt.tprintf("%v = ", label),
-									position = range.start,
-								}
-								append(&hints, hint)
-							}
+							break
 						}
-
-						if is_current_ellipsis {
-							is_ellipsis = true
-						}
-
-						symbol_arg_count += 1
 					}
+
+					hint := InlayHint {
+						kind     = .Parameter,
+						label    = fmt.tprintf("%s%v = %v", needs_leading_comma ? ", " : "", label, value),
+						position = end_pos,
+					}
+					append(&hints, hint)
+
+					has_added_default = true
+				} else if config.enable_inlay_hints_params && is_provided_positional && !is_provided_named {
+					// This parameter is provided via positional argument, show parameter hint
+
+					// if the arg name and param name are the same, don't add it.
+					call_arg_name, _ := expr_name(call_arg)
+					if call_arg_name != label {
+						range := common.get_token_range(call_arg, string(document.text))
+						hint := InlayHint {
+							kind     = .Parameter,
+							label    = fmt.tprintf("%v = ", label),
+							position = range.start,
+						}
+						append(&hints, hint)
+					}
+				}
+
+				if arg.type != nil {
+					_, is_current_ellipsis := arg.type.derived.(^ast.Ellipsis)
+					is_ellipsis ||= is_current_ellipsis
 				}
 			}
 		}

--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -64,13 +64,6 @@ get_inlay_hints :: proc(
 
 		call := node_call.derived.(^ast.Call_Expr)
 
-		// TODO: support this (inlay hints in calls that use named args, e.g. `foobar(foo=bar)`
-		for arg in call.args {
-			if _, ok := arg.derived.(^ast.Field_Value); ok {
-				continue loop
-			}
-		}
-
 		if selector, ok := call.expr.derived.(^ast.Selector_Expr); ok && selector.op.kind == .Arrow_Right {
 			is_selector_call = true
 		}
@@ -146,6 +139,12 @@ get_inlay_hints :: proc(
 
 							has_added_default = true
 						} else if config.enable_inlay_hints_params {
+
+							// if is already provided as a named argument
+							if _, ok := call.args[symbol_arg_count].derived.(^ast.Field_Value); ok {
+								symbol_arg_count += 1
+								continue
+							}
 
 							// if the arg name and param name are the same, don't add it.
 							same_name: bool

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -445,7 +445,7 @@ expect_inlay_hints :: proc(t: ^testing.T, src: ^Source, expected_hints: []server
 	for i in 0 ..< min(len(expected_hints), len(hints)) {
 		e, a := expected_hints[i], hints[i]
 		if e != a {
-			log.errorf("[%d]: Expected inlay hint %v, but received %v", i, e, a)
+			log.errorf("[%d]: Expected inlay hint\n%v, but received\n%v", i, e, a)
 		}
 	}
 }

--- a/tests/inlay_hints_test.odin
+++ b/tests/inlay_hints_test.odin
@@ -25,11 +25,39 @@ ast_inlay_hints_default_parameters :: proc(t: ^testing.T) {
 	test.expect_inlay_hints(t, &source, {{
 		position = {5, 15},
 		kind     = .Parameter,
-		label    = " a := false",
+		label    = "a := false",
 	}, {
 		position = {5, 15},
 		kind     = .Parameter,
 		label    = ", b := 42",
+	}})
+}
+
+@(test)
+ast_inlay_hints_default_parameters_after_required :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(a: int, b := false, c := 42) {}
+
+		main :: proc() {
+			my_function(1)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_default_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 16},
+		kind     = .Parameter,
+		label    = ", b := false",
+	}, {
+		position = {5, 16},
+		kind     = .Parameter,
+		label    = ", c := 42",
 	}})
 }
 

--- a/tests/inlay_hints_test.odin
+++ b/tests/inlay_hints_test.odin
@@ -91,6 +91,30 @@ ast_inlay_hints_default_params_after_named :: proc(t: ^testing.T) {
 }
 
 @(test)
+ast_inlay_hints_default_params_named_ooo :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(a: int, b := false, c := 42) {}
+
+		main :: proc() {
+			my_function(1, c=42)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_default_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 22},
+		kind     = .Parameter,
+		label    = ", b = false",
+	}})
+}
+
+@(test)
 ast_inlay_hints_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
@@ -148,7 +172,7 @@ ast_inlay_hints_mixed_params :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_inlay_hints_method_call :: proc(t: ^testing.T) {
+ast_inlay_hints_selector_call :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 

--- a/tests/inlay_hints_test.odin
+++ b/tests/inlay_hints_test.odin
@@ -25,11 +25,11 @@ ast_inlay_hints_default_parameters :: proc(t: ^testing.T) {
 	test.expect_inlay_hints(t, &source, {{
 		position = {5, 15},
 		kind     = .Parameter,
-		label    = "a := false",
+		label    = "a = false",
 	}, {
 		position = {5, 15},
 		kind     = .Parameter,
-		label    = ", b := 42",
+		label    = ", b = 42",
 	}})
 }
 
@@ -53,11 +53,11 @@ ast_inlay_hints_default_parameters_after_required :: proc(t: ^testing.T) {
 	test.expect_inlay_hints(t, &source, {{
 		position = {5, 16},
 		kind     = .Parameter,
-		label    = ", b := false",
+		label    = ", b = false",
 	}, {
 		position = {5, 16},
 		kind     = .Parameter,
-		label    = ", c := 42",
+		label    = ", c = 42",
 	}})
 }
 
@@ -114,7 +114,7 @@ ast_inlay_hints_mixed_parameters :: proc(t: ^testing.T) {
 	}, {
 		position = {5, 17},
 		kind     = .Parameter,
-		label    = ", optional := false",
+		label    = ", optional = false",
 	}})
 }
 

--- a/tests/inlay_hints_test.odin
+++ b/tests/inlay_hints_test.odin
@@ -6,7 +6,7 @@ import "core:testing"
 import test "src:testing"
 
 @(test)
-ast_inlay_hints_default_parameters :: proc(t: ^testing.T) {
+ast_inlay_hints_default_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 
@@ -34,7 +34,7 @@ ast_inlay_hints_default_parameters :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_inlay_hints_default_parameters_after_required :: proc(t: ^testing.T) {
+ast_inlay_hints_default_params_after_required :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 
@@ -62,7 +62,36 @@ ast_inlay_hints_default_parameters_after_required :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_inlay_hints_parameters :: proc(t: ^testing.T) {
+ast_inlay_hints_default_params_after_named :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(a: int, b := false, c := 42) {}
+
+		main :: proc() {
+			my_function(a=1)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_params = true,
+			enable_inlay_hints_default_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 18},
+		kind     = .Parameter,
+		label    = ", b = false",
+	}, {
+		position = {5, 18},
+		kind     = .Parameter,
+		label    = ", c = 42",
+	}})
+}
+
+@(test)
+ast_inlay_hints_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 
@@ -90,7 +119,7 @@ ast_inlay_hints_parameters :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_inlay_hints_mixed_parameters :: proc(t: ^testing.T) {
+ast_inlay_hints_mixed_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 
@@ -173,7 +202,7 @@ ast_inlay_hints_no_hints_same_name :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_inlay_hints_variadic_parameters :: proc(t: ^testing.T) {
+ast_inlay_hints_variadic_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 

--- a/tests/inlay_hints_test.odin
+++ b/tests/inlay_hints_test.odin
@@ -1,0 +1,190 @@
+package tests
+
+import "core:fmt"
+import "core:testing"
+
+import test "src:testing"
+
+@(test)
+ast_inlay_hints_default_parameters :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(a := false, b := 42) {}
+
+		main :: proc() {
+			my_function()
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_default_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 15},
+		kind     = .Parameter,
+		label    = " a := false",
+	}, {
+		position = {5, 15},
+		kind     = .Parameter,
+		label    = ", b := 42",
+	}})
+}
+
+@(test)
+ast_inlay_hints_parameters :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(param1: int, param2: string) {}
+
+		main :: proc() {
+			my_function(123, "hello")
+		}
+		`,
+		packages = {},
+		config   = {
+			enable_inlay_hints_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 15},
+		kind     = .Parameter,
+		label    = "param1 = ",
+	}, {
+		position = {5, 20},
+		kind     = .Parameter,
+		label    = "param2 = ",
+	}})
+}
+
+@(test)
+ast_inlay_hints_mixed_parameters :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(required: int, optional := false) {}
+
+		main :: proc() {
+			my_function(42)
+		}
+		`,
+		packages = {},
+		config   = {
+			enable_inlay_hints_params = true,
+			enable_inlay_hints_default_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 15},
+		kind     = .Parameter,
+		label    = "required = ",
+	}, {
+		position = {5, 17},
+		kind     = .Parameter,
+		label    = ", optional := false",
+	}})
+}
+
+@(test)
+ast_inlay_hints_method_call :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Point :: struct {
+			x, y: f32,
+			move: proc(self: ^Point, dx, dy: f32)
+		}
+
+		main :: proc() {
+			p: Point
+			p->move(1.0, 2.0)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {9, 11},
+		kind     = .Parameter,
+		label    = "dx = ",
+	}, {
+		position = {9, 16},
+		kind     = .Parameter,
+		label    = "dy = ",
+	}})
+}
+
+@(test)
+ast_inlay_hints_no_hints_same_name :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(value: int) {}
+
+		main :: proc() {
+			value := 42
+			my_function(value)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_params = true,
+		},
+	}
+
+	// No hints should be shown when argument name matches parameter name
+	test.expect_inlay_hints(t, &source, {})
+}
+
+@(test)
+ast_inlay_hints_variadic_parameters :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		variadic_func :: proc(args: ..int) {}
+
+		main :: proc() {
+			variadic_func(1, 2, 3)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_params = true,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {{
+		position = {5, 17},
+		kind     = .Parameter,
+		label    = "args = ",
+	}})
+}
+
+@(test)
+ast_inlay_hints_disabled :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		my_function :: proc(param: int, optional := false) {}
+
+		main :: proc() {
+			my_function(42)
+		}
+		`,
+		packages = {},
+		config = {
+			enable_inlay_hints_params = false,
+			enable_inlay_hints_default_params = false,
+		},
+	}
+
+	test.expect_inlay_hints(t, &source, {})
+}


### PR DESCRIPTION
- fixes #476
- adds tests for inlay hints
- removes additional space before param names
- changes `:=` to `=` to match the syntax of passing a named param