### PR TITLE
Run the nightly release once a week

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 2 * * *
+    - cron: 0 2 * * 0
 
 jobs:
   dist-arm64-darwin:


### PR DESCRIPTION
It seems to be a common complaint amongst vscode users that they're prompted to update the binary every day. This will simple make the automated "nightly" release once per week (I've set it to sunday arbitrarily). For those who want the more frequent updates, they could always build it themselves. Maybe in the longer term we could have mulitple release tags that people could use instead.
