### PR TITLE
Fix/resolve procs that return procs called immediately

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3274,18 +3274,18 @@ get_generic_assignment :: proc(
 				if value, ok := symbol.value.(SymbolProcedureValue); ok {
 					if len(value.return_types) == 1 {
 						if proc_type, ok := value.return_types[0].type.derived.(^Proc_Type); ok {
-							if len(proc_type.results.list) == 1 {
+							for return_item in proc_type.results.list {
 								get_generic_assignment(
 									file,
-									proc_type.results.list[0].type,
+									return_item.type,
 									ast_context,
 									results,
 									calls,
 									flags,
 									is_mutable,
 								)
-								return
 							}
+							return
 						}
 					}
 				}

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1505,109 +1505,7 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 	}
 
 	if local, ok := get_local(ast_context^, node); ok && (ast_context.use_locals || local.local_global) {
-		is_distinct := false
-
-		if local.parameter {
-			for imp in ast_context.imports {
-				if strings.compare(imp.base, node.name) == 0 {
-					symbol := Symbol {
-						type  = .Package,
-						pkg   = imp.name,
-						value = SymbolPackageValue{},
-					}
-
-					return symbol, true
-				}
-			}
-		}
-
-		if local.pkg != "" {
-			ast_context.current_package = local.pkg
-		}
-
-		//Sometimes the locals are semi resolved and can no longer use the locals
-		if local.resolved_global {
-			ast_context.use_locals = false
-		}
-
-		if dist, ok := local.rhs.derived.(^ast.Distinct_Type); ok {
-			if dist.type != nil {
-				local.rhs = dist.type
-				is_distinct = true
-			}
-		}
-
-		return_symbol: Symbol
-		ok: bool
-
-		#partial switch v in local.rhs.derived {
-		case ^Ident:
-			return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
-		case ^Union_Type:
-			return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Enum_Type:
-			return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Struct_Type:
-			return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node, {}), true
-			return_symbol.name = node.name
-		case ^Bit_Set_Type:
-			return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Bit_Field_Type:
-			return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node), true
-			return_symbol.name = node.name
-		case ^Proc_Lit:
-			if is_procedure_generic(v.type) {
-				return_symbol, ok = resolve_generic_function(ast_context, v^)
-
-				if !ok && !ast_context.overloading {
-					return_symbol, ok =
-						make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining),
-						true
-				}
-			} else {
-				return_symbol, ok =
-					make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining), true
-			}
-		case ^Proc_Group:
-			return_symbol, ok = resolve_function_overload(ast_context, v^)
-		case ^Array_Type:
-			return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
-		case ^Dynamic_Array_Type:
-			return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
-		case ^Matrix_Type:
-			return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
-		case ^Map_Type:
-			return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
-		case ^Basic_Lit:
-			return_symbol, ok = resolve_basic_lit(ast_context, v^)
-			return_symbol.name = node.name
-			return_symbol.type = local.variable ? .Variable : .Constant
-		case ^ast.Binary_Expr:
-			return_symbol, ok = resolve_binary_expression(ast_context, v)
-		case:
-			return_symbol, ok = internal_resolve_type_expression(ast_context, local.rhs)
-		}
-
-		if is_distinct {
-			return_symbol.name = node.name
-			return_symbol.flags |= {.Distinct}
-		}
-
-		if local.parameter {
-			return_symbol.flags |= {.Parameter}
-		}
-
-		if local.variable {
-			return_symbol.type = .Variable
-		}
-
-		return_symbol.flags |= {.Local}
-
-		return return_symbol, ok
-
+		return resolve_local_identifier(ast_context, node, &local)
 	}
 
 	for imp in ast_context.imports {
@@ -1641,120 +1539,7 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 
 	if global, ok := ast_context.globals[node.name];
 	   ast_context.current_package == ast_context.document_package && ok {
-		is_distinct := false
-		ast_context.use_locals = false
-
-		if dist, ok := global.expr.derived.(^ast.Distinct_Type); ok {
-			if dist.type != nil {
-				global.expr = dist.type
-				is_distinct = true
-			}
-		}
-
-		return_symbol: Symbol
-		ok: bool
-
-		#partial switch v in global.expr.derived {
-		case ^Ident:
-			return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
-		case ^ast.Call_Expr:
-			old_call := ast_context.call
-			ast_context.call = cast(^Call_Expr)global.expr
-
-			defer {
-				ast_context.call = old_call
-			}
-
-			if return_symbol, ok = internal_resolve_type_expression(ast_context, v.expr); ok {
-				return_types := get_proc_return_types(ast_context, return_symbol, v, global.mutable)
-				if len(return_types) > 0 {
-					return_symbol, ok = internal_resolve_type_expression(ast_context, return_types[0])
-				}
-				// Otherwise should be a parapoly style
-			}
-
-		case ^Struct_Type:
-			return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node, global.attributes), true
-			return_symbol.name = node.name
-		case ^Bit_Set_Type:
-			return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Union_Type:
-			return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Enum_Type:
-			return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node), true
-			return_symbol.name = node.name
-		case ^Bit_Field_Type:
-			return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node), true
-			return_symbol.name = node.name
-		case ^Proc_Lit:
-			if is_procedure_generic(v.type) {
-				return_symbol, ok = resolve_generic_function(ast_context, v^)
-
-				//If we are not overloading just show the unresolved generic function
-				if !ok && !ast_context.overloading {
-					return_symbol, ok =
-						make_symbol_procedure_from_ast(
-							ast_context,
-							global.expr,
-							v.type^,
-							node,
-							global.attributes,
-							false,
-							v.inlining,
-						),
-						true
-				}
-			} else {
-				return_symbol, ok =
-					make_symbol_procedure_from_ast(
-						ast_context,
-						global.expr,
-						v.type^,
-						node,
-						global.attributes,
-						false,
-						v.inlining,
-					),
-					true
-			}
-		case ^Proc_Group:
-			return_symbol, ok = resolve_function_overload(ast_context, v^)
-		case ^Array_Type:
-			return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
-		case ^Dynamic_Array_Type:
-			return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
-		case ^Matrix_Type:
-			return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
-		case ^Map_Type:
-			return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
-		case ^Basic_Lit:
-			return_symbol, ok = resolve_basic_lit(ast_context, v^)
-			return_symbol.name = node.name
-			return_symbol.type = global.mutable ? .Variable : .Constant
-		case:
-			return_symbol, ok = internal_resolve_type_expression(ast_context, global.expr)
-		}
-
-		if is_distinct {
-			return_symbol.name = node.name
-			return_symbol.flags |= {.Distinct}
-		}
-
-		if global.mutable {
-			return_symbol.type = .Variable
-		}
-
-		if global.docs != nil {
-			return_symbol.doc = get_doc(global.docs, ast_context.allocator)
-		}
-
-		if global.comment != nil {
-			return_symbol.comment = get_comment(global.comment)
-		}
-
-		return return_symbol, ok
+		return resolve_global_identifier(ast_context, node, &global)
 	} else {
 		switch node.name {
 		case "context":
@@ -1817,6 +1602,228 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 	}
 
 	return Symbol{}, false
+}
+
+resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, local: ^DocumentLocal) -> (Symbol, bool) {
+	is_distinct := false
+
+	if local.parameter {
+		for imp in ast_context.imports {
+			if strings.compare(imp.base, node.name) == 0 {
+				symbol := Symbol {
+					type  = .Package,
+					pkg   = imp.name,
+					value = SymbolPackageValue{},
+				}
+
+				return symbol, true
+			}
+		}
+	}
+
+	if local.pkg != "" {
+		ast_context.current_package = local.pkg
+	}
+
+	//Sometimes the locals are semi resolved and can no longer use the locals
+	if local.resolved_global {
+		ast_context.use_locals = false
+	}
+
+	if dist, ok := local.rhs.derived.(^ast.Distinct_Type); ok {
+		if dist.type != nil {
+			local.rhs = dist.type
+			is_distinct = true
+		}
+	}
+
+	return_symbol: Symbol
+	ok: bool
+
+	#partial switch v in local.rhs.derived {
+	case ^ast.Ident:
+		return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
+	case ^ast.Union_Type:
+		return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Enum_Type:
+		return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Struct_Type:
+		return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node, {}), true
+		return_symbol.name = node.name
+	case ^ast.Bit_Set_Type:
+		return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Bit_Field_Type:
+		return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node), true
+		return_symbol.name = node.name
+	case ^ast.Proc_Lit:
+		if is_procedure_generic(v.type) {
+			return_symbol, ok = resolve_generic_function(ast_context, v^)
+
+			if !ok && !ast_context.overloading {
+				return_symbol, ok =
+					make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining),
+					true
+			}
+		} else {
+			return_symbol, ok =
+				make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining), true
+		}
+	case ^ast.Proc_Group:
+		return_symbol, ok = resolve_function_overload(ast_context, v^)
+	case ^ast.Array_Type:
+		return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
+	case ^ast.Dynamic_Array_Type:
+		return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
+	case ^ast.Matrix_Type:
+		return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
+	case ^ast.Map_Type:
+		return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
+	case ^ast.Basic_Lit:
+		return_symbol, ok = resolve_basic_lit(ast_context, v^)
+		return_symbol.name = node.name
+		return_symbol.type = local.variable ? .Variable : .Constant
+	case ^ast.Binary_Expr:
+		return_symbol, ok = resolve_binary_expression(ast_context, v)
+	case:
+		return_symbol, ok = internal_resolve_type_expression(ast_context, local.rhs)
+	}
+
+	if is_distinct {
+		return_symbol.name = node.name
+		return_symbol.flags |= {.Distinct}
+	}
+
+	if local.parameter {
+		return_symbol.flags |= {.Parameter}
+	}
+
+	if local.variable {
+		return_symbol.type = .Variable
+	}
+
+	return_symbol.flags |= {.Local}
+
+	return return_symbol, ok
+}
+
+resolve_global_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, global: ^GlobalExpr) -> (Symbol, bool) {
+	is_distinct := false
+	ast_context.use_locals = false
+
+	if dist, ok := global.expr.derived.(^ast.Distinct_Type); ok {
+		if dist.type != nil {
+			global.expr = dist.type
+			is_distinct = true
+		}
+	}
+
+	return_symbol: Symbol
+	ok: bool
+
+	#partial switch v in global.expr.derived {
+	case ^ast.Ident:
+		return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
+	case ^ast.Call_Expr:
+		old_call := ast_context.call
+		ast_context.call = cast(^ast.Call_Expr)global.expr
+
+		defer {
+			ast_context.call = old_call
+		}
+
+		if return_symbol, ok = internal_resolve_type_expression(ast_context, v.expr); ok {
+			return_types := get_proc_return_types(ast_context, return_symbol, v, global.mutable)
+			if len(return_types) > 0 {
+				return_symbol, ok = internal_resolve_type_expression(ast_context, return_types[0])
+			}
+			// Otherwise should be a parapoly style
+		}
+
+	case ^ast.Struct_Type:
+		return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node, global.attributes), true
+		return_symbol.name = node.name
+	case ^ast.Bit_Set_Type:
+		return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Union_Type:
+		return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Enum_Type:
+		return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node), true
+		return_symbol.name = node.name
+	case ^ast.Bit_Field_Type:
+		return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node), true
+		return_symbol.name = node.name
+	case ^ast.Proc_Lit:
+		if is_procedure_generic(v.type) {
+			return_symbol, ok = resolve_generic_function(ast_context, v^)
+
+			//If we are not overloading just show the unresolved generic function
+			if !ok && !ast_context.overloading {
+				return_symbol, ok =
+					make_symbol_procedure_from_ast(
+						ast_context,
+						global.expr,
+						v.type^,
+						node,
+						global.attributes,
+						false,
+						v.inlining,
+					),
+					true
+			}
+		} else {
+			return_symbol, ok =
+				make_symbol_procedure_from_ast(
+					ast_context,
+					global.expr,
+					v.type^,
+					node,
+					global.attributes,
+					false,
+					v.inlining,
+				),
+				true
+		}
+	case ^ast.Proc_Group:
+		return_symbol, ok = resolve_function_overload(ast_context, v^)
+	case ^ast.Array_Type:
+		return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
+	case ^ast.Dynamic_Array_Type:
+		return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
+	case ^ast.Matrix_Type:
+		return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
+	case ^ast.Map_Type:
+		return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
+	case ^ast.Basic_Lit:
+		return_symbol, ok = resolve_basic_lit(ast_context, v^)
+		return_symbol.name = node.name
+		return_symbol.type = global.mutable ? .Variable : .Constant
+	case:
+		return_symbol, ok = internal_resolve_type_expression(ast_context, global.expr)
+	}
+
+	if is_distinct {
+		return_symbol.name = node.name
+		return_symbol.flags |= {.Distinct}
+	}
+
+	if global.mutable {
+		return_symbol.type = .Variable
+	}
+
+	if global.docs != nil {
+		return_symbol.doc = get_doc(global.docs, ast_context.allocator)
+	}
+
+	if global.comment != nil {
+		return_symbol.comment = get_comment(global.comment)
+	}
+
+	return return_symbol, ok
 }
 
 struct_type_from_identifier :: proc(ast_context: ^AstContext, node: ast.Ident) -> (^ast.Struct_Type, bool) {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3301,6 +3301,22 @@ get_generic_assignment :: proc(
 								)
 							}
 							return
