### PR TITLE
Remove trailing whitespace when using Allman style braces

### DIFF
--- a/src/odin/printer/document.odin
+++ b/src/odin/printer/document.odin
@@ -446,6 +446,10 @@ format :: proc(width: int, list: ^[dynamic]Tuple, builder: ^strings.Builder, p: 
 		case Document_Newline:
 			if v.amount > 0 {
 				flush_line_suffix(builder, &suffix_builder)
+				// ensure we strip any misplaced trailing whitespace
+				for builder.buf[len(builder.buf)-1] == ' ' {
+					pop(&builder.buf)
+				}
 				for i := 0; i < v.amount; i += 1 {
 					strings.write_string(builder, p.newline)
 				}

--- a/tools/odinfmt/tests/allman/.snapshots/switch.odin
+++ b/tools/odinfmt/tests/allman/.snapshots/switch.odin
@@ -1,16 +1,16 @@
 package allman
 
-main :: proc() 
+main :: proc()
 {
 	num := 1
 
-	switch num 
+	switch num
 	{
 	case 0:
 	case 1:
 	}
 
-	switch num 
+	switch num
 	{
 	case 0:
 	case 1:

--- a/tools/odinfmt/tests/allman/.snapshots/when.odin
+++ b/tools/odinfmt/tests/allman/.snapshots/when.odin
@@ -1,10 +1,10 @@
 package allman
 
-main :: proc() 
+main :: proc()
 {
 	TEST_BOOL := false
 
-	when TEST_BOOL 
+	when TEST_BOOL
 	{
 	}
 }


### PR DESCRIPTION
When working on the fix for the allman style braces in the formatter, I noticed that it would some whitespace before the new lines, eg

```odin
Foo :: struct <-- whitespace here
{ 
}
```

I had a brief look at how it built the document, and it seemed like the whitespace was generally placed before we check the brace style and insert the newline (though I could be wrong there, I'm not very familiar with the formatting code).

Rather than trying to rework how the document itself is built, I figured an easy and quick option was to just check for trailing newlines when we're actually printing the document. I tested it out with various files across `ols` and it seemed to format it all correctly without any trailing whitespace.