### PR TITLE
Remove space when formatting empty struct literals used as values

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1617,8 +1617,11 @@ visit_expr :: proc(
 
 
 		if v.fields != nil && len(v.fields.list) == 0 {
-
-			document = cons_with_nopl(document, text("{"))
+			if called_from == .Generic {
+				document = cons(document, text("{"))
+			} else {
+				document = cons_with_nopl(document, text("{"))
+			}
 
 			if contains_comments_in_range(p, v.pos, v.end) {
 				comments, _ := visit_comments(p, v.end)


### PR DESCRIPTION
Similarly to go, odin allows you to have empty struct literals which can be used as zero sized values:

```odin
m: map[int]struct{}
m[0] = struct{}{}

foo := struct{}{}
``` 

Right now these are formatted as
```odin
m: map[int]struct {}
m[0] = struct {}{}

foo := struct {}{}
```

similar to how they are formatted for struct declarations.

This change just removes that space when we aren't declaring a struct. Not strongly attached to this or anything if we want to keep it simple and just always keep the space.