### PR TITLE
Moves comments to the end of the docs and uses markdown for completion documentation

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2740,7 +2740,7 @@ get_using_packages :: proc(ast_context: ^AstContext) -> []string {
 	return usings
 }
 
-get_symbol_pkg_name :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
+get_symbol_pkg_name :: proc(ast_context: ^AstContext, symbol: ^Symbol) -> string {
 	return get_pkg_name(ast_context, symbol.pkg)
 }
 

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -67,7 +67,7 @@ append_method_completion :: proc(
 		if symbols, ok := &v.methods[method]; ok {
 			for &symbol in symbols {
 				resolve_unresolved_symbol(ast_context, &symbol)
-				symbol.signature = get_short_signature(ast_context, symbol)
+				build_documentation(ast_context, &symbol)
 
 				range, ok := get_range_from_selection_start_to_dot(position_context)
 
@@ -113,7 +113,7 @@ append_method_completion :: proc(
 				if symbol.pkg != ast_context.document_package {
 					new_text = fmt.tprintf(
 						"%v.%v",
-						path.base(get_symbol_pkg_name(ast_context, symbol), false, ast_context.allocator),
+						path.base(get_symbol_pkg_name(ast_context, &symbol), false, ast_context.allocator),
 						symbol.name,
 					)
 				} else {
@@ -125,11 +125,12 @@ append_method_completion :: proc(
 				} else {
 					new_text = fmt.tprintf("%v(%v%v%v)$0", new_text, references, receiver, dereferences)
 				}
+				build_documentation(ast_context, &symbol)
 
 				item := CompletionItem {
 					label = symbol.name,
 					kind = symbol_type_to_completion_kind(symbol.type),
-					detail = get_short_signature(ast_context, symbol),
+					detail = symbol.signature,
 					additionalTextEdits = remove_edit,
 					textEdit = TextEdit{newText = new_text, range = {start = range.end, end = range.end}},
 					insertTextFormat = .Snippet,

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -134,7 +134,7 @@ get_signature_information :: proc(document: ^Document, position: common.Position
 			parameters[i].label = node_to_string(arg)
 		}
 
-		call.signature = get_short_signature(&ast_context, call)
+		build_documentation(&ast_context, &call)
 
 		info := SignatureInformation {
 			label         = concatenate_symbol_information(&ast_context, call),
@@ -160,7 +160,7 @@ get_signature_information :: proc(document: ^Document, position: common.Position
 					parameters[i].label = node_to_string(arg)
 				}
 
-				symbol.signature = get_short_signature(&ast_context, symbol)
+				build_documentation(&ast_context, &symbol)
 
 				info := SignatureInformation {
 					label         = concatenate_symbol_information(&ast_context, symbol),

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -355,11 +355,16 @@ InsertTextMode :: enum {
 	adjustIndentation = 2,
 }
 
+CompletionDocumention :: union {
+	MarkupContent,
+	string,
+}
+
 CompletionItem :: struct {
 	label:               string,
 	kind:                CompletionItemKind,
 	detail:              string,
-	documentation:       string,
+	documentation:       CompletionDocumention,
 	insertTextFormat:    Maybe(InsertTextFormat),
 	insertText:          Maybe(string),
 	InsertTextMode:      Maybe(InsertTextMode),

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -265,7 +265,8 @@ expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {
 		return
 	}
 
-	content_without_markdown, _ := strings.remove(hover.contents.value[8:], "\n```", 1, context.temp_allocator)
+	first_strip, _ := strings.remove(hover.contents.value, "```odin\n", 2, context.temp_allocator)
+	content_without_markdown, _ := strings.remove(first_strip, "\n```", 2, context.temp_allocator)
 
 	if content_without_markdown != expect_hover_string {
 		log.errorf("Expected hover string:\n%q, but received:\n%q", expect_hover_string, content_without_markdown)

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -29,7 +29,7 @@ ast_simple_struct_completion :: proc(t: ^testing.T) {
 		t,
 		&source,
 		".",
-		{"My_Struct.one: int", "My_Struct.two: int // test comment", "My_Struct.three: int"},
+		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
 	)
 }
 
@@ -3338,7 +3338,7 @@ ast_completion_struct_documentation :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_completion_details(t, &source, "", {"Foo.bazz: my_package.My_Struct // bazz"})
+	test.expect_completion_details(t, &source, "", {"Foo.bazz: my_package.My_Struct"})
 }
 
 @(test)
@@ -3460,7 +3460,7 @@ ast_completion_poly_struct_another_package :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_completion_details(t, &source, "", {"Runner.state: test.State // state"})
+	test.expect_completion_details(t, &source, "", {"Runner.state: test.State"})
 }
 
 @(test)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -680,7 +680,7 @@ ast_hover_struct_field_complex_definition :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "Foo.bar: ^test.Bar // inline docs\n Docs")
+	test.expect_hover(t, &source, "Foo.bar: ^test.Bar\n Docs\n\n// inline docs")
 }
 
 @(test)
@@ -1486,7 +1486,7 @@ ast_hover_proc_comments :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "// do foo\ntest.foo: proc()\n doc")
+	test.expect_hover(t, &source, "test.foo: proc()\n doc\n\n// do foo")
 }
 
 @(test)
@@ -1514,7 +1514,7 @@ ast_hover_proc_comments_package :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "// do foo\nmy_package.foo: proc()")
+	test.expect_hover(t, &source, "my_package.foo: proc()\n// do foo")
 }
 
 @(test)
@@ -1532,7 +1532,7 @@ ast_hover_struct_field_distinct :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "S.fb: test.B // type: fb")
+	test.expect_hover(t, &source, "S.fb: test.B\n// type: fb")
 }
 
 @(test)
