### PR TITLE
Resolve named procedure params

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -670,7 +670,19 @@ get_proc_call_argument_type :: proc(value: SymbolProcedureValue, parameter_index
 			index += 1
 		}
 	}
+	return nil, false
+}
 
+get_proc_arg_type_from_name :: proc(v: SymbolProcedureValue, name: string) -> (^ast.Field, bool) {
+	for arg in v.arg_types {
+		for arg_name in arg.names {
+			if ident, ok := arg_name.derived.(^ast.Ident); ok {
+				if name == ident.name {
+					return arg, true
+				}
+			}
+		}
+	}
 	return nil, false
 }
 

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2232,6 +2232,31 @@ resolve_location_proc_param_name :: proc(
 	return symbol, true
 }
 
+resolve_type_location_proc_param_name :: proc(
+	ast_context: ^AstContext,
+	position_context: ^DocumentPositionContext,
+) -> (
+	call_symbol: Symbol,
+	ok: bool,
+) {
+	ident := position_context.field_value.field.derived.(^ast.Ident) or_return
+    call := position_context.call.derived.(^ast.Call_Expr) or_return
+	call_symbol = resolve_type_expression(ast_context, call) or_return
+
+	if value, ok := call_symbol.value.(SymbolProcedureValue); ok {
+		if arg_type, ok := get_proc_arg_type_from_name(value, ident.name); ok {
+			if symbol, ok := resolve_type_expression(ast_context, arg_type.type); ok {
+				symbol.type_pkg = symbol.pkg
+				symbol.type_name = symbol.name
+				symbol.pkg = call_symbol.name
+				symbol.name = ident.name
+				return symbol, true
+			}
+		}
+	}
+	return call_symbol, false
+}
+
 resolve_location_comp_lit_field :: proc(
 	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2224,6 +2224,7 @@ resolve_location_proc_param_name :: proc(
     call := position_context.call.derived.(^ast.Call_Expr) or_return
 	symbol = resolve_type_expression(ast_context, call) or_return
 
+	reset_ast_context(ast_context)
 	if value, ok := symbol.value.(SymbolProcedureValue); ok {
 		if arg_name, ok := get_proc_arg_name_from_name(value, ident.name); ok {
 			symbol.range = common.get_token_range(arg_name, ast_context.file.src)
@@ -2243,15 +2244,14 @@ resolve_type_location_proc_param_name :: proc(
     call := position_context.call.derived.(^ast.Call_Expr) or_return
 	call_symbol = resolve_type_expression(ast_context, call) or_return
 
+	reset_ast_context(ast_context)
 	if value, ok := call_symbol.value.(SymbolProcedureValue); ok {
-		if arg_type, ok := get_proc_arg_type_from_name(value, ident.name); ok {
-			if symbol, ok := resolve_type_expression(ast_context, arg_type.type); ok {
-				symbol.type_pkg = symbol.pkg
-				symbol.type_name = symbol.name
-				symbol.pkg = call_symbol.name
-				symbol.name = ident.name
-				return symbol, true
-			}
+		if symbol, ok := resolve_type_expression(ast_context, position_context.field_value.value); ok {
+			symbol.type_pkg = symbol.pkg
+			symbol.type_name = symbol.name
+			symbol.pkg = call_symbol.name
+			symbol.name = ident.name
+			return symbol, true
 		}
 	}
 	return call_symbol, false
@@ -2269,11 +2269,15 @@ resolve_location_proc_param_name_type :: proc(
     call := position_context.call.derived.(^ast.Call_Expr) or_return
 	call_symbol = resolve_type_expression(ast_context, call) or_return
 
+	reset_ast_context(ast_context)
 	if value, ok := call_symbol.value.(SymbolProcedureValue); ok {
 		if arg_type, ok := get_proc_arg_type_from_name(value, ident.name); ok {
 			if symbol, ok := resolve_location_type_expression(ast_context, arg_type.type); ok {
 				return symbol, true
 			}
+		}
+		if symbol, ok := resolve_location_type_expression(ast_context, position_context.field_value.value); ok {
+			return symbol, true
 		}
 	}
 	return call_symbol, false

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -649,43 +649,6 @@ get_unnamed_arg_count :: proc(args: []^ast.Expr) -> int {
 	return total
 }
 
-get_procedure_arg_count :: proc(v: SymbolProcedureValue) -> int {
-	total := 0
-	for proc_arg in v.arg_types {
-		for name in proc_arg.names {
-			total += 1
-		}
-	}
-	return total
-}
-
-// Gets the call argument type at the specified index
-get_proc_call_argument_type :: proc(value: SymbolProcedureValue, parameter_index: int) -> (^ast.Field, bool) {
-	index := 0
-	for arg in value.arg_types {
-		for name in arg.names {
-			if index == parameter_index {
-				return arg, true
-			}
-			index += 1
-		}
-	}
-	return nil, false
-}
-
-get_proc_arg_type_from_name :: proc(v: SymbolProcedureValue, name: string) -> (^ast.Field, bool) {
-	for arg in v.arg_types {
-		for arg_name in arg.names {
-			if ident, ok := arg_name.derived.(^ast.Ident); ok {
-				if name == ident.name {
-					return arg, true
-				}
-			}
-		}
-	}
-	return nil, false
-}
-
 /*
 	Figure out which function the call expression is using out of the list from proc group
 */
@@ -724,7 +687,7 @@ resolve_function_overload :: proc(ast_context: ^AstContext, group: ast.Proc_Grou
 				named := false
 
 				if !resolve_all_possibilities {
-					arg_count := get_procedure_arg_count(procedure)
+					arg_count := get_proc_arg_count(procedure)
 					if call_expr != nil && arg_count < call_unnamed_arg_count {
 						break next_fn
 					}

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2213,6 +2213,25 @@ resolve_location_identifier :: proc(ast_context: ^AstContext, node: ast.Ident) -
 	return {}, false
 }
 
+resolve_location_proc_param_name :: proc(
+	ast_context: ^AstContext,
+	position_context: ^DocumentPositionContext,
+) -> (
+	symbol: Symbol,
+	ok: bool,
+) {
+	ident := position_context.field_value.field.derived.(^ast.Ident) or_return
+    call := position_context.call.derived.(^ast.Call_Expr) or_return
+	symbol = resolve_type_expression(ast_context, call) or_return
+
+	if value, ok := symbol.value.(SymbolProcedureValue); ok {
+		if arg_name, ok := get_proc_arg_name_from_name(value, ident.name); ok {
+			symbol.range = common.get_token_range(arg_name, ast_context.file.src)
+		}
+	}
+	return symbol, true
+}
+
 resolve_location_comp_lit_field :: proc(
 	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2257,6 +2257,28 @@ resolve_type_location_proc_param_name :: proc(
 	return call_symbol, false
 }
 
+// resolves the underlying location of type of the named param
+resolve_location_proc_param_name_type :: proc(
+	ast_context: ^AstContext,
+	position_context: ^DocumentPositionContext,
+) -> (
+	call_symbol: Symbol,
+	ok: bool,
+) {
+	ident := position_context.field_value.field.derived.(^ast.Ident) or_return
+    call := position_context.call.derived.(^ast.Call_Expr) or_return
+	call_symbol = resolve_type_expression(ast_context, call) or_return
+
+	if value, ok := call_symbol.value.(SymbolProcedureValue); ok {
+		if arg_type, ok := get_proc_arg_type_from_name(value, ident.name); ok {
+			if symbol, ok := resolve_location_type_expression(ast_context, arg_type.type); ok {
+				return symbol, true
+			}
+		}
+	}
+	return call_symbol, false
+}
+
 resolve_location_comp_lit_field :: proc(
 	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1171,7 +1171,7 @@ get_implicit_completion :: proc(
 				}
 
 				if proc_value, ok := symbol.value.(SymbolProcedureValue); ok {
-					arg_type, arg_type_ok := get_proc_call_argument_type(proc_value, parameter_index)
+					arg_type, arg_type_ok := get_proc_arg_type_from_index(proc_value, parameter_index)
 					if !arg_type_ok {
 						return
 					}

--- a/src/server/definition.odin
+++ b/src/server/definition.odin
@@ -106,14 +106,22 @@ get_definition_location :: proc(document: ^Document, position: common.Position) 
 			return {}, false
 		}
 	} else if position_context.field_value != nil &&
-	   position_context.comp_lit != nil &&
 	   !is_expr_basic_lit(position_context.field_value.field) &&
 	   position_in_node(position_context.field_value.field, position_context.position) {
-		if resolved, ok := resolve_location_comp_lit_field(&ast_context, &position_context); ok {
-			location.range = resolved.range
-			uri = resolved.uri
-		} else {
-			return {}, false
+		if position_context.comp_lit != nil {
+			if resolved, ok := resolve_location_comp_lit_field(&ast_context, &position_context); ok {
+				location.range = resolved.range
+				uri = resolved.uri
+			} else {
+				return {}, false
+			}
+		} else if position_context.call != nil {
+			if resolved, ok := resolve_location_proc_param_name(&ast_context, &position_context); ok {
+				location.range = resolved.range
+				uri = resolved.uri
+			} else {
+				return {}, false
+			}
 		}
 	} else if position_context.implicit_selector_expr != nil {
 		if resolved, ok := resolve_location_implicit_selector(

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -149,16 +149,16 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 		return strings.to_string(sb)
 	case SymbolStructValue:
 		sb := strings.builder_make(ast_context.allocator)
-		if is_variable {
-			append_variable_full_name(&sb, ast_context, symbol, pointer_prefix)
-			strings.write_string(&sb, " :: ")
-		} else if symbol.type_name != "" {
+		if symbol.type_name != "" {
 			if symbol.type_pkg == "" {
 				fmt.sbprintf(&sb, "%s%s :: ", pointer_prefix, symbol.type_name)
 			} else {
 				pkg_name := get_pkg_name(ast_context, symbol.type_pkg)
 				fmt.sbprintf(&sb, "%s%s.%s :: ", pointer_prefix, pkg_name, symbol.type_name)
 			}
+		} else if is_variable {
+			append_variable_full_name(&sb, ast_context, symbol, pointer_prefix)
+			strings.write_string(&sb, " :: ")
 		}
 		if len(v.names) == 0 {
 			strings.write_string(&sb, "struct {}")

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -229,6 +229,14 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 			}
 
 			resolve_node(n.value, data)
+		} else if data.flag != .None && data.position_context.call != nil {
+			if symbol, ok := resolve_location_proc_param_name(data.ast_context, data.position_context); ok {
+				data.symbols[cast(uintptr)node] = SymbolAndNode {
+					node   = n.field,
+					symbol = symbol,
+				}
+			}
+			resolve_node(n.value, data)
 		} else {
 			resolve_node(n.field, data)
 			resolve_node(n.value, data)

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -213,44 +213,27 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 				}
 			}
 		}
-
-		if position_context.call != nil {
-			// Check if we're resolving the name of a parameter being passed to a proc call
-			if call, ok := position_context.call.derived.(^ast.Call_Expr); ok {
-				if proc_symbol, ok := resolve_type_expression(&ast_context, call); ok {
-					if value, ok := proc_symbol.value.(SymbolProcedureValue); ok {
-						for arg in call.args {
-							if field_value, ok := arg.derived.(^ast.Field_Value); ok {
-								if position_in_node(field_value.field, position_context.position) {
-									if identifier, ok := field_value.field.derived.(^ast.Ident); ok {
-										if arg_type, arg_type_ok := get_proc_arg_type_from_name(value, identifier.name); ok {
-											if symbol, ok := resolve_type_expression(&ast_context, arg_type.type); ok {
-												symbol.range = common.get_token_range(field_value.field, ast_context.file.src)
-												symbol.type_name = symbol.name
-												symbol.type_pkg = symbol.pkg
-												symbol.pkg = proc_symbol.name
-												symbol.name = identifier.name
-												symbol.signature = get_signature(&ast_context, symbol)
-												hover.contents = write_hover_content(&ast_context, symbol)
-												return hover, true, true
-											}
-										}
-									}
-								}
-								break
-							}
-						}
-					}
-				}
-			}
-		}
 	}
 
-	if position_context.field_value != nil && position_context.comp_lit != nil {
-		if comp_symbol, ok := resolve_comp_literal(&ast_context, &position_context); ok {
-			if field, ok := position_context.field_value.field.derived.(^ast.Ident); ok {
-				if position_in_node(field, position_context.position) {
-					if v, ok := comp_symbol.value.(SymbolStructValue); ok {
+	if position_context.field_value != nil && position_in_node(position_context.field_value.field, position_context.position) {
+		if position_context.comp_lit != nil {
+			if comp_symbol, ok := resolve_comp_literal(&ast_context, &position_context); ok {
+				if field, ok := position_context.field_value.field.derived.(^ast.Ident); ok {
+					if position_in_node(field, position_context.position) {
+						if v, ok := comp_symbol.value.(SymbolStructValue); ok {
+							for name, i in v.names {
+								if name == field.name {
+									if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
+										symbol.name = name
+										symbol.pkg = comp_symbol.name
+										symbol.signature = node_to_string(v.types[i])
+										hover.contents = write_hover_content(&ast_context, symbol)
+										return hover, true, true
+									}
+								}
+							}
+						}
+					} else if v, ok := comp_symbol.value.(SymbolBitFieldValue); ok {
 						for name, i in v.names {
 							if name == field.name {
 								if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
@@ -263,19 +246,15 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 							}
 						}
 					}
-				} else if v, ok := comp_symbol.value.(SymbolBitFieldValue); ok {
-					for name, i in v.names {
-						if name == field.name {
-							if symbol, ok := resolve_type_expression(&ast_context, v.types[i]); ok {
-								symbol.name = name
-								symbol.pkg = comp_symbol.name
-								symbol.signature = node_to_string(v.types[i])
-								hover.contents = write_hover_content(&ast_context, symbol)
-								return hover, true, true
-							}
-						}
-					}
 				}
+			}
+		}
+
+		if position_context.call != nil {
+			if symbol, ok := resolve_type_location_proc_param_name(&ast_context, &position_context); ok {
+				symbol.signature = get_signature(&ast_context, symbol)
+				hover.contents = write_hover_content(&ast_context, symbol)
+				return hover, true, true
 			}
 		}
 	}

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -145,13 +145,18 @@ prepare_references :: proc(
 		}
 
 	} else if position_context.field_value != nil &&
-	   position_context.comp_lit != nil &&
 	   !is_expr_basic_lit(position_context.field_value.field) &&
 	   position_in_node(position_context.field_value.field, position_context.position) {
-		symbol, ok = resolve_location_comp_lit_field(ast_context, position_context)
-
-		if !ok {
-			return
+		if position_context.comp_lit != nil {
+			symbol, ok = resolve_location_comp_lit_field(ast_context, position_context)
+			if !ok {
+				return
+			}
+		} else if position_context.call != nil {
+			symbol, ok = resolve_location_proc_param_name(ast_context, position_context)
+			if !ok {
+				return
+			}
 		}
 
 		resolve_flag = .Field

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -562,6 +562,19 @@ get_proc_arg_type_from_name :: proc(v: SymbolProcedureValue, name: string) -> (^
 	return nil, false
 }
 
+get_proc_arg_name_from_name :: proc(v: SymbolProcedureValue, name: string) -> (^ast.Ident, bool) {
+	for arg in v.arg_types {
+		for arg_name in arg.names {
+			if ident, ok := arg_name.derived.(^ast.Ident); ok {
+				if name == ident.name {
+					return ident, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
 new_clone_symbol :: proc(data: Symbol, allocator := context.allocator) -> ^Symbol {
 	new_symbol := new(Symbol, allocator)
 	new_symbol^ = data

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -525,6 +525,43 @@ expand_objc :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuilder) {
 	}
 }
 
+get_proc_arg_count :: proc(v: SymbolProcedureValue) -> int {
+	total := 0
+	for proc_arg in v.arg_types {
+		for name in proc_arg.names {
+			total += 1
+		}
+	}
+	return total
+}
+
+// Gets the call argument type at the specified index
+get_proc_arg_type_from_index :: proc(value: SymbolProcedureValue, parameter_index: int) -> (^ast.Field, bool) {
+	index := 0
+	for arg in value.arg_types {
+		for name in arg.names {
+			if index == parameter_index {
+				return arg, true
+			}
+			index += 1
+		}
+	}
+	return nil, false
+}
+
+get_proc_arg_type_from_name :: proc(v: SymbolProcedureValue, name: string) -> (^ast.Field, bool) {
+	for arg in v.arg_types {
+		for arg_name in arg.names {
+			if ident, ok := arg_name.derived.(^ast.Ident); ok {
+				if name == ident.name {
+					return arg, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
 new_clone_symbol :: proc(data: Symbol, allocator := context.allocator) -> ^Symbol {
 	new_symbol := new(Symbol, allocator)
 	new_symbol^ = data

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -543,3 +543,24 @@ ast_goto_struct_field_from_proc :: proc (t: ^testing.T) {
 
 	test.expect_definition_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_goto_proc_named_param :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		foo :: proc(a: int) {}
+
+		main :: proc() {
+			a := "hellope"
+			foo(a{*} = 0)
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 14}, end = {line = 2, character = 15}}},
+	}
+
+	test.expect_definition_locations(t, &source, locations[:])
+}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2598,6 +2598,44 @@ ast_hover_named_parameter_same_as_variable :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "foo.a: int")
 }
+
+@(test)
+ast_hover_named_parameter_with_default_value :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		foo :: proc(b := "") {}
+
+		main :: proc() {
+			a := "hellope"
+			foo(b{*} = a)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "foo.b: string")
+}
+
+@(test)
+ast_hover_named_parameter_with_default_value_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Bar :: struct{
+			bar: int,
+		}
+
+		bar := Bar{}
+
+		foo :: proc(a := bar) {}
+
+		main :: proc() {
+			b := Bar{}
+			foo(a{*} = b)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "foo.a: test.Bar :: struct {\n\tbar: int,\n}")
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2177,7 +2177,7 @@ ast_hover_bitset_enum :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "test.Foo: .Aaa")
+	test.expect_hover(t, &source, "test.Foo: .Aaa")
 }
 
 @(test)
@@ -2203,7 +2203,7 @@ ast_hover_enumerated_array_key :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "test.Foo: .A")
+	test.expect_hover(t, &source, "test.Foo: .A")
 }
 
 @(test)
@@ -2229,7 +2229,7 @@ ast_hover_enumerated_array_value :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "test.Bar: struct {\n\tbar: int,\n}")
+	test.expect_hover(t, &source, "test.Bar: struct {\n\tbar: int,\n}")
 }
 
 @(test)
@@ -2254,7 +2254,7 @@ ast_hover_struct_fields_when_not_specifying_type_at_use :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Bar.foo: Foo")
+	test.expect_hover(t, &source, "Bar.foo: Foo")
 }
 
 @(test)
@@ -2278,7 +2278,7 @@ ast_hover_struct_field_value_when_not_specifying_type_at_use :: proc(t: ^testing
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "test.Foo: .B")
+	test.expect_hover(t, &source, "test.Foo: .B")
 }
 
 @(test)
@@ -2344,7 +2344,7 @@ ast_hover_struct_field_should_show_docs_and_comments :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.a: int // a comment\n a docs")
+	test.expect_hover(t, &source, "Foo.a: int // a comment\n a docs")
 }
 
 @(test)
@@ -2358,7 +2358,7 @@ ast_hover_struct_field_should_show_docs_and_comments_field :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.a: int // a comment\n a docs")
+	test.expect_hover(t, &source, "Foo.a: int // a comment\n a docs")
 }
 
 @(test)
@@ -2379,7 +2379,7 @@ ast_hover_struct_field_should_show_docs_and_comments_struct_types :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
 }
 
 @(test)
@@ -2398,7 +2398,7 @@ ast_hover_struct_field_should_show_docs_and_comments_procs :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "// bar comment\nFoo.bar: proc(a: int) -> int\n bar docs")
+	test.expect_hover(t, &source, "// bar comment\nFoo.bar: proc(a: int) -> int\n bar docs")
 }
 
 @(test)
@@ -2419,7 +2419,7 @@ ast_hover_struct_field_should_show_docs_and_comments_named_procs :: proc(t: ^tes
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "// bar comment\nFoo.bar: proc(a: int) -> string\n bar docs")
+	test.expect_hover(t, &source, "// bar comment\nFoo.bar: proc(a: int) -> string\n bar docs")
 }
 
 @(test)
@@ -2438,7 +2438,7 @@ ast_hover_struct_field_should_show_docs_and_comments_maps :: proc(t: ^testing.T)
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: map[int]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: map[int]int // bar comment\n bar docs")
 }
 
 @(test)
@@ -2457,7 +2457,7 @@ ast_hover_struct_field_should_show_docs_and_comments_bit_sets :: proc(t: ^testin
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: bit_set[0 ..< 10] // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: bit_set[0 ..< 10] // bar comment\n bar docs")
 }
 
 @(test)
@@ -2481,7 +2481,7 @@ ast_hover_struct_field_should_show_docs_and_comments_unions :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
 }
 
 @(test)
@@ -2500,7 +2500,7 @@ ast_hover_struct_field_should_show_docs_and_comments_multipointers :: proc(t: ^t
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: [^]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [^]int // bar comment\n bar docs")
 }
 
 @(test)
@@ -2519,7 +2519,7 @@ ast_hover_struct_field_should_show_docs_and_comments_dynamic_arrays :: proc(t: ^
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: [dynamic]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [dynamic]int // bar comment\n bar docs")
 }
 
 @(test)
@@ -2538,7 +2538,7 @@ ast_hover_struct_field_should_show_docs_and_comments_fixed_arrays :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: [5]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [5]int // bar comment\n bar docs")
 }
 
 @(test)
@@ -2557,7 +2557,7 @@ ast_hover_struct_field_should_show_docs_and_comments_matrix :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "Foo.bar: matrix[4,5]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: matrix[4,5]int // bar comment\n bar docs")
 }
 
 @(test)
