### PR TITLE
Bit field improvements

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2836,7 +2836,7 @@ make_symbol_struct_from_ast :: proc(
 	}
 
 	b := symbol_struct_value_builder_make(symbol, ast_context.allocator)
-	write_struct_type(ast_context, &b, v^, ident, attributes, -1, inlined)
+	write_struct_type(ast_context, &b, v, ident, attributes, -1, inlined)
 	symbol = to_symbol(b)
 	return symbol
 }

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -158,15 +158,19 @@ collect_struct_fields :: proc(
 
 collect_bit_field_fields :: proc(
 	collection: ^SymbolCollection,
-	fields: []^ast.Bit_Field_Field,
+	bit_field_type: ^ast.Bit_Field_Type,
 	package_map: map[string]string,
 	file: ast.File,
 ) -> SymbolBitFieldValue {
-	names := make([dynamic]string, 0, len(fields), collection.allocator)
-	types := make([dynamic]^ast.Expr, 0, len(fields), collection.allocator)
-	ranges := make([dynamic]common.Range, 0, len(fields), collection.allocator)
+	construct_bit_field_field_docs(file, bit_field_type)
+	names := make([dynamic]string, 0, len(bit_field_type.fields), collection.allocator)
+	types := make([dynamic]^ast.Expr, 0, len(bit_field_type.fields), collection.allocator)
+	ranges := make([dynamic]common.Range, 0, len(bit_field_type.fields), collection.allocator)
+	docs := make([dynamic]^ast.Comment_Group, 0, collection.allocator)
+	comments := make([dynamic]^ast.Comment_Group, 0, collection.allocator)
+	bit_sizes := make([dynamic]^ast.Expr, 0, collection.allocator)
 
-	for field, i in fields {
+	for field, i in bit_field_type.fields {
 		if ident, ok := field.name.derived.(^ast.Ident); ok {
 			append(&names, get_index_unique_string(collection, ident.name))
 
@@ -175,13 +179,20 @@ collect_bit_field_fields :: proc(
 			append(&types, cloned)
 
 			append(&ranges, common.get_token_range(ident, file.src))
+			append(&docs, clone_comment_group(field.docs, collection.allocator, &collection.unique_strings))
+			append(&comments, clone_comment_group(field.comments, collection.allocator, &collection.unique_strings))
+			append(&bit_sizes, clone_type(field.bit_size, collection.allocator, &collection.unique_strings))
 		}
 	}
 
 	value := SymbolBitFieldValue {
-		names  = names[:],
-		types  = types[:],
-		ranges = ranges[:],
+		backing_type = clone_type(bit_field_type.backing_type, collection.allocator, &collection.unique_strings),
+		names        = names[:],
+		types        = types[:],
+		ranges       = ranges[:],
+		docs         = docs[:],
+		comments     = comments[:],
+		bit_sizes    = bit_sizes[:],
 	}
 
 	return value
@@ -547,7 +558,7 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 		case ^ast.Bit_Field_Type:
 			token = v^
 			token_type = .Struct
-			symbol.value = collect_bit_field_fields(collection, v.fields, package_map, file)
+			symbol.value = collect_bit_field_fields(collection, v, package_map, file)
 			symbol.signature = "bit_field"
 		case ^ast.Map_Type:
 			token = v^

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -2,6 +2,7 @@ package server
 
 import "core:fmt"
 import "core:log"
+import "core:odin/ast"
 import path "core:path/slashpath"
 import "core:strings"
 
@@ -9,8 +10,7 @@ import "core:strings"
 get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 	is_variable := symbol.type == .Variable
 
-	pointer_prefix := repeat("^", symbol.pointers, context.temp_allocator)
-
+	pointer_prefix := repeat("^", symbol.pointers, ast_context.allocator)
 
 	#partial switch v in symbol.value {
 	case SymbolEnumValue:
@@ -18,6 +18,13 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 		if is_variable {
 			append_variable_full_name(&sb, ast_context, symbol, pointer_prefix)
 			strings.write_string(&sb, " :: ")
+		}
+		if len(v.names) == 0 {
+			strings.write_string(&sb, "enum {}")
+			if symbol.comment != "" {
+				fmt.sbprintf(&sb, " %s", symbol.comment)
+			}
+			return strings.to_string(sb)
 		}
 
 		longestNameLen := 0
@@ -71,6 +78,10 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 			append_variable_full_name(&sb, ast_context, symbol, pointer_prefix)
 			strings.write_string(&sb, " :: ")
 		}
+		if len(v.types) == 0 {
+			strings.write_string(&sb, "union {}")
+			return strings.to_string(sb)
+		}
 		strings.write_string(&sb, "union {\n")
 		for i in 0 ..< len(v.types) {
 			strings.write_string(&sb, "\t")
@@ -80,7 +91,7 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 		strings.write_string(&sb, "}")
 		return strings.to_string(sb)
 	case SymbolAggregateValue:
-		sb := strings.builder_make(context.temp_allocator)
+		sb := strings.builder_make(ast_context.allocator)
 		strings.write_string(&sb, "proc {\n")
 		for symbol in v.symbols {
 			if value, ok := symbol.value.(SymbolProcedureValue); ok {
@@ -88,6 +99,53 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 				write_procedure_symbol_signature(&sb, value)
 				strings.write_string(&sb, ",\n")
 			}
+		}
+		strings.write_string(&sb, "}")
+		return strings.to_string(sb)
+	case SymbolBitFieldValue:
+		sb := strings.builder_make(ast_context.allocator)
+		if is_variable {
+			append_variable_full_name(&sb, ast_context, symbol, pointer_prefix)
+			strings.write_string(&sb, " :: ")
+		} else if symbol.type_name != "" {
+			if symbol.type_pkg == "" {
+				fmt.sbprintf(&sb, "%s%s :: ", pointer_prefix, symbol.type_name)
+			} else {
+				pkg_name := get_pkg_name(ast_context, symbol.type_pkg)
+				fmt.sbprintf(&sb, "%s%s.%s :: ", pointer_prefix, pkg_name, symbol.type_name)
+			}
+		}
+		strings.write_string(&sb, "bit_field ")
+		build_string_node(v.backing_type, &sb, false)
+		if len(v.names) == 0 {
+			strings.write_string(&sb, " {}")
+			return strings.to_string(sb)
+		}
+		strings.write_string(&sb, " {\n")
+		longest_name_len := 0
+		for name in v.names {
+			if len(name) > longest_name_len {
+				longest_name_len = len(name)
+			}
+		}
+		longest_type_len := 0
+		type_names := make([dynamic]string, 0, len(v.types), ast_context.allocator)
+		for t in v.types {
+			type_name := node_to_string(t)
+			append(&type_names, type_name)
+			if len(type_name) > longest_type_len {
+				longest_type_len = len(type_name)
+			}
+		}
+
+		for name, i in v.names {
+		    append_docs(&sb, v.docs, i)
+			fmt.sbprintf(&sb, "\t%s:%*s", v.names[i], longest_name_len - len(name) + 1, "")
+			fmt.sbprintf(&sb, "%s%*s| ", type_names[i], longest_type_len - len(type_names[i]) + 1, "")
+			build_string_node(v.bit_sizes[i], &sb, false)
+			strings.write_string(&sb, ",")
+			append_comments(&sb, v.comments, i)
+			strings.write_string(&sb, "\n")
 		}
 		strings.write_string(&sb, "}")
 		return strings.to_string(sb)
@@ -99,7 +157,7 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 get_short_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 	is_variable := symbol.type == .Variable
 
-	pointer_prefix := repeat("^", symbol.pointers, context.temp_allocator)
+	pointer_prefix := repeat("^", symbol.pointers, ast_context.allocator)
 	#partial switch v in symbol.value {
 	case SymbolBasicValue:
 		sb := strings.builder_make(ast_context.allocator)
@@ -139,7 +197,7 @@ get_short_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string 
 			allocator = ast_context.allocator,
 		)
 	case SymbolProcedureValue:
-		sb := strings.builder_make(context.temp_allocator)
+		sb := strings.builder_make(ast_context.allocator)
 		if symbol.type_pkg != "" && symbol.type_name != "" {
 			pkg_name := get_pkg_name(ast_context, symbol.type_pkg)
 			fmt.sbprintf(&sb, "%s%s.%s :: ", pointer_prefix, pkg_name, symbol.type_name)
@@ -227,8 +285,8 @@ get_short_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string 
 	return ""
 }
 
-get_enum_field_signature :: proc(value: SymbolEnumValue, index: int) -> string {
-	sb := strings.builder_make(context.temp_allocator)
+get_enum_field_signature :: proc(value: SymbolEnumValue, index: int, allocator := context.temp_allocator) -> string {
+	sb := strings.builder_make(allocator)
 	fmt.sbprintf(&sb, ".%s", value.names[index])
 	if index < len(value.values) && value.values[index] != nil {
 		strings.write_string(&sb, " = ")
@@ -342,12 +400,7 @@ write_struct_hover :: proc(ast_context: ^AstContext, sb: ^strings.Builder, v: Sy
 				using_index = index
 			}
 		}
-		if i < len(v.docs) && v.docs[i] != nil {
-			for c in v.docs[i].list {
-				fmt.sbprintf(sb, "\t%s\n", c.text)
-			}
-		}
-
+		append_docs(sb, v.docs, i)
 		strings.write_string(sb, "\t")
 
 		name_len := len(v.names[i])
@@ -355,18 +408,11 @@ write_struct_hover :: proc(ast_context: ^AstContext, sb: ^strings.Builder, v: Sy
 			strings.write_string(sb, using_prefix)
 			name_len += len(using_prefix)
 		}
-		strings.write_string(sb, v.names[i])
-		fmt.sbprintf(sb, ":%*s", longestNameLen - name_len + 1, "")
+		fmt.sbprintf(sb, "%s:%*s", v.names[i], longestNameLen - name_len + 1, "")
 		build_string_node(v.types[i], sb, false)
 		strings.write_string(sb, ",")
-
-		if i < len(v.comments) && v.comments[i] != nil {
-			for c in v.comments[i].list {
-				fmt.sbprintf(sb, " %s\n", c.text)
-			}
-		} else {
-			strings.write_string(sb, "\n")
-		}
+		append_comments(sb, v.comments, i)
+		strings.write_string(sb, "\n")
 	}
 	strings.write_string(sb, "}")
 }
@@ -384,6 +430,22 @@ append_variable_full_name :: proc(
 	}
 	fmt.sbprintf(sb, "%s%s.%s", pointer_prefix, pkg_name, symbol.name)
 	return
+}
+
+append_docs :: proc(sb: ^strings.Builder, docs: []^ast.Comment_Group, index: int) {
+	if index < len(docs) && docs[index] != nil {
+		for c in docs[index].list {
+			fmt.sbprintf(sb, "\t%s\n", c.text)
+		}
+	}
+}
+
+append_comments :: proc(sb: ^strings.Builder, comments: []^ast.Comment_Group, index: int) {
+	if index < len(comments) && comments[index] != nil {
+		for c in comments[index].list {
+			fmt.sbprintf(sb, " %s", c.text)
+		}
+	}
 }
 
 concatenate_symbol_information :: proc {

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -39,9 +39,13 @@ SymbolStructValue :: struct {
 }
 
 SymbolBitFieldValue :: struct {
-	names:  []string,
-	ranges: []common.Range,
-	types:  []^ast.Expr,
+	backing_type: ^ast.Expr,
+	names:        []string,
+	ranges:       []common.Range,
+	types:        []^ast.Expr,
+	docs:         []^ast.Comment_Group,
+	comments:     []^ast.Comment_Group,
+	bit_sizes:    []^ast.Expr,
 }
 
 SymbolPackageValue :: struct {

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -36,6 +36,10 @@ SymbolStructValue :: struct {
 	args:              []^ast.Expr, //The arguments in the call expression for poly
 	docs:              []^ast.Comment_Group,
 	comments:          []^ast.Comment_Group,
+
+	// Extra fields for embedded bit fields via usings
+	backing_types:        map[int]^ast.Expr, // the base type for the bit field
+	bit_sizes:         map[int]^ast.Expr, // the bit size of the bit field field
 }
 
 SymbolBitFieldValue :: struct {
@@ -216,6 +220,8 @@ SymbolStructValueBuilder :: struct {
 	unexpanded_usings: [dynamic]int,
 	poly:              ^ast.Field_List,
 	poly_names:        [dynamic]string,
+	backing_types:        map[int]^ast.Expr,
+	bit_sizes:         map[int]^ast.Expr,
 }
 
 symbol_struct_value_builder_make_none :: proc(allocator := context.allocator) -> SymbolStructValueBuilder {
@@ -230,6 +236,8 @@ symbol_struct_value_builder_make_none :: proc(allocator := context.allocator) ->
 		from_usings = make([dynamic]int, allocator),
 		unexpanded_usings = make([dynamic]int, allocator),
 		poly_names = make([dynamic]string, allocator),
+		backing_types = make(map[int]^ast.Expr, allocator),
+		bit_sizes = make(map[int]^ast.Expr, allocator),
 	}
 }
 
@@ -249,6 +257,8 @@ symbol_struct_value_builder_make_symbol :: proc(
 		from_usings = make([dynamic]int, allocator),
 		unexpanded_usings = make([dynamic]int, allocator),
 		poly_names = make([dynamic]string, allocator),
+		backing_types = make(map[int]^ast.Expr, allocator),
+		bit_sizes = make(map[int]^ast.Expr, allocator),
 	}
 }
 
@@ -269,6 +279,8 @@ symbol_struct_value_builder_make_symbol_symbol_struct_value :: proc(
 		from_usings = slice.to_dynamic(v.from_usings, allocator),
 		unexpanded_usings = slice.to_dynamic(v.unexpanded_usings, allocator),
 		poly_names = slice.to_dynamic(v.poly_names, allocator),
+		backing_types = v.backing_types,
+		bit_sizes = v.bit_sizes,
 	}
 }
 
@@ -297,21 +309,22 @@ to_symbol_struct_value :: proc(b: SymbolStructValueBuilder) -> SymbolStructValue
 		unexpanded_usings = b.unexpanded_usings[:],
 		poly = b.poly,
 		poly_names = b.poly_names[:],
+		backing_types = b.backing_types,
+		bit_sizes = b.bit_sizes,
 	}
 }
 
 write_struct_type :: proc(
 	ast_context: ^AstContext,
 	b: ^SymbolStructValueBuilder,
-	v: ast.Struct_Type,
+	v: ^ast.Struct_Type,
 	ident: ast.Ident,
 	attributes: []^ast.Attribute,
 	base_using_index: int,
 	inlined := false,
 ) {
 	b.poly = v.poly_params
-	v := v
-	construct_struct_field_docs(ast_context.file, &v)
+	construct_struct_field_docs(ast_context.file, v)
 	for field, i in v.fields.list {
 		for n in field.names {
 			if identifier, ok := n.derived.(^ast.Ident); ok && field.type != nil {
@@ -385,10 +398,47 @@ write_symbol_struct_value :: proc(
 	for u in v.unexpanded_usings {
 		append(&b.unexpanded_usings, u+base_index)
 	}
+	for k, value in v.backing_types {
+		b.backing_types[k+base_index] = value
+	}
+	for k, value in v.bit_sizes {
+		b.bit_sizes[k+base_index] = value
+	}
 	for k in v.usings {
 		b.usings[k+base_index] = struct{}{}
 	}
 	expand_usings(ast_context, b)
+}
+
+write_symbol_bitfield_value :: proc(
+	ast_context: ^AstContext,
+	b: ^SymbolStructValueBuilder,
+	v: SymbolBitFieldValue,
+	base_using_index: int,
+) {
+	base_index := len(b.names)
+	for name, i in v.names {
+		append(&b.names, name)
+		append(&b.from_usings, base_using_index)
+	}
+	for type in v.types {
+		append(&b.types, type)
+	}
+	for range in v.ranges {
+		append(&b.ranges, range)
+	}
+	for doc in v.docs {
+		append(&b.docs, doc)
+	}
+	for comment in v.comments {
+		append(&b.comments, comment)
+	}
+	b.backing_types[base_using_index] = v.backing_type
+	for bit_size, i in v.bit_sizes {
+		b.bit_sizes[i+base_index] = bit_size
+	}
+	expand_usings(ast_context, b)
+
 }
 
 expand_usings :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuilder) {
@@ -409,23 +459,27 @@ expand_usings :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuilder) {
 		
 		if ident, ok := field_expr.derived.(^ast.Ident); ok {
 			if v, ok := struct_type_from_identifier(ast_context, ident^); ok {
-				write_struct_type(ast_context, b, v^, ident^, {}, u, true)
+				write_struct_type(ast_context, b, v, ident^, {}, u, true)
 			} else {
 				clear(&ast_context.recursion_map)
 				if symbol, ok := resolve_type_identifier(ast_context, ident^); ok {
 					if v, ok := symbol.value.(SymbolStructValue); ok {
 						write_symbol_struct_value(ast_context, b, v, u)
+					} else if v, ok := symbol.value.(SymbolBitFieldValue); ok {
+						write_symbol_bitfield_value(ast_context, b, v, u)
 					}
 				}
 			}
 		} else if selector, ok := field_expr.derived.(^ast.Selector_Expr); ok {
-			if s, ok := resolve_selector_expression(ast_context, selector); ok {
-				if v, ok := s.value.(SymbolStructValue); ok {
+			if symbol, ok := resolve_selector_expression(ast_context, selector); ok {
+				if v, ok := symbol.value.(SymbolStructValue); ok {
 					write_symbol_struct_value(ast_context, b, v, u)
+				} else if v, ok := symbol.value.(SymbolBitFieldValue); ok {
+					write_symbol_bitfield_value(ast_context, b, v, u)
 				}
 			}
 		} else if v, ok := field_expr.derived.(^ast.Struct_Type); ok {
-			write_struct_type(ast_context, b, v^, ast_context.field_name, {}, u)
+			write_struct_type(ast_context, b, v, ast_context.field_name, {}, u)
 		}
 		delete_key(&ast_context.recursion_map, b.types[u])
 	}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2097,6 +2097,68 @@ ast_hover_struct_with_bit_field_using_across_packages :: proc(t: ^testing.T) {
 	)
 }
 
+@(test)
+ast_hover_bit_field_field :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: bit_field u8 {
+			foo_a: uint | 2,
+			f{*}oo_aa: uint | 6, // last 6 bits
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"Foo.foo_aa: uint | 6 // last 6 bits",
+	)
+}
+
+@(test)
+ast_hover_bit_field_variable_with_docs :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: bit_field u8 {
+			// doc
+			foo_a: uint | 2, // foo a
+			foo_aa: uint | 4,
+		}
+
+		main :: proc() {
+			foo := Foo{}
+			foo.f{*}oo_a = 1
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"Foo.foo_a: uint | 2 // foo a\n doc",
+	)
+}
+
+@(test)
+ast_hover_bit_field_on_struct_field :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: bit_field u8 {
+			// doc
+			foo_a: uint | 2, // foo a
+			foo_aa: uint | 4,
+		}
+
+		Bar :: struct {
+			fo{*}o: Foo,
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"Bar.foo: test.Foo",
+	)
+}
+
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -1992,6 +1992,49 @@ ast_hover_enum_defintion_with_base_type :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.Foo: enum u8 {\n\tA   = 1,\n\tBar = 2,\n\tC   = 3,\n}")
 }
