### PR TITLE
Add bitset completions for `in` and `not_in`

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -788,6 +788,32 @@ get_selector_completion :: proc(
 					},
 				},
 			)
+			in_text := fmt.tprintf(".%s in %s", name, selector.name)
+			append(
+				results,
+				CompletionResult {
+					completion_item = CompletionItem {
+						label = fmt.tprintf(".%s in", name),
+						kind = .EnumMember,
+						detail = in_text,
+						insertText = in_text,
+						additionalTextEdits = additionalTextEdits,
+					},
+				},
+			)
+			not_in_text := fmt.tprintf(".%s not_in %s", name, selector.name)
+			append(
+				results,
+				CompletionResult {
+					completion_item = CompletionItem {
+						label = fmt.tprintf(".%s not_in", name),
+						kind = .EnumMember,
+						detail = not_in_text,
+						insertText = not_in_text,
+						additionalTextEdits = additionalTextEdits,
+					},
+				},
+			)
 		}
 
 	case SymbolStructValue:


### PR DESCRIPTION

<img width="389" height="192" alt="image" src="https://github.com/user-attachments/assets/e62f0ac0-5a8b-400d-80ea-0a81c0a3d150" />


Resolves https://github.com/DanielGavin/ols/issues/274