### PR TITLE
Check for updates in the vscode extension asynchronously

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -7,7 +7,7 @@
 		"type": "git",
 		"url": "git://github.com/DanielGavin/ols.git"
 	},
-	"version": "0.1.37",
+	"version": "0.1.39",
 	"engines": {
 		"vscode": "^1.96.0"
 	},


### PR DESCRIPTION
Basically rather than checking for updates inline when starting the extension, we just check it without blocking the start of the lsp.

The problem was when people would hide the notification, it would sit waiting for them to respond before moving forward. This should mean that it'll always run and only update if they confirm.

We could also implement a setting now that would allow people to specify how often they want to check for the nightly updates since some people seem to be annoyed by the popup every day.

I did some basic testing on my end and it seemed good but should have another person try it out. I tested with/without updates available, and also a completely fresh install and it seemed to work fine.

Helps resolve https://github.com/DanielGavin/ols/issues/825