### PR TITLE
Adds hover documentation for enums and unions

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3105,9 +3105,13 @@ make_symbol_union_from_ast :: proc(
 		}
 	}
 
+	docs, comments := get_field_docs_and_comments(ast_context.file, v.variants, ast_context.allocator)
+
 	symbol.value = SymbolUnionValue {
-		types = types[:],
-		poly  = v.poly_params,
+		types    = types[:],
+		poly     = v.poly_params,
+		docs     = docs[:],
+		comments = comments[:],
 	}
 
 	if v.poly_params != nil {

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1274,11 +1274,8 @@ resolve_type_assertion_expr :: proc(ast_context: ^AstContext, v: ^ast.Type_Asser
 						return {}, false
 					}
 
-					if ok := internal_resolve_type_expression(
-						ast_context,
-						proc_value.return_types[0].type,
-						&symbol,
-					); ok {
+					if ok := internal_resolve_type_expression(ast_context, proc_value.return_types[0].type, &symbol);
+					   ok {
 						if union_value, ok := symbol.value.(SymbolUnionValue); ok {
 							if len(union_value.types) != 1 {
 								return {}, false
@@ -1711,8 +1708,7 @@ resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, loca
 
 			if !ok && !ast_context.overloading {
 				return_symbol, ok =
-					make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining),
-					true
+					make_symbol_procedure_from_ast(ast_context, local.rhs, v.type^, node, {}, false, v.inlining), true
 			}
 		} else {
 			return_symbol, ok =
@@ -3152,11 +3148,15 @@ make_symbol_enum_from_ast :: proc(
 		append(&values, value)
 	}
 
+	docs, comments := get_field_docs_and_comments(ast_context.file, v.fields, ast_context.allocator)
+
 	symbol.value = SymbolEnumValue {
 		names     = names[:],
 		ranges    = ranges[:],
 		base_type = v.base_type,
 		values    = values[:],
+		docs      = docs[:],
+		comments  = comments[:],
 	}
 
 	return symbol

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -174,13 +174,16 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 		}
 		strings.write_string(&sb, "{\n")
 		for i in 0 ..< len(v.names) {
+			append_docs(&sb, v.docs, i)
 			strings.write_string(&sb, "\t")
 			strings.write_string(&sb, v.names[i])
 			if i < len(v.values) && v.values[i] != nil {
 				fmt.sbprintf(&sb, "%*s= ", longestNameLen - len(v.names[i]) + 1, "")
 				build_string_node(v.values[i], &sb, false)
 			}
-			strings.write_string(&sb, ",\n")
+			strings.write_string(&sb, ",")
+			append_comments(&sb, v.comments, i)
+			strings.write_string(&sb, "\n")
 		}
 		strings.write_string(&sb, "}")
 		return strings.to_string(sb)

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -216,9 +216,12 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string {
 		}
 		strings.write_string(&sb, " {\n")
 		for i in 0 ..< len(v.types) {
+			append_docs(&sb, v.docs, i)
 			strings.write_string(&sb, "\t")
 			build_string_node(v.types[i], &sb, false)
-			strings.write_string(&sb, ",\n")
+			strings.write_string(&sb, ",")
+			append_comments(&sb, v.comments, i)
+			strings.write_string(&sb, "\n")
 		}
 		strings.write_string(&sb, "}")
 		return strings.to_string(sb)

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -77,6 +77,8 @@ SymbolEnumValue :: struct {
 	values:    []^ast.Expr,
 	base_type: ^ast.Expr,
 	ranges:    []common.Range,
+	docs:      []^ast.Comment_Group,
+	comments:  []^ast.Comment_Group,
 }
 
 SymbolUnionValue :: struct {
@@ -793,7 +795,7 @@ construct_bit_field_field_symbol :: proc(symbol: ^Symbol, parent_name: string, v
 
 construct_enum_field_symbol :: proc(symbol: ^Symbol, value: SymbolEnumValue, index: int) {
 	symbol.type = .Field
-	//symbol.doc = get_doc(value.docs[index], context.temp_allocator)
-	//symbol.comment = get_comment(value.comments[index])
+	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
+	symbol.comment = get_comment(value.comments[index])
 	symbol.signature = get_enum_field_signature(value, index)
 }

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -85,6 +85,8 @@ SymbolUnionValue :: struct {
 	types:      []^ast.Expr,
 	poly:       ^ast.Field_List,
 	poly_names: []string,
+	docs:       []^ast.Comment_Group,
+	comments:   []^ast.Comment_Group,
 }
 
 SymbolDynamicArrayValue :: struct {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3531,6 +3531,47 @@ ast_hover_enum_field_directly :: proc(t: ^testing.T) {
 		"test.Foo: .A\n Doc for A and B\n Mulitple lines!\n\n// comment for A and B"
 	)
 }
+
+@(test)
+ast_hover_union_field_documentation :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		F{*}oo :: union {
+			int, // this is a comment for int
+			// This is a doc for string
+			// across many lines
+			string,
+			i16,
+			// i32 Doc
+			i32,
+			i64, // i64 comment
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: union {\n\tint, // this is a comment for int\n\t// This is a doc for string\n\t// across many lines\n\tstring,\n\ti16,\n\t// i32 Doc\n\ti32,\n\ti64, // i64 comment\n}"
+	)
+}
+
+@(test)
+ast_hover_union_field_documentation_same_line :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		F{*}oo :: union {
+			// Doc for int and string
+			// Mulitple lines!
+			int, string, // comment for int and string
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: union {\n\t// Doc for int and string\n\t// Mulitple lines!\n\tint, // comment for int and string\n\t// Doc for int and string\n\t// Mulitple lines!\n\tstring, // comment for int and string\n}"
+	)
+}
 /*
 
 Waiting for odin fix

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3472,6 +3472,65 @@ ast_hover_multiple_chained_call_expr  :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.a: int")
 }
+
+@(test)
+ast_hover_enum_field_documentation :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		F{*}oo :: enum {
+			A = 1, // this is a comment for A
+			// This is a doc for B
+			// across many lines
+			B,
+			C,
+			// D Doc
+			D,
+			E, // E comment
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: enum {\n\tA = 1, // this is a comment for A\n\t// This is a doc for B\n\t// across many lines\n\tB,\n\tC,\n\t// D Doc\n\tD,\n\tE, // E comment\n}"
+	)
+}
+
+@(test)
+ast_hover_enum_field_documentation_same_line :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		F{*}oo :: enum {
+			// Doc for A and B
+			// Mulitple lines!
+			A, B, // comment for A and B
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: enum {\n\t// Doc for A and B\n\t// Mulitple lines!\n\tA, // comment for A and B\n\t// Doc for A and B\n\t// Mulitple lines!\n\tB, // comment for A and B\n}"
+	)
+}
+
+@(test)
+ast_hover_enum_field_directly :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: enum {
+			// Doc for A and B
+			// Mulitple lines!
+			A{*}, B, // comment for A and B
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.Foo: .A\n Doc for A and B\n Mulitple lines!\n\n// comment for A and B"
+	)
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Adds documentation to hover  information for enum fields and union variants to behave similarly to structs and bit fields.

The odin parser doesn't provide this information in the ast, so I've just manually constructed it from the file comments (we basically do the same thing for structs and bit fields anyways due to bugs in the parser).

<img width="1118" height="536" alt="image" src="https://github.com/user-attachments/assets/0579f767-c780-453b-bf58-0e5c826f367c" />

I think for now a lot of the enum completions and added manually so I suspect the information won't be there yet, though once that all gets updated to use symbols it should automatically be included.

Resolves https://github.com/DanielGavin/ols/issues/761