### PR TITLE
Run nightly release with version information

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,12 +1,11 @@
 name: nightly
 
-
 on:
   workflow_dispatch:
-  #schedule:
-  #- cron: 0 20 * * *
-jobs:
+  schedule:
+    - cron: 0 2 * * *
 
+jobs:
   dist-arm64-darwin:
     runs-on: macos-latest
     timeout-minutes: 15
@@ -147,7 +146,7 @@ jobs:
       run: ./ci.bat CI
     - name: Move to Dist
       shell: cmd
-      run: | 
+      run: |
         mkdir dist
         move ols.exe dist/
         move builtin dist/

--- a/build.sh
+++ b/build.sh
@@ -46,8 +46,4 @@ then
     exit 0
 fi
 
-version="$(git describe --tags --abbrev=7)"
-version="${version%-*}:${version##*-}"
-sed "s|VERSION :: .*|VERSION :: \"${version}\"|g" src/main.odin > /tmp/main.odin.build && mv -f /tmp/main.odin.build src/main.odin
-
 odin build src/ -show-timings -collection:src=src -out:ols -microarch:native -no-bounds-check -o:speed $@

--- a/ci.bat
+++ b/ci.bat
@@ -1,16 +1,21 @@
 @echo off
 
 setlocal enabledelayedexpansion
+
+for /f "tokens=1-3 delims=-" %%a in ('echo %date%') do set today=%%a-%%b-%%c
+set commit_hash=%GITHUB_SHA:~0,8%
+set version=nightly-%today%-%commit_hash%
+
 if "%1" == "CI" (
     set "PATH=%cd%\Odin;!PATH!"
 
     rem odin test tests -collection:src=src -define:ODIN_TEST_THREADS=1
     rem if %errorlevel% neq 0 exit /b 1
-    
+
     odin build src\ -collection:src=src -out:ols.exe -o:speed -extra-linker-flags:"/STACK:4000000,2000000"
 
     call "tools/odinfmt/tests.bat"
     if %errorlevel% neq 0 exit /b 1
 ) else (
-     odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000"
+     odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
 )

--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+VERSION="nightly-$(date -u '+%Y-%m-%d')-$(git rev-parse --short HEAD)"
 
 if [[ $1 == "CI" ]]
 then
@@ -36,4 +37,4 @@ then
 fi
 
 
-odin build src/ -show-timings -collection:src=src -out:ols -no-bounds-check -o:speed $@
+odin build src/ -show-timings -collection:src=src -out:ols -no-bounds-check -o:speed -define:VERSION=$VERSION $@

--- a/src/main.odin
+++ b/src/main.odin
@@ -19,7 +19,7 @@ import "core:sys/windows"
 import "src:common"
 import "src:server"
 
-VERSION :: "dev-2024-11-9:g584f01b"
+VERSION := #config(VERSION, "dev")
 
 os_read :: proc(handle: rawptr, data: []byte) -> (int, int) {
 	ptr := cast(^os.Handle)handle


### PR DESCRIPTION
Just a quick pass at running a nightly release with version information.

For the version it uses `nightly-{date}-{commit-hash}`. Should work for mac and linux (works simply running `./ci.sh CI_NO_TESTS` on my mac), though I have not tested the batch script on windows.

This would run at 2am UTC regardless as to whether there are changes or not. I had a brief look on how to do that but it seemed more involved than I would have liked lol. Something that would be good to look into at some point though.

If we don't want to automate the release right now, it would still be good to just add the versioning information as we have here.