@@ -2110,7 +2110,7 @@ ast_hover_bit_field_field :: proc(t: ^testing.T) {
 	test.expect_hover(
 		t,
 		&source,
-		"Foo.foo_aa: uint | 6 // last 6 bits",
+		"Foo.foo_aa: uint | 6\n// last 6 bits",
 	)
 }
 
@@ -2133,7 +2133,7 @@ ast_hover_bit_field_variable_with_docs :: proc(t: ^testing.T) {
 	test.expect_hover(
 		t,
 		&source,
-		"Foo.foo_a: uint | 2 // foo a\n doc",
+		"Foo.foo_a: uint | 2\n doc\n\n// foo a",
 	)
 }
 
@@ -2344,7 +2344,7 @@ ast_hover_struct_field_should_show_docs_and_comments :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.a: int // a comment\n a docs")
+	test.expect_hover(t, &source, "Foo.a: int\n a docs\n\n// a comment")
 }
 
 @(test)
@@ -2358,7 +2358,7 @@ ast_hover_struct_field_should_show_docs_and_comments_field :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.a: int // a comment\n a docs")
+	test.expect_hover(t, &source, "Foo.a: int\n a docs\n\n// a comment")
 }
 
 @(test)
@@ -2379,7 +2379,7 @@ ast_hover_struct_field_should_show_docs_and_comments_struct_types :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2398,7 +2398,7 @@ ast_hover_struct_field_should_show_docs_and_comments_procs :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "// bar comment\nFoo.bar: proc(a: int) -> int\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> int\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2419,7 +2419,7 @@ ast_hover_struct_field_should_show_docs_and_comments_named_procs :: proc(t: ^tes
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "// bar comment\nFoo.bar: proc(a: int) -> string\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> string\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2438,7 +2438,7 @@ ast_hover_struct_field_should_show_docs_and_comments_maps :: proc(t: ^testing.T)
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: map[int]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: map[int]int\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2457,7 +2457,7 @@ ast_hover_struct_field_should_show_docs_and_comments_bit_sets :: proc(t: ^testin
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: bit_set[0 ..< 10] // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: bit_set[0 ..< 10]\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2481,7 +2481,7 @@ ast_hover_struct_field_should_show_docs_and_comments_unions :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: test.Bar // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2500,7 +2500,7 @@ ast_hover_struct_field_should_show_docs_and_comments_multipointers :: proc(t: ^t
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [^]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [^]int\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2519,7 +2519,7 @@ ast_hover_struct_field_should_show_docs_and_comments_dynamic_arrays :: proc(t: ^
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [dynamic]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [dynamic]int\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2538,7 +2538,7 @@ ast_hover_struct_field_should_show_docs_and_comments_fixed_arrays :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [5]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: [5]int\n bar docs\n\n// bar comment")
 }
 
 @(test)
@@ -2557,7 +2557,7 @@ ast_hover_struct_field_should_show_docs_and_comments_matrix :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: matrix[4,5]int // bar comment\n bar docs")
+	test.expect_hover(t, &source, "Foo.bar: matrix[4,5]int\n bar docs\n\n// bar comment")
 }
 
 @(test)


### PR DESCRIPTION
Should help reduce the noise in things like vscode. 

Completion:
<img width="887" height="290" alt="image" src="https://github.com/user-attachments/assets/d1611473-dee5-43a6-a2f0-bb0f73af1092" />

Hover:
<img width="441" height="137" alt="image" src="https://github.com/user-attachments/assets/af12a37d-96da-47ac-8d37-60033472d86a" />
