### PR TITLE
Only limit identifier completions to maintain consistency from before the changes

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -187,8 +187,12 @@ convert_completion_results :: proc(
 		return j.score < i.score
 	})
 
-	//hard code for now
-	top_results := results[0:(min(100, len(results)))]
+	top_results := results
+	// Just to keep consistency to what it was before these changes
+	if completion_type == .Identifier {
+		//hard code for now
+		top_results = results[0:(min(100, len(results)))]
+	}
 
 	items := make([dynamic]CompletionItem, 0, len(top_results), allocator = context.temp_allocator)
 


### PR DESCRIPTION
Basically before the completion rework, it would only limit the completions for identifiers. When playing around with this I noticed that when using `ast_context.` I would not get any completions for the fields, only for procedures. This is just a simple fix to ensure that it's always available. 

When we start scoring these completions we should probably ensure that fields are placed above the procs as well.