### PR TITLE
Implement method to resolve poly return types based on the types of local variables

### DIFF
--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -494,6 +494,7 @@ resolve_generic_function_symbol :: proc(
 
 			if symbol, ok := resolve_type_expression(ast_context, call_expr.args[i]); ok {
 				file := strings.trim_prefix(symbol.uri, "file://")
+
 				if file == "" {
 					file = call_expr.args[i].pos.file
 				}
@@ -521,6 +522,10 @@ resolve_generic_function_symbol :: proc(
 						}
 					}
 				}
+
+				// We set the offset so we can find it as a local if it's based on the type of a local var
+				symbol_expr.pos.offset = call_expr.pos.offset
+				symbol_expr.end.offset = call_expr.end.offset
 
 				symbol_expr = clone_expr(symbol_expr, ast_context.allocator, nil)
 				param_type := clone_expr(param.type, ast_context.allocator, nil)

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -773,6 +773,10 @@ symbol_to_expr :: proc(symbol: Symbol, file: string, allocator := context.temp_a
 	case SymbolBitFieldValue:
 		type := new_type(ast.Bit_Field_Type, pos, end, allocator)
 		return type
+	case SymbolMultiPointerValue:
+		type := new_type(ast.Multi_Pointer_Type, pos, end, allocator)
+		type.elem = v.expr
+		return type
 	case:
 		return nil
 	}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3590,6 +3590,41 @@ ast_hover_parapoly_proc_dynamic_array_elems :: proc(t: ^testing.T) {
 		"test.elem: ^$T"
 	)
 }
+
+@(test)
+ast_hover_parapoly_proc_slice_param :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		foo :: proc(x: $T) -> T {
+			return x
+		}
+
+		main :: proc() {
+			x : []u8
+			b{*}ar := foo(x)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.bar: []u8")
+}
+
+@(test)
+ast_hover_parapoly_proc_multi_pointer_param :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		foo :: proc(x: ^$T) -> ^T {
+			return x
+		}
+
+
+		main :: proc() {
+			x : [^]u8
+			b{*}ar := foo(x)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.bar: ^[^]u8")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Would resolve https://github.com/DanielGavin/ols/issues/836

Basically it wouldn't check the locals for finding the returned type. It now should do that correctly. I did have a look at this case 

```odin
package main

import "core:fmt"
Foo :: struct{
	x: int,
}

foo :: proc() -> Foo {
	return Foo{}
}

main :: proc() {
	Foo :: struct {
		x: string,
	}
	result := foo()
	fmt.println(typeid_of(type_of(result.x)))
}
```

and it seems to incorrectly resolve to the local `Foo` both with and without these changes.