### PR TITLE
Switch to using out params for `internal_resolve_type_expression` to greatly reduce stack used

### DIFF
--- a/src/server/builtins.odin
+++ b/src/server/builtins.odin
@@ -139,7 +139,8 @@ get_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr, is_mutable: b
 		return get_return_expr(ast_context, v.value, is_mutable)
 	}
 	if ident, ok := expr.derived.(^ast.Ident); ok {
-		if symbol, ok := internal_resolve_type_expression(ast_context, ident); ok {
+		symbol := Symbol{}
+		if ok := internal_resolve_type_expression(ast_context, ident, &symbol); ok {
 			if v, ok := symbol.value.(SymbolBasicValue); ok {
 				return v.ident
 			} else if v, ok := symbol.value.(SymbolUntypedValue); ok {
@@ -173,7 +174,8 @@ get_complex_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) -> ^a
 		return get_complex_return_expr(ast_context, v.value)
 	}
 	if ident, ok := expr.derived.(^ast.Ident); ok {
-		if symbol, ok := internal_resolve_type_expression(ast_context, ident); ok {
+		symbol := Symbol{}
+		if ok := internal_resolve_type_expression(ast_context, ident, &symbol); ok {
 			if v, ok := symbol.value.(SymbolBasicValue); ok {
 				return v.ident
 			} else if v, ok := symbol.value.(SymbolUntypedValue); ok {
@@ -204,7 +206,8 @@ get_quaternion_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) ->
 		return get_quaternion_return_expr(ast_context, v.value)
 	}
 	if ident, ok := expr.derived.(^ast.Ident); ok {
-		if symbol, ok := internal_resolve_type_expression(ast_context, ident); ok {
+		symbol := Symbol{}
+		if ok := internal_resolve_type_expression(ast_context, ident, &symbol); ok {
 			if v, ok := symbol.value.(SymbolBasicValue); ok {
 				return v.ident
 			} else if v, ok := symbol.value.(SymbolUntypedValue); ok {


### PR DESCRIPTION
After working on https://github.com/DanielGavin/ols/pull/817 and encountering some issues with certain tests stack overflowing which led to a discussion here https://github.com/odin-lang/Odin/issues/5528, it looks like having large switch statements completely blows out the stack. The worst culprit for us right now is the `internal_resolve_type_expression` function which was adding around 50kb per call (~25kb with `-o:speed`). By using an out parameter for just this function it pretty significantly reduces the amount of stack used (from ~500kb to ~240kb in the tests that were stack overflowing for me).

I could probably add more functions to behave like this, but since this is the main culprit I think we can just make this change here to minimise the impact, as out params aren't exactly the nicest.

I also retested this https://github.com/DanielGavin/ols/issues/578 and with this change (and the other ones in the previous PR) this large file no longer stackoverflows for me.