### PR TITLE
Only override docs for re-exported items if there is new documentation on the when doing the export

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1855,8 +1855,13 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 			return_symbol.type = .Variable
 		}
 
-		return_symbol.doc = get_doc(global.docs, ast_context.allocator)
-		return_symbol.comment = get_comment(global.comment)
+		if global.docs != nil {
+			return_symbol.doc = get_doc(global.docs, ast_context.allocator)
+		}
+
+		if global.comment != nil {
+			return_symbol.comment = get_comment(global.comment)
+		}
 
 		return return_symbol, ok
 	} else {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3042,6 +3042,65 @@ ast_hover_enum_explicit_type :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.Foo: .A")
 }
+
+@(test)
+ast_hover_documentation_reexported :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+			// Documentation for Foo
+			Foo :: struct{}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+
+		F{*}oo :: my_package.Foo
+		`,
+		packages = packages[:],
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"my_package.Foo: struct {}\n Documentation for Foo",
+	)
+}
+
+@(test)
+ast_hover_override_documentation_reexported :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+			// Documentation for Foo
+			Foo :: struct{}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+
+		// New docs for Foo
+		F{*}oo :: my_package.Foo
+		`,
+		packages = packages[:],
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"my_package.Foo: struct {}\n New docs for Foo",
+	)
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Makes it so that when you re-export an item like

```odin
package foo
// My docs
Foo :: struct {}
```

```odin
package bar
import "foo"

Foo :: foo.Foo <-- this will use the docs/comments of `foo.Foo`
// My docs for Foo2
Foo2 :: foo.Foo <-- this will have the docs "My docs for Foo2"
```

