### PR TITLE
Implement sortText for CompletionItem

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -157,11 +157,45 @@ get_completion_list :: proc(
 		get_package_completion(&ast_context, &position_context, &list)
 	}
 
+	for &item in list.items {
+		item.sortText = fmt.tprintf("%s_%s", kind_to_sort_score(item.kind), item.label)
+	}
+
 	if common.config.enable_label_details {
 		format_to_label_details(&list)
 	}
 
 	return list, true
+}
+
+kind_to_sort_score :: proc(kind: CompletionItemKind) -> string {
+	score: string
+	#partial switch kind {
+	case .Module:
+		score = "1"
+	case .Folder:
+		score = "2"
+	case .File:
+		score = "3"
+
+	case .Operator:
+		score = "1"
+	case .Field, .EnumMember:
+		score = "2"
+	case .Method:
+		score = "3"
+	case .Function:
+		score = "4"
+	case .Text, .Constant, .Variable, .Struct, .Enum, .TypeParameter:
+		score = "5"
+	case .Snippet:
+		score = "6"
+	case .Keyword:
+		score = "7"
+	case:
+		score = "8"
+	}
+	return score
 }
 
 get_attribute_completion :: proc(

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -369,6 +369,7 @@ CompletionItem :: struct {
 	deprecated:          bool,
 	command:             Maybe(Command),
 	labelDetails:        Maybe(CompletionItemLabelDetails),
+	sortText:            Maybe(string),
 }
 
 CompletionItemLabelDetails :: struct {


### PR DESCRIPTION
Yoinked the values from zls

Perhaps default could be tuned for Odin, but it looks good to me as is

This should perhaps also be an option, opt in, to not annoy people who are already used to the current non existing "sorting" by label

But i don't know how to do that, so i'll leave it to you

https://github.com/zigtools/zls/blob/45b855f7ec3dccea3c9a95df0b68e27dab842ae4/src/features/completions.zig#L919C23-L920

https://github.com/zigtools/zls/blob/45b855f7ec3dccea3c9a95df0b68e27dab842ae4/src/features/completions.zig#L566-L588