### PR TITLE
Correct odin problemMatcher and add odin-unix

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -137,11 +137,21 @@
 			{
 				"name": "odin",
 				"owner": "odin",
-				"fileLocation": [
-					"absolute"
-				],
+				"fileLocation": "absolute",
 				"pattern": {
-					"regexp": "^(.+)\\(([0-9]+)\\:([0-9]+)\\) ([^:]+)(.+)$",
+					"regexp": "^(.+)\\((\\d+):(\\d+)\\) (Error|Warning): (.+)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"severity": 4,
+					"message": 5
+				}
+			}, {
+				"name": "odin-unix",
+				"owner": "odin",
+				"fileLocation": "absolute",
+				"pattern": {
+					"regexp": "^(.+):(\\d+):(\\d+): (Error|Warning): (.+)$",
 					"file": 1,
 					"line": 2,
 					"column": 3,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -139,7 +139,7 @@
 				"owner": "odin",
 				"fileLocation": "absolute",
 				"pattern": {
-					"regexp": "^(.+)\\((\\d+):(\\d+)\\) (Error|Warning): (.+)$",
+					"regexp": "^(.+)\\((\\d+):(\\d+)\\) ([^:]+): (.+)$",
 					"file": 1,
 					"line": 2,
 					"column": 3,
@@ -151,7 +151,7 @@
 				"owner": "odin",
 				"fileLocation": "absolute",
 				"pattern": {
-					"regexp": "^(.+):(\\d+):(\\d+): (Error|Warning): (.+)$",
+					"regexp": "^(.+):(\\d+):(\\d+): ([^:]+): (.+)$",
 					"file": 1,
 					"line": 2,
 					"column": 3,


### PR DESCRIPTION
- Correct `$odin` problem matcher to remove ": " from parsed message.
- Add `$odin-unix` matcher for those who use `-error-pos-style:unix`