### PR TITLE
Add missing version from windows nightly release

### DIFF
--- a/ci.bat
+++ b/ci.bat
@@ -12,10 +12,10 @@ if "%1" == "CI" (
     rem odin test tests -collection:src=src -define:ODIN_TEST_THREADS=1
     rem if %errorlevel% neq 0 exit /b 1
 
-    odin build src\ -collection:src=src -out:ols.exe -o:speed -extra-linker-flags:"/STACK:4000000,2000000"
+    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
 
     call "tools/odinfmt/tests.bat"
     if %errorlevel% neq 0 exit /b 1
 ) else (
-     odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
+    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
 )


### PR DESCRIPTION
The nightly build runs `.\ci.bat CI` so it was missing the nightly version being added. Also made the build command it runs the same if it didn't have `CI` there.