### PR TITLE
Fix issue with vscode extension incorrectly concatenating paths when using `odin_command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Options:
 
 `enable_references`: Turns on finding references for a symbol. _(Enabled by default)_
 
-`odin_command`: Allows you to specify your Odin location, instead of just relying on the environment path.
+`odin_command`: Specify the location to your Odin executable, rather than relying on the environment path.
 
 `checker_args`: Pass custom arguments to `odin check`.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -7,7 +7,7 @@
 		"type": "git",
 		"url": "git://github.com/DanielGavin/ols.git"
 	},
-	"version": "0.1.39",
+	"version": "0.1.40",
 	"engines": {
 		"vscode": "^1.96.0"
 	},

--- a/editors/vscode/src/toolchain.ts
+++ b/editors/vscode/src/toolchain.ts
@@ -1,19 +1,15 @@
-import * as vscode from "vscode";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 
-import { execute, log, memoize } from './util';
+import { memoize } from './util';
 import { Config } from "./config";
 
 export function isOdinInstalled(config: Config): boolean {
-	return vscode.workspace.workspaceFolders?.some(folder => {
-		if (config.odinCommand) {
-			let command = path.isAbsolute(config.odinCommand) ? config.odinCommand :
-				path.join(folder.uri.fsPath, config.odinCommand);
-			return isFile(command) && fs.existsSync(command);
-		}
-	}) || getPathForExecutable("odin") !== "";
+	if (config.odinCommand) {
+		return true
+	}
+	return getPathForExecutable("odin") !== "";
 }
 
 export const getPathForExecutable = memoize(
@@ -57,14 +53,4 @@ function lookupInPath(exec: string): string | undefined {
 	}
 
 	return undefined;
-}
-
-function isFile(suspectPath: string): boolean {
-	// It is not mentionned in docs, but `statSync()` throws an error when
-	// the path doesn't exist
-	try {
-		return fs.statSync(suspectPath).isFile();
-	} catch {
-		return false;
-	}
 }

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -78,7 +78,7 @@
 		"file_log": { "type": "boolean" },
 		"odin_command": {
 			"type": "string",
-			"description": "Allows you to specify your Odin location, instead of just relying on the environment path."
+			"description": "Specify the location to your Odin executable, rather than relying on the environment path."
 		},
 		"checker_args": {
 			"type": "string",


### PR DESCRIPTION
Basically the nodejs `path.isAbsolute` treats basically anything that does start with `/` (or equivalent on windows) as a relative path, meaning if you were to set your odin command to something like `odin_command: "$HOME/odin"` or `odin_command: "~/odin"`, it would be concatenated into something like `<path_to_vscode_workspace>/$HOME/odin` and fail to be found.

This basically means that unless you were to very explicitly provide the absolute path, it would not for vscode (though everything would be fine with `ols`)

I also don't think this check is really that valuable in any case, as if they're explicitly specifying the `odin_command` and it doesn't exist, they'll receive errors from `ols` when it tries to call it.

Resolves https://github.com/DanielGavin/ols/issues/350