### PR TITLE
Make `file_resolve_cache` and `build_cache` thread_local to stop isses with tests

### DIFF
--- a/src/server/caches.odin
+++ b/src/server/caches.odin
@@ -22,6 +22,7 @@ FileResolveCache :: struct {
 	files: map[string]FileResolve,
 }
 
+@(thread_local)
 file_resolve_cache: FileResolveCache
 
 resolve_entire_file_cached :: proc(document: ^Document) -> map[uintptr]SymbolAndNode {
@@ -43,6 +44,7 @@ PackageCacheInfo :: struct {
 	timestamp: time.Time,
 }
 
+@(thread_local)
 build_cache: BuildCache
 
 


### PR DESCRIPTION
There's been an issue with the tests when running them across multiple threads where sometimes a random test that uses the builtins would fail as below. Whilst working on the completion changes I ended up encountering a problem with another test randomly that would consistently fail, and I was able to track it down to these variables needing to be thread local.

```sh
❯ odin test tests -collection:src=src  -define:ODIN_TEST_THREADS=0
[INFO ] --- [2025-07-28 12:37:12] Starting test runner with 10 threads. Set with -define:ODIN_TEST_THREADS=n.
[INFO ] --- [2025-07-28 12:37:12] The random seed sent to every test is: 68268113535839. Set with -define:ODIN_TEST_RANDOM_SEED=n.
[INFO ] --- [2025-07-28 12:37:12] Memory tracking is enabled. Tests will log their memory usage if there's an issue.
[INFO ] --- [2025-07-28 12:37:12] < Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]
[ERROR] --- [2025-07-28 12:37:12] [testing.odin:264:expect_hover()] &T{error_count = 0, seed = 68268113535839, channel = Chan($T=Channel_Event, $D=-1){}, cleanups = [], _log_allocator = Allocator{procedure = proc(rawptr, Allocator_Mode, int, int, rawptr, int, Source_Code_Location) -> ([]u8, Allocator_Error) @ 0x104A9D830, data = 0x0}, _fail_now_called = false} Failed get_hover_information
[WARN ] --- [2025-07-28 12:37:13] [analysis.odin:1340:internal_resolve_type_expression()] default node kind, internal_resolve_type_expression: &Bad_Expr{node = Expr{expr_base = Node{pos = Pos{file = "test/test.odin", offset = 75, line = 7, column = 76}, end = Pos{file = "test/test.odin", offset = 75, line = 7, column = 76}, state_flags = Node_State_Flags{}, derived = 0x12AC85340}, derived_expr = 0x12AC85340}}
tests  [||||||||||||||||||||||||]       450 :: [package done] (1 failed)

Finished 450 tests in 1.300535s. 1 test failed.
 - tests.ast_hover_builtin_max_with_type_local                                          &T{error_count = 0, seed = 68268113535839, channel = Chan($T=Channel_Event, $D=-1){}, cleanups = [], _log_allocator = Allocator{procedure = proc(rawptr, Allocator_Mode, int, int, rawptr, int, Source_Code_Location) -> ([]u8, Allocator_Error) @ 0x104A9D830, data = 0x0}, _fail_now_called = false} Failed get_hover_information

To run only the failed test, use:
        -define:ODIN_TEST_NAMES=tests.ast_hover_builtin_max_with_type_local,

If your terminal supports OSC 52, you may use -define:ODIN_TEST_CLIPBOARD to have this copied directly to your clipboard.
```