### PR TITLE
Support alternate odin folder name for the c.odin doc hack

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -346,7 +346,7 @@ collect_generic :: proc(
 	//In the c package code it uses a documentation package(builtin).
 	if selector, ok := expr.derived.(^ast.Selector_Expr); ok {
 		if ident, ok := selector.expr.derived.(^ast.Ident); ok {
-			if ident.name == "builtin" && strings.contains(uri, "Odin/core/c/c.odin") {
+			if ident.name == "builtin" && strings.contains(uri, "/core/c/c.odin") {
 				cloned := clone_type(selector.field, collection.allocator, &collection.unique_strings)
 				replace_package_alias(cloned, package_map, collection)
 				value := SymbolGenericValue {


### PR DESCRIPTION
I had odin installed in a specific folder name, so this hack failed

Fixes #730 