### PR TITLE
Fix issue with constructing docs on indexed symbols

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -631,10 +631,11 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 		symbol.range = common.get_token_range(expr.name_expr, file.src)
 		symbol.name = get_index_unique_string(collection, name)
 		symbol.type = token_type
-		symbol.doc = get_doc(expr.docs, collection.allocator)
+		doc := get_doc(expr.docs, collection.allocator)
+		symbol.doc = get_index_unique_string(collection, doc)
 		symbol.uri = get_index_unique_string(collection, uri)
 		comment := get_file_comment(file, symbol.range.start.line + 1)
-		symbol.comment = strings.clone(get_comment(comment), collection.allocator)
+		symbol.comment = get_index_unique_string(collection, get_comment(comment))
 		symbol.flags |= {.Distinct}
 
 		if expr.builtin || strings.contains(uri, "builtin.odin") {

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -105,6 +105,7 @@ keywords_docs: map[string]bool = {
 }
 
 // Adds signature and docs information to the provided symbol
+// This should only be used for a symbol created with the temp allocator
 build_documentation :: proc(ast_context: ^AstContext, symbol: ^Symbol, short_signature := true) {
 	if short_signature {
 		symbol.signature = get_short_signature(ast_context, symbol)
@@ -116,7 +117,7 @@ build_documentation :: proc(ast_context: ^AstContext, symbol: ^Symbol, short_sig
 		return
 	}
 
-	symbol.doc = construct_symbol_docs(symbol.doc, symbol.comment)
+	symbol.doc = construct_symbol_docs(symbol, allocator = ast_context.allocator)
 }
 
 // Adds signature and docs information for a bit field field
@@ -124,20 +125,20 @@ build_bit_field_field_documentation :: proc(
 	ast_context: ^AstContext, symbol: ^Symbol, value: SymbolBitFieldValue, index: int, allocator := context.temp_allocator
 ) {
 	symbol.signature = get_bit_field_field_signature(value, index, allocator)
-	symbol.doc = construct_symbol_docs(symbol.doc, symbol.comment)
+	symbol.doc = construct_symbol_docs(symbol)
 }
 
-construct_symbol_docs :: proc(docs, comment: string, allocator := context.temp_allocator) -> string {
-	sb := strings.builder_make(allocator = context.temp_allocator)
-	if docs != "" {
-		strings.write_string(&sb, docs)
-		if comment != "" {
+construct_symbol_docs :: proc(symbol: ^Symbol, allocator := context.temp_allocator) -> string {
+	sb := strings.builder_make(allocator = allocator)
+	if symbol.doc != "" {
+		strings.write_string(&sb, symbol.doc)
+		if symbol.comment != "" {
 			strings.write_string(&sb, "\n")
 		}
 	}
 
-	if comment != "" {
-	    fmt.sbprintf(&sb, "\n```odin\n%s\n```", comment)
+	if symbol.comment != "" {
+	    fmt.sbprintf(&sb, "\n```odin\n%s\n```", symbol.comment)
 	}
 
 	 return strings.to_string(sb)

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -67,7 +67,6 @@ append_method_completion :: proc(
 		if symbols, ok := &v.methods[method]; ok {
 			for &symbol in symbols {
 				resolve_unresolved_symbol(ast_context, &symbol)
-				build_documentation(ast_context, &symbol)
 
 				range, ok := get_range_from_selection_start_to_dot(position_context)
 
@@ -125,17 +124,16 @@ append_method_completion :: proc(
 				} else {
 					new_text = fmt.tprintf("%v(%v%v%v)$0", new_text, references, receiver, dereferences)
 				}
-				build_documentation(ast_context, &symbol)
 
 				item := CompletionItem {
 					label = symbol.name,
 					kind = symbol_type_to_completion_kind(symbol.type),
-					detail = symbol.signature,
+					detail = get_short_signature(ast_context, &symbol),
 					additionalTextEdits = remove_edit,
 					textEdit = TextEdit{newText = new_text, range = {start = range.end, end = range.end}},
 					insertTextFormat = .Snippet,
 					InsertTextMode = .adjustIndentation,
-					documentation = symbol.doc,
+					documentation = construct_symbol_docs(&symbol),
 				}
 
 				append(items, item)


### PR DESCRIPTION
Whilst looking into https://github.com/DanielGavin/ols/issues/799 I noticed that I was getting null bytes for symbol method documentation after first completion. After a brief investigation, I found that with the recent changes it was overriding the indexed symbols documentation with a string created on the temp allocator. To fix this for now I've just made it so that it no longer overrides the docs in this case.

A more permanent solution to this will come with the ongoing improvements to the docs generation so that we always use those functions to construct the docs as needed. With that becoming more streamlined it should make it easier as well.

Possibly resolves https://github.com/DanielGavin/ols/issues/799