### PR TITLE
Fix crash on accessing nil arg type pointer

### DIFF
--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -567,8 +567,10 @@ get_proc_arg_type_from_index :: proc(value: SymbolProcedureValue, parameter_inde
 	index := 0
 	for arg in value.arg_types {
 		// We're in a variadic arg, so return true
-		if _, ok := arg.type.derived.(^ast.Ellipsis); ok {
-			return arg, true
+		if arg.type != nil {
+			if _, ok := arg.type.derived.(^ast.Ellipsis); ok {
+				return arg, true
+			}
 		}
 		for name in arg.names {
 			if index == parameter_index {


### PR DESCRIPTION
Fixes this:
```odin
import "core:encoding/json"

main :: proc () {

	src: []byte
	data: struct {}

	json.unmarshal(src, &data, /* type .JSON5 */, context.allocator)
}
```