+
+@(test)
+ast_hover_bit_field :: proc(t: ^testing.T) {
+	source :=test.Source {
+		main = `package test
+		F{*}oo :: bit_field u8 {
+			foo_a: uint | 2,
+			foo_aa: uint | 4,
+		}
+		`
+	}
+	test.expect_hover(t, &source, "test.Foo: bit_field u8 {\n\tfoo_a:  uint | 2,\n\tfoo_aa: uint | 4,\n}")
+}
+
+@(test)
+ast_hover_bit_field_array_backed :: proc(t: ^testing.T) {
+	source :=test.Source {
+		main = `package test
+		F{*}oo :: bit_field [4]u8 {
+			foo_a: uint | 1,
+			foo_aa: uint | 3,
+		}
+		`
+	}
+	test.expect_hover(t, &source, "test.Foo: bit_field [4]u8 {\n\tfoo_a:  uint | 1,\n\tfoo_aa: uint | 3,\n}")
+}
+
+@(test)
+ast_hover_bit_field_with_docs :: proc(t: ^testing.T) {
+	source :=test.Source {
+		main = `package test
+		F{*}oo :: bit_field u8 {
+		    // documentation
+			foo_a: uintptr | 2,
+			foo_bbbb: uint | 4, // comment for b
+			// doc
+			foo_c: uint | 2, //comment
+		}
+		`
+	}
+	test.expect_hover(t, &source, "test.Foo: bit_field u8 {\n\t// documentation\n\tfoo_a:    uintptr | 2,\n\tfoo_bbbb: uint    | 4, // comment for b\n\t// doc\n\tfoo_c:    uint    | 2, //comment\n}")
+}
+
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -1184,15 +1184,12 @@ ast_hover_distinguish_symbols_in_packages_struct :: proc(t: ^testing.T) {
 
 	append(
 		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+		test.Package{pkg = "my_package", source = `package my_package
 
 			Foo :: struct {
 				foo: string,
 			}
-		`,
-		},
+		`},
 	)
 	source := test.Source {
 		main     = `package test
@@ -1218,15 +1215,12 @@ ast_hover_distinguish_symbols_in_packages_local_struct :: proc(t: ^testing.T) {
 
 	append(
 		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+		test.Package{pkg = "my_package", source = `package my_package
 
 			Foo :: struct {
 				foo: string,
 			}
-		`,
-		},
+		`},
 	)
 	source := test.Source {
 		main     = `package test
@@ -1471,7 +1465,7 @@ ast_hover_struct_documentation_using_package :: proc(t: ^testing.T) {
 	test.expect_hover(
 		t,
 		&source,
-		"test.Foo: struct {\n\tusing outer:     my_package.Outer,\n\n\t// from `using outer: my_package.Outer`\n\t// Inner doc\n\tusing inner:     Inner,\n\n\t// from `using inner: Inner`\n\tusing ii:  InnerInner, // InnerInner comment\n\n\t// from `using ii: InnerInner`\n\tfield: int,\n}",
+		"test.Foo: struct {\n\tusing outer: my_package.Outer,\n\n\t// from `using outer: my_package.Outer`\n\t// Inner doc\n\tusing inner: Inner,\n\n\t// from `using inner: Inner`\n\tusing ii:    InnerInner, // InnerInner comment\n\n\t// from `using ii: InnerInner`\n\tfield:       int,\n}",
 	)
 }
 
@@ -1752,18 +1746,15 @@ ast_hover_poly_proc_mixed_packages :: proc(t: ^testing.T) {
 		}
 		`,
 		},
-		test.Package {
-			pkg = "bar_package",
-			source = `package bar_package
+		test.Package{pkg = "bar_package", source = `package bar_package
 			Bar :: struct {
 				bar: int,
 			}
-		`,
-		},
+		`},
 	)
 
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 		import "foo_package"
 		import "bar_package"
@@ -1797,7 +1788,7 @@ ast_hover_poly_struct_proc_field :: proc(t: ^testing.T) {
 	)
 
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 		import "my_package"
 
@@ -1838,25 +1829,23 @@ ast_hover_poly_struct_poly_proc_fields :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "test.Foo: struct($S: typeid, $T: typeid) {\n\tmy_proc1: proc(s: S) -> ^S,\n\tmy_proc2: proc(t: ^T) -> T,\n\tmy_proc3: proc(s: ^S,t: T) -> T,\n\tmy_proc4: proc() -> T,\n\tmy_proc5: proc(t: T),\n\tfoo1:     T,\n\tfoo2:     ^S,\n}")
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: struct($S: typeid, $T: typeid) {\n\tmy_proc1: proc(s: S) -> ^S,\n\tmy_proc2: proc(t: ^T) -> T,\n\tmy_proc3: proc(s: ^S,t: T) -> T,\n\tmy_proc4: proc() -> T,\n\tmy_proc5: proc(t: T),\n\tfoo1:     T,\n\tfoo2:     ^S,\n}",
+	)
 }
 
 @(test)
 ast_hover_poly_struct_poly_proc_fields_resolved :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+	append(&packages, test.Package{pkg = "my_package", source = `package my_package
 			Bazz :: struct{}
-		`,
-		},
-	)
+		`})
 
 	source := test.Source {
-		main = `package test
+		main     = `package test
 		import "my_package"
 
 		Foo :: struct($S: typeid, $T: typeid) {
@@ -1877,12 +1866,16 @@ ast_hover_poly_struct_poly_proc_fields_resolved :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "test.Foo: struct(Bar, my_package.Bazz) {\n\tmy_proc1: proc(s: Bar) -> ^Bar,\n\tmy_proc2: proc(t: my_package.Bazz) -> my_package.Bazz,\n\tmy_proc3: proc(s: ^my_package.Bazz,t: my_package.Bazz) -> my_package.Bazz,\n\tfoo1:     my_package.Bazz,\n\tfoo2:     ^Bar,\n}")
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: struct(Bar, my_package.Bazz) {\n\tmy_proc1: proc(s: Bar) -> ^Bar,\n\tmy_proc2: proc(t: my_package.Bazz) -> my_package.Bazz,\n\tmy_proc3: proc(s: ^my_package.Bazz,t: my_package.Bazz) -> my_package.Bazz,\n\tfoo1:     my_package.Bazz,\n\tfoo2:     ^Bar,\n}",
+	)
 }
 
 @(test)
 ast_hover_bitset_enum_for_loop :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A,
@@ -1895,14 +1888,14 @@ ast_hover_bitset_enum_for_loop :: proc(t: ^testing.T) {
 
 			}
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.f: test.Foo :: enum {\n\tA,\n\tB,\n}")
 }
 
 @(test)
 ast_hover_enum_field_assignment :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A,
