### PR TITLE
Label Details description should show type information only

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2150,9 +2150,16 @@ format_to_label_details :: proc(list: ^CompletionList) {
 			}
 		case .Variable, .Constant, .Field:
 			type_index := strings.index(item.detail, ":")
+			type_name := item.detail[type_index + 1:]
+
+			commentIndex := strings.index(type_name, "/")
+			if commentIndex > 0 {
+				type_name, _ = strings.substring(type_name, 0, commentIndex)
+			}
+
 			item.labelDetails = CompletionItemLabelDetails {
 				detail      = "",
-				description = item.detail[type_index + 1:],
+				description = type_name,
 			}
 		case .Struct, .Enum, .Class:
 			type_index := strings.index(item.detail, ":")


### PR DESCRIPTION
It was too much noise it became unusable


Before:

<img width="612" height="285" alt="image" src="https://github.com/user-attachments/assets/dd2e37f7-d711-475b-b2b2-d42b239343c1" />


After:

<img width="930" height="282" alt="image" src="https://github.com/user-attachments/assets/b8b366ed-28a7-4335-b14c-f3722097b692" />


The detail box should perhaps get rid of anything before `//`, but I can't see where the logic is