### PR TITLE
Stop the ols binary before updating for vscode

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -7,7 +7,7 @@
 		"type": "git",
 		"url": "git://github.com/DanielGavin/ols.git"
 	},
-	"version": "0.1.40",
+	"version": "0.1.41",
 	"engines": {
 		"vscode": "^1.96.0"
 	},

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -61,9 +61,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		throw new Error(message);
 	});
 
-	checkForUpdates(config, state, false)
-
-
 	const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 
 	if (workspaceFolder === undefined) {
@@ -188,6 +185,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	client.start();
+
+	checkForUpdates(config, state, false)
 
 	watchOlsConfigFile(ctx, projectConfigPath);
 }
@@ -419,6 +418,7 @@ async function checkForUpdates(config: Config, state: PersistentState, required:
 		await fs.mkdir(latestDestFolder)
 	}
 
+	await vscode.commands.executeCommand("ols.stop")
 	zip.extractAllTo(latestDestFolder, true);
 
 	const ext = getExt()


### PR DESCRIPTION
Someone was having an issue on the discord where on windows vscode was trying to update the ols binary to the same release version that it already was, and since the binary was running it wasn't able update:

```sh
[error] Error: EBUSY: resource busy or locked, open 'c:\Users\<user>\AppData\Roaming\Code\User\globalStorage\danielgavin.ols\238818481\ols-x86_64-pc-windows-msvc.exe'
    at Object.openSync (node:original-fs:562:18)
    at Utils.writeFileTo (c:\Users\<user>\.vscode\extensions\danielgavin.ols-0.1.40\node_modules\adm-zip\util\utils.js:80:22)
    at c:\Users\<user>\.vscode\extensions\danielgavin.ols-0.1.40\node_modules\adm-zip\adm-zip.js:616:27
    at Array.forEach (<anonymous>)
    at Object.extractAllTo (c:\Users\<user>\.vscode\extensions\danielgavin.ols-0.1.40\node_modules\adm-zip\adm-zip.js:604:26)
    at checkForUpdates (c:\Users\<user>\.vscode\extensions\danielgavin.ols-0.1.40\out\extension.js:304:9)
```

I'm not sure why it thinks it needs to update if it already has that version, but just to handle these weird scenarios we can just stop the binary before extracting the files.

I've also moved the `checkForUpdates` call to happen after we have registered the commands as I have no idea what would happen if we have an edge case where we call the `executeCommand` before it is registered.