+						} else if ident, ok := value.return_types[0].type.derived.(^ast.Ident); ok {
+							if symbol, ok := internal_resolve_type_expression(ast_context, ident); ok {
+								if value, ok := symbol.value.(SymbolProcedureValue); ok {
+									for return_item in value.return_types {
+										get_generic_assignment(
+											file,
+											return_item.type,
+											ast_context,
+											results,
+											calls,
+											flags,
+											is_mutable,
+										)
+									}
+								}
+							}
 						}
 					}
 				}

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1193,6 +1193,18 @@ internal_resolve_type_expression :: proc(ast_context: ^AstContext, node: ^ast.Ex
 				ast_context.call = nil
 				return internal_resolve_type_expression(ast_context, v.args[0])
 			}
+		} else if call, ok := v.expr.derived.(^ast.Call_Expr); ok {
+			// handle the case where we immediately call a proc returned by another proc
+			if symbol, ok := internal_resolve_type_expression(ast_context, v.expr); ok {
+				if value, ok := symbol.value.(SymbolProcedureValue); ok {
+					if len(value.return_types) == 1 {
+						return internal_resolve_type_expression(ast_context, value.return_types[0].type)
+					}
+				}
+				return symbol, ok
+			} else {
+				return {}, false
+			}
 		}
 
 		return internal_resolve_type_expression(ast_context, v.expr)

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -2434,7 +2434,7 @@ ast_generic_struct_with_array :: proc(t: ^testing.T) {
 		main :: proc() {
 			test := Test(Test_Inner) {}
 			a := test.values[0]
-			a.{*} 
+			a.{*}
 		}
 		
 		`,
@@ -4174,3 +4174,26 @@ ast_completion_union_with_poly_from_package :: proc(t: ^testing.T) {
 	)
 }
 
+@(test)
+ast_completion_proc_call_param_returned_from_proc :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			data: int,
+		}
+
+		main :: proc() {
+			foo()({{*}})
+		}
+
+		foo :: proc() -> proc(data: Foo) -> bool {
+			return bar
+		}
+
+		bar :: proc(data: Foo) -> bool {
+			return false
+		}
+		`,
+	}
+	test.expect_completion_docs( t, &source, "", {"Foo.data: int"})
+}

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4175,7 +4175,7 @@ ast_completion_union_with_poly_from_package :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_completion_proc_call_param_returned_from_proc :: proc(t: ^testing.T) {
+ast_completion_chained_proc_call_params :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 		Foo :: struct {
@@ -4196,4 +4196,30 @@ ast_completion_proc_call_param_returned_from_proc :: proc(t: ^testing.T) {
 		`,
 	}
 	test.expect_completion_docs( t, &source, "", {"Foo.data: int"})
+}
+
+@(test)
+ast_completion_multiple_chained_call_expr  :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			someData: int,
+		}
+
+		Bazz :: struct {
+			bazz: string,
+		}
+
+		main :: proc() {
+			a := foo()({})({{*}})
+		}
+
+		Bar :: proc(data: Foo) -> Bar2
+
+		Bar2 :: proc(bazz: Bazz) -> int
+
+		foo :: proc() -> Bar {}
+		`,
+	}
+	test.expect_completion_docs( t, &source, "", {"Bazz.bazz: string"})
 }

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3392,6 +3392,34 @@ ast_hover_returned_proc_call_parameter :: proc(t: ^testing.T) {
 		"test.a: bool",
 	)
 }
