### PR TITLE
Enable references by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
 
 `enable_format`: Turns on formatting with `odinfmt`. _(Enabled by default)_
 
-`enable_hover`: Enables hover feature
+`enable_hover`: Enables hover feature. _(Enabled by default)_
 
 `enable_snippets`: Turns on builtin snippets
 
@@ -86,11 +86,9 @@ Options:
 
 `enable_procedure_snippet`: Use snippets when completing procedures—adds parenthesis after the name. _(Enabled by default)_
 
-`enable_checker_only_saved`: Turns on only calling the checker on the package being saved. 
+`enable_checker_only_saved`: Turns on only calling the checker on the package being saved.
 
-`enable_references`: Turns on finding references for a symbol.  (Experimental)
-
-`enable_rename`: Turns on renaming a symbol. (Experimental)
+`enable_references`: Turns on finding references for a symbol. _(Enabled by default)_
 
 `odin_command`: Allows you to specify your Odin location, instead of just relying on the environment path.
 

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -27,7 +27,6 @@ Config :: struct {
 	enable_procedure_context:          bool,
 	enable_snippets:                   bool,
 	enable_references:                 bool,
-	enable_rename:                     bool,
 	enable_label_details:              bool,
 	enable_std_references:             bool,
 	enable_import_fixer:               bool,

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -368,8 +368,6 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 	config.verbose = ols_config.verbose.(bool) or_else config.verbose
 	config.file_log = ols_config.file_log.(bool) or_else config.file_log
 
-	config.enable_rename = ols_config.enable_rename.(bool) or_else config.enable_rename
-
 	config.enable_procedure_snippet =
 		ols_config.enable_procedure_snippet.(bool) or_else config.enable_procedure_snippet
 
@@ -599,8 +597,7 @@ request_initialize :: proc(
 	config.enable_semantic_tokens = false
 	config.enable_procedure_context = false
 	config.enable_snippets = false
-	config.enable_references = false
-	config.enable_rename = false
+	config.enable_references = true
 	config.verbose = false
 	config.file_log = false
 	config.odin_command = ""

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -413,7 +413,6 @@ OlsConfig :: struct {
 	enable_inlay_hints_params:         Maybe(bool),
 	enable_inlay_hints_default_params: Maybe(bool),
 	enable_references:                 Maybe(bool),
-	enable_rename:                     Maybe(bool),
 	enable_fake_methods:               Maybe(bool),
 	enable_procedure_snippet:          Maybe(bool),
 	enable_checker_only_saved:         Maybe(bool),


### PR DESCRIPTION
We've had a few people recently who have been unaware that references exist for the project. Since it's relatively stable now, and it's kind of an opt-in feature anyways I figured it would be good to just make it opt-out.

I also cleaned up some config that wasn't actually used.