### PR TITLE
Add configuration option to allow overriding `ODIN_ROOT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Options:
 
 `odin_command`: Allows you to specify your Odin location, instead of just relying on the environment path.
 
+`odin_root_override`: Allows you to specify a custom `ODIN_ROOT` that `ols` will use to look for `odin` core libraries when implementing custom runtimes.
+
 `checker_args`: Pass custom arguments to `odin check`.
 
 `verbose`: Logs warnings instead of just errors.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Example of `ols.json`:
 }
 ```
 
-You can also set `ODIN_ROOT` environment variable to the path where ols should look for core and vendor libraries.
-
 Options:
 
 `enable_format`: Turns on formatting with `odinfmt`. _(Enabled by default)_

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -80,6 +80,10 @@
 			"type": "string",
 			"description": "Allows you to specify your Odin location, instead of just relying on the environment path."
 		},
+		"odin_root_override": {
+			"type": "string",
+			"description": "Allows you to specify a custom `ODIN_ROOT` that `ols` will use to look for `odin` core libraries when implementing custom runtimes."
+		},
 		"checker_args": {
 			"type": "string",
 			"description": "Pass custom arguments to `odin check`."

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -38,6 +38,7 @@ Config :: struct {
 	thread_count:                      int,
 	file_log:                          bool,
 	odin_command:                      string,
+	odin_root_override:                string,
 	checker_args:                      string,
 	checker_targets:                   []string,
 	client_name:                       string,

--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -58,17 +58,24 @@ resolve_home_dir :: proc(
 	when ODIN_OS == .Windows {
 		return path, false
 	} else {
-		if !strings.has_prefix(path, "~") {
-			return path, false
-		}
+		if strings.has_prefix(path, "~") {
+			home := os.get_env("HOME", context.temp_allocator)
+			if home == "" {
+				log.error("could not find $HOME in the environment to be able to resolve ~ in collection paths")
+				return path, false
+			}
 
-		home := os.get_env("HOME", context.temp_allocator)
-		if home == "" {
-			log.error("could not find $HOME in the environment to be able to resolve ~ in collection paths")
-			return path, false
-		}
+			return filepath.join({home, path[1:]}, allocator), true
+		} else if strings.has_prefix(path, "$HOME") {
+			home := os.get_env("HOME", context.temp_allocator)
+			if home == "" {
+				log.error("could not find $HOME in the environment to be able to resolve $HOME in collection paths")
+				return path, false
+			}
 
-		return filepath.join({home, path[1:]}, allocator), true
+			return filepath.join({home, path[5:]}, allocator), true
+		}
+		return path, false
 	}
 }
 

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -421,6 +421,7 @@ OlsConfig :: struct {
 	verbose:                           Maybe(bool),
 	file_log:                          Maybe(bool),
 	odin_command:                      string,
+	odin_root_override:                string,
 	checker_args:                      string,
 	checker_targets:                   []string,
 	profiles:                          [dynamic]common.ConfigProfile,


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/832

Should allow a user to specify where they want `ols` to look for the core libraries. Setting `$ODIN_ROOT` also doesn't work anymore as it's only used as a backup if it can't find the directory using `odin root`.