### PR TITLE
Copy the users ols.json to the new folder when updating the binary with vscode

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -426,6 +426,9 @@ async function checkForUpdates(config: Config, state: PersistentState, required:
 		fs.chmod(latestExecutable, 0o755);
 	}
 
+	const prevFolder = getDestFolder(config, state.releaseId)
+	await fs.copyFile(`${prevFolder}/ols.json`, `${latestDestFolder}/ols.json`)
+
 	await state.updateServerVersion(config.package.version);
 	await state.updateReleaseId(release.id);
 	await state.updateLastCheck(Date.now());


### PR DESCRIPTION
Currently the vscode extension works by creating a new folder to put the ols files into. This means the global user configuation for `ols.json` won't be used anymore as it's not copied over into the new folder. This just copies the `ols.json` file to the new folder when we do an update

Resolves https://github.com/DanielGavin/ols/issues/757