### PR TITLE
Improve and consolidate resolving implicit selector comp literals

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -889,23 +889,21 @@ get_implicit_completion :: proc(
 					}
 				} else if v, ok := symbol.value.(SymbolStructValue); ok {
 					if position_context.field_value != nil {
-						if field_name, ok := get_field_value_name(position_context.field_value); ok {
-							if symbol, ok := resolve_implicit_selector_comp_literal(ast_context, position_context, symbol, field_name); ok {
-								if enum_value, ok := symbol.value.(SymbolEnumValue); ok {
-									for name in enum_value.names {
-										if position_context.comp_lit != nil && field_exists_in_comp_lit(position_context.comp_lit, name) {
-											continue
-										}
-										item := CompletionItem {
-											label  = name,
-											kind   = .EnumMember,
-											detail = name,
-										}
-										append(results, CompletionResult{completion_item = item})
+						if symbol, ok := resolve_implicit_selector_comp_literal(ast_context, position_context, symbol); ok {
+							if enum_value, ok := symbol.value.(SymbolEnumValue); ok {
+								for name in enum_value.names {
+									if position_context.comp_lit != nil && field_exists_in_comp_lit(position_context.comp_lit, name) {
+										continue
 									}
-
-									return is_incomplete
+									item := CompletionItem {
+										label  = name,
+										kind   = .EnumMember,
+										detail = name,
+									}
+									append(results, CompletionResult{completion_item = item})
 								}
+
+								return is_incomplete
 							}
 						}
 					}
@@ -1030,81 +1028,37 @@ get_implicit_completion :: proc(
 			}
 		}
 	}
+	
+	//infer bitset and enums based on the identifier comp_lit, i.e. a := My_Struct { my_ident = . }
+	if position_context.comp_lit != nil && position_context.parent_comp_lit != nil {
+		if symbol, ok := resolve_comp_literal(ast_context, position_context); ok {
+			if comp_symbol, ok := resolve_implicit_selector_comp_literal(ast_context, position_context, symbol); ok {
+				if enum_value, ok := comp_symbol.value.(SymbolEnumValue); ok {
+					for enum_name in enum_value.names {
+						item := CompletionItem {
+							label  = enum_name,
+							kind   = .EnumMember,
+							detail = enum_name,
+						}
 
-	//infer bitset and enums based on the identifier comp_lit, i.e. a := My_Struct { my_ident = . } 
-	if position_context.comp_lit != nil {
-		if position_context.parent_comp_lit != nil {
-			field_name: string
+						append(results, CompletionResult{completion_item = item})
+					}
 
-			if position_context.field_value != nil {
-				if field, ok := position_context.field_value.field.derived.(^ast.Ident); ok {
-					field_name = field.name
-				} else {
+					return is_incomplete
+				} else if s, ok := unwrap_bitset(ast_context, comp_symbol); ok {
+					for enum_name in s.names {
+						item := CompletionItem {
+							label  = enum_name,
+							kind   = .EnumMember,
+							detail = enum_name,
+						}
+
+						append(results, CompletionResult{completion_item = item})
+					}
+
 					return is_incomplete
 				}
 			}
-
-			if symbol, ok := resolve_comp_literal(ast_context, position_context); ok {
-				if comp_symbol, comp_lit, ok := resolve_type_comp_literal(
-					ast_context,
-					position_context,
-					symbol,
-					position_context.parent_comp_lit,
-				); ok {
-					if s, ok := comp_symbol.value.(SymbolStructValue); ok {
-						set_ast_package_set_scoped(ast_context, comp_symbol.pkg)
-
-						type := get_struct_comp_lit_type(position_context, comp_lit, s, field_name)
-
-						if enum_value, ok := unwrap_enum(ast_context, type); ok {
-							for enum_name in enum_value.names {
-								item := CompletionItem {
-									label  = enum_name,
-									kind   = .EnumMember,
-									detail = enum_name,
-								}
-
-								append(results, CompletionResult{completion_item = item})
-							}
-
-							return is_incomplete
-						} else if bitset_symbol, ok := resolve_type_expression(ast_context, type); ok {
-							set_ast_package_set_scoped(ast_context, bitset_symbol.pkg)
-
-							if value, ok := unwrap_bitset(ast_context, bitset_symbol); ok {
-								for name in value.names {
-
-									item := CompletionItem {
-										label  = name,
-										kind   = .EnumMember,
-										detail = name,
-									}
-
-									append(results, CompletionResult{completion_item = item})
-								}
-								return is_incomplete
-							}
-						}
-					} else {
-						set_ast_package_set_scoped(ast_context, comp_symbol.pkg)
-						if s, ok := unwrap_bitset(ast_context, comp_symbol); ok {
-							for enum_name in s.names {
-								item := CompletionItem {
-									label  = enum_name,
-									kind   = .EnumMember,
-									detail = enum_name,
-								}
-
-								append(results, CompletionResult{completion_item = item})
-							}
-
-							return is_incomplete
-						}
-					}
-				}
-			}
-
-			reset_ast_context(ast_context)
 		}
 	}
 
@@ -1335,55 +1289,6 @@ get_implicit_completion :: proc(
 		}
 	}
 	return is_incomplete
-}
-
-get_struct_comp_lit_type :: proc(
-	position_context: ^DocumentPositionContext,
-	comp_lit: ^ast.Comp_Lit,
-	s: SymbolStructValue,
-	field_name: string,
-) -> ^ast.Expr {
-	elem_index := -1
-
-	for elem, i in comp_lit.elems {
-		if position_in_node(elem, position_context.position) {
-			elem_index = i
-			if field_value, ok := elem.derived.(^ast.Field_Value); ok {
-				// If our field is another comp_lit, check to see if we're actually in that one
-				if cl, ok := field_value.value.derived.(^ast.Comp_Lit); ok {
-					if type :=  get_struct_comp_lit_type(
-						position_context,
-						cl,
-						s,
-						field_name,
-					); type != nil {
-						return type
-					}
-				}
-			}
-		}
-	}
-
-	if elem_index == -1 {
-		return nil
-	}
-
-	type: ^ast.Expr
-
-	for name, i in s.names {
-		if name != field_name {
-			continue
-		}
-
-		type = s.types[i]
-		break
-	}
-
-	if type == nil && len(s.types) > elem_index && elem_index != -1 {
-		type = s.types[elem_index]
-	}
-
-	return type
 }
 
 get_identifier_completion :: proc(

--- a/tests/definition_test.odin
+++ b/tests/definition_test.odin
@@ -12,7 +12,7 @@ ast_goto_bit_set_comp_literal :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		TestEnum :: enum {
-			valueOne, 
+			valueOne,
 			valueTwo,
 		}
 		
@@ -35,7 +35,7 @@ ast_goto_bit_set_index_enumerated_array :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		TestEnum :: enum {
-			valueOne, 
+			valueOne,
 			valueTwo,
 		}
 
@@ -66,12 +66,12 @@ ast_goto_comp_lit_field :: proc(t: ^testing.T) {
         Point :: struct {
             x, y, z : f32,
         }
-        
+
         main :: proc() {
             point := Point {
                 x{*} = 2, y = 5, z = 0,
             }
-        } 
+        }
 		`,
 	}
 
@@ -89,12 +89,12 @@ ast_goto_struct_definition :: proc(t: ^testing.T) {
         Point :: struct {
             x, y, z : f32,
         }
-        
+
         main :: proc() {
             point := Po{*}int {
                 x = 2, y = 5, z = 0,
             }
-        } 
+        }
 		`,
 	}
 
@@ -112,13 +112,13 @@ ast_goto_comp_lit_field_indexed :: proc(t: ^testing.T) {
         Point :: struct {
             x, y, z : f32,
         }
-        
+
         main :: proc() {
             point := [2]Point {
                 {x{*} = 2, y = 5, z = 0},
                 {y = 10, y = 20, z = 10},
             }
-        } 
+        }
 		`,
 	}
 
@@ -577,6 +577,31 @@ ast_goto_param_inside_where_clause :: proc(t: ^testing.T) {
 	}
 	locations := []common.Location {
 		{range = {start = {line = 1, character = 14}, end = {line = 1, character = 15}}},
+	}
+
+	test.expect_definition_locations(t, &source, locations[:])
+}
+
+@(test)
+ast_goto_enum_struct_field_without_name :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+		}
+
+		Bar :: struct {
+			foo: Foo,
+		}
+
+		main :: proc() {
+			bar: Bar = {.A{*}}
+		}
+	`,
+	}
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 3}, end = {line = 2, character = 4}}},
 	}
 
 	test.expect_definition_locations(t, &source, locations[:])

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -1104,3 +1104,28 @@ ast_references_union_switch_type :: proc(t: ^testing.T) {
 	test.expect_reference_locations(t, &source, locations[:])
 }
 
+@(test)
+ast_references_enum_struct_field_without_name :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+		}
+
+		Bar :: struct {
+			foo: Foo,
+		}
+
+		main :: proc() {
+			bar: Bar = {.A{*}}
+		}
+	`,
+	}
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 3}, end = {line = 2, character = 4}}},
+		{range = {start = {line = 11, character = 16}, end = {line = 11, character = 17}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}


### PR DESCRIPTION
Fixes some issues with go-to definition and finding references of enums inside of comp lits. Also consolidates a decent amount of the logic used.