@@ -1912,7 +1905,7 @@ ast_hover_enum_field_assignment :: proc(t: ^testing.T) {
 		main :: proc() {
 			a := Foo.A{*}
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: .A")
 }
@@ -1920,7 +1913,7 @@ ast_hover_enum_field_assignment :: proc(t: ^testing.T) {
 
 @(test)
 ast_hover_enum_field_implicit_assignment :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A,
@@ -1931,40 +1924,40 @@ ast_hover_enum_field_implicit_assignment :: proc(t: ^testing.T) {
 			a: Foo
 			a = .A{*}
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: .A")
 }
 
 @(test)
 ast_hover_enum_field_definition :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A{*},
 			B,
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: .A")
 }
 
 @(test)
 ast_hover_enum_field_definition_with_type :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A{*} = 1,
 			B,
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: .A = 1")
 }
 
 @(test)
 ast_hover_enum_map_key :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		Foo :: enum {
 			A = 1,
@@ -1974,54 +1967,54 @@ ast_hover_enum_map_key :: proc(t: ^testing.T) {
 			m: map[Foo]int
 			m[.A{*}] = 2
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: .A = 1")
 }
 
 @(test)
 ast_hover_enum_defintion_with_base_type :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		F{*}oo :: enum u8 {
 			A   = 1,
 			Bar = 2,
 			C   = 3,
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: enum u8 {\n\tA   = 1,\n\tBar = 2,\n\tC   = 3,\n}")
 }
 
 @(test)
 ast_hover_bit_field :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		F{*}oo :: bit_field u8 {
 			foo_a: uint | 2,
 			foo_aa: uint | 4,
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: bit_field u8 {\n\tfoo_a:  uint | 2,\n\tfoo_aa: uint | 4,\n}")
 }
 
 @(test)
 ast_hover_bit_field_array_backed :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		F{*}oo :: bit_field [4]u8 {
 			foo_a: uint | 1,
 			foo_aa: uint | 3,
 		}
-		`
+		`,
 	}
 	test.expect_hover(t, &source, "test.Foo: bit_field [4]u8 {\n\tfoo_a:  uint | 1,\n\tfoo_aa: uint | 3,\n}")
 }
 
 @(test)
 ast_hover_bit_field_with_docs :: proc(t: ^testing.T) {
-	source :=test.Source {
+	source := test.Source {
 		main = `package test
 		F{*}oo :: bit_field u8 {
 		    // documentation
@@ -2030,9 +2023,78 @@ ast_hover_bit_field_with_docs :: proc(t: ^testing.T) {
 			// doc
 			foo_c: uint | 2, //comment
 		}
-		`
+		`,
 	}
-	test.expect_hover(t, &source, "test.Foo: bit_field u8 {\n\t// documentation\n\tfoo_a:    uintptr | 2,\n\tfoo_bbbb: uint    | 4, // comment for b\n\t// doc\n\tfoo_c:    uint    | 2, //comment\n}")
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: bit_field u8 {\n\t// documentation\n\tfoo_a:    uintptr | 2,\n\tfoo_bbbb: uint    | 4, // comment for b\n\t// doc\n\tfoo_c:    uint    | 2, //comment\n}",
+	)
+}
+
+@(test)
+ast_hover_struct_with_bit_field_using :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: bit_field u8 {
+			foo_a: uint | 2, // foo_a
+			// foo_aa
+			foo_aa: uint | 4,
+		}
+
+		Ba{*}r :: struct {
+			using foo: Foo,
+
+			bar: int,
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Bar: struct {\n\tusing foo: Foo,\n\tbar:       int,\n\n\t// from `using foo: Foo (bit_field u8)`\n\tfoo_a:     uint | 2, // foo_a\n\t// foo_aa\n\tfoo_aa:    uint | 4,\n}",
+	)
+}
+
+@(test)
+ast_hover_struct_with_bit_field_using_across_packages :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+			Foo :: bit_field u8 {
+				foo_a: uint | 1, // foo_a
+				// foo_aa
+				foo_aa: uint | 7,
+			}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+
+		Bazz :: struct {
+			bazz: string, // string for bazz
+		}
+
+		Ba{*}r :: struct {
+			using foo: my_package.Foo,
+			using bazz: Bazz,
+
+			bar: int,
+		}
+		`,
+		packages = packages[:],
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Bar: struct {\n\tusing foo:  my_package.Foo,\n\tusing bazz: Bazz,\n\tbar:        int,\n\n\t// from `using foo: my_package.Foo (bit_field u8)`\n\tfoo_a:      uint           | 1, // foo_a\n\t// foo_aa\n\tfoo_aa:     uint           | 7,\n\n\t// from `using bazz: Bazz`\n\tbazz:       string, // string for bazz\n}",
+	)
 }
 
 /*


### PR DESCRIPTION
Enriches bit fields so they have similar hover behaviour to structs. I've also added relevant bit field information to structs as they can have "embedded" bitfields in them via using. They will now be expanded properly with proper docs and completion.

Resolves https://github.com/DanielGavin/ols/issues/597