### PR TITLE
Resolve objc methods before expanding usings to fix issues with hover documentation

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2344,8 +2344,8 @@ resolve_symbol_return :: proc(ast_context: ^AstContext, symbol: Symbol, ok := tr
 		}
 
 		//expand the types and names from the using - can't be done while indexing without complicating everything(this also saves memory)
-		expand_usings(ast_context, &b)
 		expand_objc(ast_context, &b)
+		expand_usings(ast_context, &b)
 		return to_symbol(b), ok
 	case SymbolGenericValue:
 		ret, ok := resolve_type_expression(ast_context, v.expr)

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -549,7 +549,7 @@ write_struct_hover :: proc(ast_context: ^AstContext, sb: ^strings.Builder, v: Sy
 
 	for i in 0 ..< len(v.names) {
 		if i < len(v.from_usings) {
-			if index := v.from_usings[i]; index != using_index {
+			if index := v.from_usings[i]; index != using_index && index != -1 {
 				fmt.sbprintf(sb, "\n\t// from `using %s: ", v.names[index])
 				build_string_node(v.types[index], sb, false)
 				if backing_type, ok := v.backing_types[index]; ok {

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -361,8 +361,8 @@ write_struct_type :: proc(
 		resolve_poly_struct(ast_context, b, v.poly_params)
 	}
 
-	expand_usings(ast_context, b)
 	expand_objc(ast_context, b)
+	expand_usings(ast_context, b)
 }
 
 write_symbol_struct_value :: proc(


### PR DESCRIPTION
Fixes crashing issues with objc code where the ordering of the using expansions would be incorrect and set to -1 when generating the hover docs. I've also added the check to ensure even if something does go wrong there, it'll just be displayed wrong rather than crash