@@ -2580,7 +2580,23 @@ ast_hover_variable_from_comparison :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover( t, &source, "test.bazz: bool")
+	test.expect_hover(t, &source, "test.bazz: bool")
+}
+
+@(test)
+ast_hover_named_parameter_same_as_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		foo :: proc(a: int) {}
+
+		main :: proc() {
+			a := "hellope"
+			foo(a{*} = 0)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "foo.a: int")
 }
 /*
 

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -1047,8 +1047,8 @@ ast_reference_struct_comp_lit_field :: proc(t: ^testing.T) {
 	}
 
 	locations := []common.Location {
-		{range = {start = {line = 3, character = 3}, end = {line = 3, character = 4}}},
-		{range = {start = {line = 13, character = 11}, end = {line = 13, character = 12}}},
+		{range = {start = {line = 8, character = 3}, end = {line = 8, character = 6}}},
+		{range = {start = {line = 13, character = 4}, end = {line = 13, character = 7}}},
 	}
 
 	test.expect_reference_locations(t, &source, locations[:])

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -1010,7 +1010,7 @@ ast_reference_named_parameter_same_as_variable :: proc(t: ^testing.T) {
 		foo :: proc(a: int) {}
 
 		main :: proc() {
-			b := "hellope"
+			a := "hellope"
 			foo(a{*} = 0)
 		}
 		`,

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -1001,3 +1001,55 @@ ast_reference_struct_field_map :: proc(t: ^testing.T) {
 
 	test.expect_reference_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_reference_named_parameter_same_as_variable :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		foo :: proc(a: int) {}
+
+		main :: proc() {
+			b := "hellope"
+			foo(a{*} = 0)
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 14}, end = {line = 2, character = 15}}},
+		{range = {start = {line = 6, character = 7}, end = {line = 6, character = 8}}},
+	}
+	test.expect_reference_locations(t, &source, locations[:])
+}
+
+@(test)
+ast_reference_struct_comp_lit_field :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Foo :: enum {
+			A,
+			B,
+		}
+
+		Bar :: struct {
+			foo: Foo,
+		}
+
+		foo :: proc() -> Bar {
+			return Bar {
+				fo{*}o = .A,
+			}
+		}
+
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 3, character = 3}, end = {line = 3, character = 4}}},
+		{range = {start = {line = 13, character = 11}, end = {line = 13, character = 12}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}

--- a/tests/type_definition_test.odin
+++ b/tests/type_definition_test.odin
@@ -868,3 +868,27 @@ ast_type_definition_type_cast :: proc(t: ^testing.T) {
 	test.expect_type_definition_locations(t, &source, {location})
 }
 
+@(test)
+ast_type_definition_proc_named_param :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Bar :: struct{
+			bar: int,
+		}
+
+		foo :: proc(a: Bar) {}
+
+		main :: proc() {
+			a := "hellope"
+			foo(a{*} = {})
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 2}, end = {line = 2, character = 5}}},
+	}
+
+	test.expect_type_definition_locations(t, &source, locations[:])
+}

--- a/tests/type_definition_test.odin
+++ b/tests/type_definition_test.odin
@@ -892,3 +892,30 @@ ast_type_definition_proc_named_param :: proc (t: ^testing.T) {
 
 	test.expect_type_definition_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_type_definition_proc_named_param_with_default_value :: proc (t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Bar :: struct{
+			bar: int,
+		}
+
+		bar := Bar{}
+
+		foo :: proc(a := bar) {}
+
+		main :: proc() {
+			b := Bar{}
+			foo(a{*} = b)
+		}
+		`,
+	}
+
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 2}, end = {line = 2, character = 5}}},
+	}
+
+	test.expect_type_definition_locations(t, &source, locations[:])
+}


### PR DESCRIPTION
Implements resolving for named proc params. Should allow for these names to be renamed correctly as well as implementing hover, references, go to definition and go to type definition