### PR TITLE
Handle semantic token for const global variables returned from functions

### DIFF
--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -390,9 +390,11 @@ visit_node :: proc(node: ^ast.Node, builder: ^SemanticTokenBuilder) {
 	}
 }
 
+// TODO: it seems the global symbols don't distinguish between a type decl and
+// a const variable declaration, so we do a quick check here to distinguish the cases.
 is_variable_declaration :: proc(expr: ^ast.Expr) -> bool {
 	#partial switch v in expr.derived {
-	case ^ast.Comp_Lit, ^ast.Basic_Lit, ^ast.Type_Cast:
+	case ^ast.Comp_Lit, ^ast.Basic_Lit, ^ast.Type_Cast, ^ast.Call_Expr:
 		return true
 	case:
 		return false

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -58,6 +58,7 @@ semantic_tokens_literals_with_explicit_types :: proc(t: ^testing.T) {
 		Foo :: 1
 		Foo2 : int : 1
 		Foo3 :: cast(string) "hello"
+		Foo4 :: cstring("hello")
 		`
 	}
 
@@ -67,5 +68,7 @@ semantic_tokens_literals_with_explicit_types :: proc(t: ^testing.T) {
 		{0, 7,  3, .Type,     {.ReadOnly}}, // [2]  int
 		{1, 2,  4, .Variable, {.ReadOnly}}, // [3]  Foo3
 		{0, 13, 6, .Type,     {.ReadOnly}}, // [4]  string
+		{1, 2,  4, .Variable, {.ReadOnly}}, // [5]  Foo4
+		{0, 8,  7, .Type,     {.ReadOnly}}, // [6]  cstring
 	})
 }


### PR DESCRIPTION
Further improvements for https://github.com/DanielGavin/ols/issues/470

We probably want to move this kind of thing to be done as part of the resolving process. Right now global expr are marked between `Type` and `Variable` depending on whether or not they are constant.