### PR TITLE
Resolve poly type variables

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1168,6 +1168,8 @@ internal_resolve_type_expression :: proc(ast_context: ^AstContext, node: ^ast.Ex
 		if v.specialization != nil {
 			return internal_resolve_type_expression(ast_context, v.specialization, out)
 		}
+		out^ = make_symbol_poly_type_from_ast(ast_context, v.type)
+		return true
 
 	case:
 		log.warnf("default node kind, internal_resolve_type_expression: %v", v)
@@ -3090,6 +3092,20 @@ make_symbol_basic_type_from_ast :: proc(ast_context: ^AstContext, n: ^ast.Ident)
 	}
 
 	symbol.value = SymbolBasicValue {
+		ident = n,
+	}
+
+	return symbol
+}
+
+make_symbol_poly_type_from_ast :: proc(ast_context: ^AstContext, n: ^ast.Ident) -> Symbol {
+	symbol := Symbol {
+		range = common.get_token_range(n^, ast_context.file.src),
+		type  = .Variable,
+		pkg   = get_package_from_node(n^),
+	}
+
+	symbol.value = SymbolPolyTypeValue {
 		ident = n,
 	}
 

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -312,6 +312,11 @@ get_short_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string 
 			build_string_node(v.ident, &sb, false)
 		}
 		return strings.to_string(sb)
+	case SymbolPolyTypeValue:
+		sb := strings.builder_make(ast_context.allocator)
+		fmt.sbprintf(&sb, "%s$", pointer_prefix)
+		build_string_node(v.ident, &sb, false)
+		return strings.to_string(sb)
 	case SymbolBitSetValue:
 		sb := strings.builder_make(ast_context.allocator)
 		fmt.sbprintf(&sb, "%sbit_set[", pointer_prefix)

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -611,7 +611,8 @@ visit_ident :: proc(
 		     SymbolSliceValue,
 		     SymbolMapValue,
 		     SymbolMultiPointerValue,
-		     SymbolBasicValue:
+		     SymbolBasicValue,
+			 SymbolPolyTypeValue:
 			write_semantic_node(builder, ident, .Type, modifiers)
 		case SymbolUntypedValue:
 		// handled by static syntax highlighting

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -135,6 +135,10 @@ SymbolMatrixValue :: struct {
 	expr: ^ast.Expr,
 }
 
+SymbolPolyTypeValue :: struct {
+	ident: ^ast.Ident,
+}
+
 /*
 	Generic symbol that is used by the indexer for any variable type(constants, defined global variables, etc),
 */
@@ -161,6 +165,7 @@ SymbolValue :: union {
 	SymbolUntypedValue,
 	SymbolMatrixValue,
 	SymbolBitFieldValue,
+	SymbolPolyTypeValue,
 }
 
 SymbolFlag :: enum {
@@ -640,6 +645,8 @@ free_symbol :: proc(symbol: Symbol, allocator: mem.Allocator) {
 	case SymbolSliceValue:
 		free_ast(v.expr, allocator)
 	case SymbolBasicValue:
+		free_ast(v.ident, allocator)
+	case SymbolPolyTypeValue:
 		free_ast(v.ident, allocator)
 	case SymbolAggregateValue:
 		for symbol in v.symbols {

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4259,3 +4259,17 @@ ast_completion_nested_struct_with_enum_fields_unnamed  :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs( t, &source, "", {"C", "D"}, {"A", "B"})
 }
+
+@(test)
+ast_completion_poly_type :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		foo :: proc(array: $A/[]$T) {
+			for elem, i in array {
+				el{*}
+			}
+		}
+		`,
+	}
+	test.expect_completion_docs( t, &source, "", {"test.elem: $T"})
+}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3572,6 +3572,24 @@ ast_hover_union_field_documentation_same_line :: proc(t: ^testing.T) {
 		"test.Foo: union {\n\t// Doc for int and string\n\t// Mulitple lines!\n\tint, // comment for int and string\n\t// Doc for int and string\n\t// Mulitple lines!\n\tstring, // comment for int and string\n}"
 	)
 }
+
+@(test)
+ast_hover_parapoly_proc_dynamic_array_elems :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		foo :: proc(array: $A/[dynamic]^$T) {
+			for e{*}lem, i in array {
+
+			}
+		}
+		`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.elem: ^$T"
+	)
+}
 /*
 
 Waiting for odin fix

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -1129,3 +1129,22 @@ ast_references_enum_struct_field_without_name :: proc(t: ^testing.T) {
 
 	test.expect_reference_locations(t, &source, locations[:])
 }
+
+@(test)
+ast_references_poly_type :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		foo :: proc(array: $A/[dynamic]^$T) {
+			for e{*}lem, i in array {
+				elem
+			}
+		}
+	`,
+	}
+	locations := []common.Location {
+		{range = {start = {line = 2, character = 7}, end = {line = 2, character = 11}}},
+		{range = {start = {line = 3, character = 4}, end = {line = 3, character = 8}}},
+	}
+
+	test.expect_reference_locations(t, &source, locations[:])
+}


### PR DESCRIPTION
Resolves poly type variables. 

Before in this example
```odin
foo :: proc(a: $T) {
}
```
within `foo` you would have no information (hover, completion, etc) for `a`, now it should all work correctly.