### PR TITLE
Increase the capacity of the `usings` map so it doesn't cause a panic when trying to insert

### DIFF
--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -231,7 +231,9 @@ symbol_struct_value_builder_make_none :: proc(allocator := context.allocator) ->
 		ranges = make([dynamic]common.Range, allocator),
 		docs = make([dynamic]^ast.Comment_Group, allocator),
 		comments = make([dynamic]^ast.Comment_Group, allocator),
-		usings = make(map[int]struct{}, allocator),
+		// Set it to an arbitary size due to issues with crashes
+		// See https://github.com/DanielGavin/ols/issues/787
+		usings = make(map[int]struct{}, 16, allocator),
 		from_usings = make([dynamic]int, allocator),
 		unexpanded_usings = make([dynamic]int, allocator),
 		poly_names = make([dynamic]string, allocator),


### PR DESCRIPTION
No idea why this is an issue, but this seems to resolve it. It fails to find a free slot to insert an item into as you can see here https://github.com/odin-lang/Odin/blob/master/base/runtime/dynamic_map_internal.odin#L427. Only happened with semantic tokens, hover and everything else was fine.

Resolves https://github.com/DanielGavin/ols/issues/787