+
+@(test)
+ast_hover_returned_proc_call_parameter_multiple_return :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			someData: int,
+		}
+
+		main :: proc() {
+			a, b{*} := foo()({})
+		}
+
+		foo :: proc() -> proc(data: Foo) -> (int, bool) {
+			return 1, bar
+		}
+
+		bar :: proc(data: Foo) -> bool {
+			return false
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.b: bool",
+	)
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3364,6 +3364,34 @@ ast_hover_overloaded_proc_with_u8_byte_alias :: proc(t: ^testing.T) {
 		"test.result: []u8",
 	)
 }
+
+@(test)
+ast_hover_returned_proc_call_parameter :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			someData: int,
+		}
+
+		main :: proc() {
+			a{*} := foo()({})
+		}
+
+		foo :: proc() -> proc(data: Foo) -> bool {
+			return bar
+		}
+
+		bar :: proc(data: Foo) -> bool {
+			return false
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.a: bool",
+	)
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3366,7 +3366,7 @@ ast_hover_overloaded_proc_with_u8_byte_alias :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_hover_returned_proc_call_parameter :: proc(t: ^testing.T) {
+ast_hover_chained_proc_call :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 		Foo :: struct {
@@ -3394,7 +3394,7 @@ ast_hover_returned_proc_call_parameter :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_hover_returned_proc_call_parameter_multiple_return :: proc(t: ^testing.T) {
+ast_hover_chained_proc_call_multiple_return :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 		Foo :: struct {
@@ -3406,11 +3406,11 @@ ast_hover_returned_proc_call_parameter_multiple_return :: proc(t: ^testing.T) {
 		}
 
 		foo :: proc() -> proc(data: Foo) -> (int, bool) {
-			return 1, bar
+			return bar
 		}
 
-		bar :: proc(data: Foo) -> bool {
-			return false
+		bar :: proc(data: Foo) -> (int, bool) {
+			return 1, false
 		}
 		`,
 	}
@@ -3419,6 +3419,58 @@ ast_hover_returned_proc_call_parameter_multiple_return :: proc(t: ^testing.T) {
 		&source,
 		"test.b: bool",
 	)
+}
+
+@(test)
+ast_hover_chained_call_expr_with_named_proc_return  :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			someData: int,
+		}
+
+		main :: proc() {
+			a, b{*} := foo()({})
+		}
+
+		Bar :: proc(data: Foo) -> (bool, Foo)
+
+		foo :: proc() -> Bar {
+			return bar
+		}
+
+		bar :: proc(data: Foo) -> (bool, Foo) {
+			return false, data
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.b: test.Foo :: struct {\n\tsomeData: int,\n}")
+}
+
+@(test)
+ast_hover_multipple_chained_call_expr  :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			someData: int,
+		}
+
+		Bazz :: struct {
+			bazz: string,
+		}
+
+		main :: proc() {
+			a{*} := foo()({})({})
+		}
+
+		Bar :: proc(data: Foo) -> Bar2
+
+		Bar2 :: proc(bazz: Bazz) -> int
+
+		foo :: proc() -> Bar {}
+		`,
+	}
+	test.expect_hover(t, &source, "test.a: int")
 }
 /*
 

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3448,7 +3448,7 @@ ast_hover_chained_call_expr_with_named_proc_return  :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_hover_multipple_chained_call_expr  :: proc(t: ^testing.T) {
+ast_hover_multiple_chained_call_expr  :: proc(t: ^testing.T) {
 	source := test.Source {
 		main     = `package test
 		Foo :: struct {


### PR DESCRIPTION
Improves resolution of symbols when immediately calling a proc returned from a proc (eg `a := foo()()`).

In a draft at the moment as I'm not sure it's complete yet, but I'm running into to issues with some tests crashing (`objc_return_type_with_selector_expression_2` and `ast_generic_struct_with_array`) on macos (running them on windows is fine) due to the code around `1199` in `analysis.odin`. The broken tests don't go through the if statement on line `1196` so I'm not sure what's causing them to fail. 

Looks like all the tests pass here 🤔 

Edit: It looks like moving the logic from inside the switch statement to external procs has pretty significantly reduced the amount of stack being used (from ~50kb per function call to ~34kb). Definitely something to keep an eye on when we're dealing with stack overflows