### PR TITLE
Correctly render hover information for maps with empty struct values

### DIFF
--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -4009,6 +4009,16 @@ ast_hover_proc_overloads_arrays :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.n3: [3]f32")
 }
+
+@(test)
+ast_hover_map_empty_struct_literal :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		m{*}: map[int]struct{}
+		`,
+	}
+	test.expect_hover(t, &source, "test.m: map[int]struct {}")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Currently the hover information when using an empty struct for a map value is missing the value information:
<img width="235" height="81" alt="image" src="https://github.com/user-attachments/assets/ef5cc74e-31d1-4333-8826-87fd7b72ef75" />

This just adds the missing `struct {}`