### PR TITLE
Resolve leak

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -232,11 +232,17 @@ index_file :: proc(uri: common.Uri, text: string) -> common.Error {
 		pkg      = pkg,
 	}
 
-	ok = parser.parse_file(&p, &file)
+	{
+		allocator := context.allocator
+		context.allocator = context.temp_allocator
+		defer context.allocator = allocator
 
-	if !ok {
-		if !strings.contains(fullpath, "builtin.odin") && !strings.contains(fullpath, "intrinsics.odin") {
-			log.errorf("error in parse file for indexing %v", fullpath)
+		ok = parser.parse_file(&p, &file)
+
+		if !ok {
+			if !strings.contains(fullpath, "builtin.odin") && !strings.contains(fullpath, "intrinsics.odin") {
+				log.errorf("error in parse file for indexing %v", fullpath)
+			}
 		}
 	}
 

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -289,7 +289,6 @@ consume_requests :: proc(config: ^common.Config, writer: ^Writer) -> bool {
 		request := temp_requests[request_index]
 		call(request.value, request.id, writer, config)
 		clear_index_cache()
-		json.destroy_value(request.value)
 		free_all(context.temp_allocator)
 	}
 


### PR DESCRIPTION
Someone on the discord mentioned that it looked like there was a leak in ols. After a little investigation I noticed that the memory usage would jump by a few mb every time I would save a file (~9-10mb for `analysis.odin`). I found it was coming from parsing the file when we index it with the parser. As a simple solution I've just set the default allocator for that part to the temp allocator as we clone all the relevant ast nodes when building the symbols.

I also removed the `json.destroy_value` as when I used the tracking allocator (just uncommenting it in main) it would instantly crash at that line with `/Users/bradlewis/repos/ols/src/server/requests.odin(292:3) Tracking allocator error: Bad free of pointer 105553149127240\n`