### PR TITLE
Remove incorrectly added doc comments from symbols

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1861,7 +1861,7 @@ resolve_global_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, glo
 	}
 
 	if global.docs != nil {
-		return_symbol.doc = get_doc(global.docs, ast_context.allocator)
+		return_symbol.doc = get_doc(global.name_expr, global.docs, ast_context.allocator)
 	}
 
 	if global.comment != nil {

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -644,7 +644,7 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 		symbol.range = common.get_token_range(expr.name_expr, file.src)
 		symbol.name = get_index_unique_string(collection, name)
 		symbol.type = token_type
-		symbol.doc = get_doc(expr.docs, collection.allocator)
+		symbol.doc = get_doc(expr.name_expr, expr.docs, collection.allocator)
 		symbol.uri = get_index_unique_string(collection, uri)
 		comment, _ := get_file_comment(file, symbol.range.start.line + 1)
 		symbol.comment = strings.clone(get_comment(comment), collection.allocator)

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -787,7 +787,7 @@ construct_struct_field_symbol :: proc(symbol: ^Symbol, parent_name: string, valu
 	symbol.name = value.names[index]
 	symbol.pkg = parent_name
 	symbol.type = .Field
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
+	symbol.doc = get_doc(value.types[index], value.docs[index], context.temp_allocator)
 	symbol.comment = get_comment(value.comments[index])
 }
 
@@ -797,14 +797,14 @@ construct_bit_field_field_symbol :: proc(symbol: ^Symbol, parent_name: string, v
 	symbol.name = value.names[index]
 	symbol.pkg = parent_name
 	symbol.type = .Field
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
+	symbol.doc = get_doc(value.types[index], value.docs[index], context.temp_allocator)
 	symbol.comment = get_comment(value.comments[index])
 	symbol.signature = get_bit_field_field_signature(value, index)
 }
 
 construct_enum_field_symbol :: proc(symbol: ^Symbol, value: SymbolEnumValue, index: int) {
 	symbol.type = .Field
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
+	symbol.doc = get_doc(nil, value.docs[index], context.temp_allocator)
 	symbol.comment = get_comment(value.comments[index])
 	symbol.signature = get_enum_field_signature(value, index)
 }

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3584,11 +3584,19 @@ ast_hover_parapoly_proc_dynamic_array_elems :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(
-		t,
-		&source,
-		"test.elem: ^$T"
-	)
+	test.expect_hover(t, &source, "test.elem: ^$T")
+}
+
+@(test)
+ast_hover_shouldnt_add_docs_with_newline :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		// Not a doc for Foo
+
+		F{*}oo :: struct {}
+		`,
+	}
+	test.expect_hover(t, &source, "test.Foo: struct {}")
 }
 /*
 


### PR DESCRIPTION
Currently the odin parser will add comments that are above the symbol even if there is an empty line between the comment and the symbol. This leads to noisy and irrelevant doc comments on certain symbols. For example:
<img width="842" height="474" alt="image" src="https://github.com/user-attachments/assets/7253ba6a-0e80-416a-aeb8-708bfbb12f3f" />

After a brief discussion on the discord, this is a bug with the odin parser. Whilst that gets resolved, we can easily do a quick check when parsing the comment to determine if it's actually the documentation for the symbol.

After:
<img width="783" height="305" alt="image" src="https://github.com/user-attachments/assets/dd0fc04b-4992-4756-8f44-717bd8e68d40" />

This would still potentially group incorrect comments, but it should help reduce the noise and it's a pretty simple check to do.