### PR TITLE
Remove functions, consts, variables and fields when in struct definitions

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -4477,6 +4477,21 @@ position_in_proc_decl :: proc(position_context: ^DocumentPositionContext) -> boo
 	return false
 }
 
+position_in_struct_decl :: proc(position_context: ^DocumentPositionContext) -> bool {
+	if position_context.value_decl == nil {
+		return false
+	}
+
+	if len(position_context.value_decl.values) != 1 {
+		return false
+	}
+
+	if _, ok := position_context.value_decl.values[0].derived.(^ast.Struct_Type); ok {
+		return true
+	}
+
+	return false
+}
 
 is_lhs_comp_lit :: proc(position_context: ^DocumentPositionContext) -> bool {
 	if position_context.position <= position_context.comp_lit.open.offset {

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -236,6 +236,13 @@ convert_completion_results :: proc(
 			continue
 		}
 
+		if position_in_struct_decl(position_context) {
+			to_skip: bit_set[SymbolType] = {.Function, .Variable, .Constant, .Field}
+			if result.symbol.type in to_skip {
+				continue
+			}
+		}
+
 		if result.snippet.insert != "" {
 			item := CompletionItem {
 				label            = result.symbol.name,

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -254,7 +254,7 @@ expect_completion_docs :: proc(
 
 	for expect_exclude in expect_excluded {
 		for completion in completion_list.items {
-			if expect_exclude == completion.detail {
+			if expect_exclude == get_doc(completion.documentation) {
 				log.errorf("Expected completion label %v to not be included", expect_exclude)
 			}
 		}

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4323,3 +4323,23 @@ ast_completion_proc_variadiac_arg :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs( t, &source, "", {"test.Foo: enum {..}"})
 }
+
+@(test)
+ast_completion_within_struct_decl :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: enum {
+			A,
+			B,
+			C,
+		}
+
+		foo :: proc(f: Foo) {}
+
+		Bar :: struct {
+			bar: f{*}
+		}
+		`,
+	}
+	test.expect_completion_docs( t, &source, "", {"test.Foo: enum {..}"}, {"test.foo: proc(f: Foo)"})
+}


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/846