### PR TITLE
Overload proc resolving improvements

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -772,8 +772,21 @@ resolve_function_overload :: proc(ast_context: ^AstContext, group: ast.Proc_Grou
 						if !ok {
 							break next_fn
 						}
-
-						if !is_symbol_same_typed(ast_context, call_symbol, arg_symbol, proc_arg.flags) {
+						
+						if value, ok := arg_symbol.value.(SymbolUnionValue); ok {
+							found := false
+							for variant in value.types {
+								if symbol, ok := resolve_type_expression(ast_context, variant); ok {
+									if is_symbol_same_typed(ast_context, call_symbol, symbol, proc_arg.flags) {
+										found = true
+										break
+									}
+								}
+							}
+							if !found {
+								break next_fn
+							}
+						} else if !is_symbol_same_typed(ast_context, call_symbol, arg_symbol, proc_arg.flags) {
 							break next_fn
 						}
 

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2683,6 +2683,116 @@ ast_hover_overloading_with_union :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.my_overload: proc(fb: FooBar)")
 }
+
+@(test)
+ast_hover_overloading_with_union_and_variant :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			foo: int,
+		}
+
+		Bar :: struct {
+			bar: string,
+		}
+
+		FooBar :: union {
+			Foo,
+			Bar,
+		}
+
+		foo_bar :: proc(fb: FooBar) {}
+		bar :: proc(bar: Bar) {}
+
+		my_overload :: proc {
+			foo_bar,
+			bar,
+		}
+
+		main :: proc() {
+			bar: Bar
+			my_overloa{*}d(bar)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.my_overload: proc(bar: Bar)")
+}
+
+@(test)
+ast_hover_overloading_struct_with_usings :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			foo: int,
+		}
+
+		Bar :: struct {
+			using f: Foo,
+
+			bar: string,
+		}
+
+		Bazz :: struct {
+			using b: Bar,
+
+			bazz: i32,
+		}
+
+
+		foo :: proc(f: Foo) {}
+		bar :: proc(b: Bar) {}
+
+		foobar :: proc {
+			foo,
+			bar,
+		}
+
+		main :: proc() {
+			bazz: Bazz
+			fooba{*}r(bazz)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.foobar: proc(b: Bar)")
+}
+
+@(test)
+ast_hover_overloading_struct_with_usings_with_pointers :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			foo: int,
+		}
+
+		Bar :: struct {
+			using f: Foo,
+
+			bar: string,
+		}
+
+		Bazz :: struct {
+			using b: Bar,
+
+			bazz: i32,
+		}
+
+
+		foo :: proc(f: ^Foo) {}
+		bar :: proc(b: ^Bar) {}
+
+		foobar :: proc {
+			foo,
+			bar,
+		}
+
+		main :: proc() {
+			bazz: Bazz
+			fooba{*}r(&bazz)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.foobar: proc(b: ^Bar)")
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2649,6 +2649,40 @@ ast_hover_inside_where_clause :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.x: [2]int")
 }
+
+@(test)
+ast_hover_overloading_with_union :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			foo: int,
+		}
+
+		Bar :: struct {
+			bar: string,
+		}
+
+		FooBar :: union {
+			Foo,
+			Bar,
+		}
+
+		foo_bar :: proc(fb: FooBar) {}
+		bar :: proc(bar: Bar) {}
+
+		my_overload :: proc {
+			foo_bar,
+			bar,
+		}
+
+		main :: proc() {
+			foo: Foo
+			my_overloa{*}d(foo)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.my_overload: proc(fb: FooBar)")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Overloaded procs will now resolve union types and embedded 'using' types in structs correctly