### PR TITLE
Handle pointers when passing variables to procedure arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Options:
 
 `enable_references`: Turns on finding references for a symbol. _(Enabled by default)_
 
+`enable_completion_matching`: Attempt to match types and pointers when passing arguments to procedures. _(Enabled by default)_
+
 `odin_command`: Specify the location to your Odin executable, rather than relying on the environment path.
 
 `odin_root_override`: Allows you to specify a custom `ODIN_ROOT` that `ols` will use to look for `odin` core libraries when implementing custom runtimes.

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -65,10 +65,20 @@
 			"description": "Automatically import packages that aren't in your import on completion",
 			"default": true
 		},
-		"enable_references": { "type": "boolean" },
+		"enable_references": {
+			"type": "boolean",
+			"description": "Turns on finding references for a symbol.",
+			"default": true
+		},
+		"enable_completion_matching": {
+			"type": "boolean",
+			"description": "Attempt to match types and pointers when passing arguments to procedures.",
+			"default": true
+		},
 		"enable_fake_methods": {
 			"type": "boolean",
 			"description": "Turn on fake methods completion."
+			"default": false
 		},
 		"disable_parser_errors": { "type": "boolean" },
 		"verbose": {

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -34,6 +34,7 @@ Config :: struct {
 	enable_procedure_snippet:          bool,
 	enable_checker_only_saved:         bool,
 	enable_auto_import:                bool,
+	enable_completion_matching:        bool,
 	disable_parser_errors:             bool,
 	thread_count:                      int,
 	file_log:                          bool,

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -408,12 +408,7 @@ are_symbol_basic_same_keywords :: proc(a, b: Symbol) -> bool {
 	return true
 }
 
-is_symbol_same_typed :: proc(
-	ast_context: ^AstContext,
-	a, b: Symbol,
-	flags: ast.Field_Flags = {},
-	ignore_pointers := false,
-) -> bool {
+is_symbol_same_typed :: proc(ast_context: ^AstContext, a, b: Symbol, flags: ast.Field_Flags = {}) -> bool {
 	// In order to correctly equate the symbols for overloaded functions, we need to check both directions
 	if same, ok := are_symbol_untyped_basic_same_typed(a, b); ok {
 		return same
@@ -428,7 +423,7 @@ is_symbol_same_typed :: proc(
 		return false
 	}
 
-	if !ignore_pointers && a.pointers != b.pointers {
+	if a.pointers != b.pointers {
 		return false
 	}
 

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -318,7 +318,7 @@ convert_completion_results :: proc(
 		}
 
 		if s, ok := symbol.(Symbol); ok && (completion_type == .Selector || completion_type == .Identifier) {
-			handle_pointers(position_context, result.symbol, s, &item, completion_type)
+			handle_pointers(ast_context, position_context, result.symbol, s, &item, completion_type)
 		}
 
 		if common.config.enable_label_details {
@@ -372,6 +372,7 @@ convert_completion_results :: proc(
 
 @(private = "file")
 handle_pointers :: proc(
+	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,
 	result_symbol: Symbol,
 	arg_symbol: Symbol,
@@ -382,6 +383,10 @@ handle_pointers :: proc(
 		if v.ident.name == "any" {
 			return
 		}
+	}
+
+	if !is_symbol_same_typed(ast_context, arg_symbol, result_symbol, ignore_pointers = true) {
+		return
 	}
 
 	diff := result_symbol.pointers - arg_symbol.pointers
@@ -861,7 +866,7 @@ get_selector_completion :: proc(
 					completion_item = CompletionItem {
 						label = fmt.tprintf(".%s", name),
 						kind = .EnumMember,
-						detail = fmt.tprintf("%s.%s", receiver, name),
+						detail = fmt.tprintf("%s.%s", selector.name, name),
 						additionalTextEdits = remove_edit,
 					},
 				},

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -385,7 +385,7 @@ handle_pointers :: proc(
 		}
 	}
 
-	if !is_symbol_same_typed(ast_context, arg_symbol, result_symbol, ignore_pointers = true) {
+	if result_symbol.uri != arg_symbol.uri || result_symbol.range != arg_symbol.range {
 		return
 	}
 

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -385,7 +385,13 @@ handle_pointers :: proc(
 		}
 	}
 
-	if result_symbol.uri != arg_symbol.uri || result_symbol.range != arg_symbol.range {
+	if _, ok := result_symbol.value.(SymbolUntypedValue); ok && arg_symbol.type == .Keyword {
+		if _, ok := are_symbol_untyped_basic_same_typed(arg_symbol, result_symbol); !ok {
+			if _, ok := are_symbol_untyped_basic_same_typed(result_symbol, arg_symbol); !ok {
+				return
+			}
+		}
+	} else if result_symbol.uri != arg_symbol.uri || result_symbol.range != arg_symbol.range {
 		return
 	}
 

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -814,7 +814,9 @@ write_symbol_name :: proc(sb: ^strings.Builder, symbol: Symbol) {
 		fmt.sbprintf(sb, "%v: package", symbol.name)
 		return
 	}
-	if pkg != "" && pkg != "$builtin" {
+	if symbol.parent_name != "" {
+		fmt.sbprintf(sb, "%v.", symbol.parent_name)
+	} else if pkg != "" && pkg != "$builtin" {
 		fmt.sbprintf(sb, "%v.", pkg)
 	}
 	strings.write_string(sb, symbol.name)

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -468,7 +468,7 @@ get_soa_field_hover :: proc(
 	}
 	if symbol, ok := resolve_soa_selector_field(ast_context, selector, expr, size, field); ok {
 		if selector.name != "" {
-			symbol.pkg = selector.name
+			symbol.parent_name = selector.name
 		}
 		symbol.name = field
 		build_documentation(ast_context, &symbol, false)

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -365,6 +365,8 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 		ols_config.enable_procedure_context.(bool) or_else config.enable_procedure_context
 	config.enable_snippets = ols_config.enable_snippets.(bool) or_else config.enable_snippets
 	config.enable_references = ols_config.enable_references.(bool) or_else config.enable_references
+	config.enable_completion_matching =
+		ols_config.enable_completion_matching.(bool) or_else config.enable_completion_matching
 	config.verbose = ols_config.verbose.(bool) or_else config.verbose
 	config.file_log = ols_config.file_log.(bool) or_else config.file_log
 
@@ -612,6 +614,7 @@ request_initialize :: proc(
 	config.enable_procedure_context = false
 	config.enable_snippets = false
 	config.enable_references = true
+	config.enable_completion_matching = true
 	config.verbose = false
 	config.file_log = false
 	config.odin_command = ""
@@ -901,7 +904,7 @@ request_completion :: proc(
 	}
 
 	list: CompletionList
-	list, ok = get_completion_list(document, completition_params.position, completition_params.context_)
+	list, ok = get_completion_list(document, completition_params.position, completition_params.context_, config)
 
 	if !ok {
 		return .InternalError

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -204,19 +204,20 @@ SymbolFlag :: enum {
 SymbolFlags :: bit_set[SymbolFlag]
 
 Symbol :: struct {
-	range:     common.Range, //the range of the symbol in the file
-	uri:       string, //uri of the file the symbol resides
-	pkg:       string, //absolute directory path where the symbol resides
-	name:      string, //name of the symbol
-	doc:       string,
-	comment:   string,
-	signature: string, //type signature
-	type:      SymbolType,
-	type_pkg:  string,
-	type_name: string,
-	value:     SymbolValue,
-	pointers:  int, //how many `^` are applied to the symbol
-	flags:     SymbolFlags,
+	range:       common.Range, //the range of the symbol in the file
+	uri:         string, //uri of the file the symbol resides
+	pkg:         string, //absolute directory path where the symbol resides
+	name:        string, //name of the symbol
+	doc:         string,
+	comment:     string,
+	signature:   string, //type signature
+	type:        SymbolType,
+	parent_name: string, // When symbol is a field, this is the name of the parent symbol it is a field of
+	type_pkg:    string,
+	type_name:   string,
+	value:       SymbolValue,
+	pointers:    int, //how many `^` are applied to the symbol
+	flags:       SymbolFlags,
 }
 
 SymbolType :: enum {
@@ -846,8 +847,8 @@ construct_struct_field_symbol :: proc(symbol: ^Symbol, parent_name: string, valu
 	symbol.type_pkg = symbol.pkg
 	symbol.type_name = symbol.name
 	symbol.name = value.names[index]
-	symbol.pkg = parent_name
 	symbol.type = .Field
+	symbol.parent_name = parent_name
 	symbol.doc = get_doc(value.types[index], value.docs[index], context.temp_allocator)
 	symbol.comment = get_comment(value.comments[index])
 }
@@ -859,7 +860,7 @@ construct_bit_field_field_symbol :: proc(
 	index: int,
 ) {
 	symbol.name = value.names[index]
-	symbol.pkg = parent_name
+	symbol.parent_name = parent_name
 	symbol.type = .Field
 	symbol.doc = get_doc(value.types[index], value.docs[index], context.temp_allocator)
 	symbol.comment = get_comment(value.comments[index])

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -417,6 +417,7 @@ OlsConfig :: struct {
 	enable_procedure_snippet:          Maybe(bool),
 	enable_checker_only_saved:         Maybe(bool),
 	enable_auto_import:                Maybe(bool),
+	enable_completion_matching:        Maybe(bool),
 	disable_parser_errors:             Maybe(bool),
 	verbose:                           Maybe(bool),
 	file_log:                          Maybe(bool),

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -174,7 +174,7 @@ expect_completion_labels :: proc(t: ^testing.T, src: ^Source, trigger_character:
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context)
+	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -202,7 +202,8 @@ expect_completion_labels :: proc(t: ^testing.T, src: ^Source, trigger_character:
 }
 
 expect_completion_docs :: proc(
-	t: ^testing.T, src: ^Source,
+	t: ^testing.T,
+	src: ^Source,
 	trigger_character: string,
 	expect_details: []string,
 	expect_excluded: []string = nil,
@@ -226,7 +227,7 @@ expect_completion_docs :: proc(
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context)
+	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -261,7 +262,12 @@ expect_completion_docs :: proc(
 	}
 }
 
-expect_completion_insert_text :: proc(t: ^testing.T, src: ^Source, trigger_character: string, expect_inserts: []string) {
+expect_completion_insert_text :: proc(
+	t: ^testing.T,
+	src: ^Source,
+	trigger_character: string,
+	expect_inserts: []string,
+) {
 	setup(src)
 	defer teardown(src)
 
@@ -269,7 +275,7 @@ expect_completion_insert_text :: proc(t: ^testing.T, src: ^Source, trigger_chara
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context)
+	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -512,7 +518,8 @@ expect_inlay_hints :: proc(t: ^testing.T, src: ^Source, expected_hints: []server
 		return
 	}
 
-	testing.expectf(t,
+	testing.expectf(
+		t,
 		len(expected_hints) == len(hints),
 		"\nExpected %d inlay hints, but received %d",
 		len(expected_hints),

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4460,7 +4460,7 @@ ast_completion_bit_set_on_struct :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_completions_handle_pointers_basic_types :: proc(t: ^testing.T) {
+ast_completions_handle_matching_basic_types :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 
@@ -4479,7 +4479,7 @@ ast_completions_handle_pointers_basic_types :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_completions_handle_pointers_struct :: proc(t: ^testing.T) {
+ast_completions_handle_matching_struct :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 
@@ -4500,7 +4500,7 @@ ast_completions_handle_pointers_struct :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_completions_handle_pointers_append :: proc(t: ^testing.T) {
+ast_completions_handle_matching_append :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 
@@ -4514,4 +4514,23 @@ ast_completions_handle_pointers_append :: proc(t: ^testing.T) {
 		}
 	}
 	test.expect_completion_insert_text(t, &source, "", {"&foos"})
+}
+
+@(test)
+ast_completions_handle_matching_dynamic_array_to_slice :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		bar :: proc(b: []int)
+
+		main :: proc() {
+			foos: [dynamic]int
+			bar(fo{*})
+		}
+		`,
+		config = {
+			enable_completion_matching = true,
+		}
+	}
+	test.expect_completion_insert_text(t, &source, "", {"foos[:]"})
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -52,12 +52,7 @@ ast_index_array_completion :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -79,12 +74,7 @@ ast_index_dynamic_array_completion :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -106,12 +96,7 @@ ast_struct_pointer_completion :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -134,12 +119,7 @@ ast_struct_take_address_completion :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -162,12 +142,7 @@ ast_struct_deref_completion :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -193,12 +168,7 @@ ast_range_map :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -224,12 +194,7 @@ ast_range_array :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_completion_docs(
-		t,
-		&source,
-		".",
-		{"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"},
-	)
+	test.expect_completion_docs(t, &source, ".", {"My_Struct.one: int", "My_Struct.two: int", "My_Struct.three: int"})
 }
 
 @(test)
@@ -3212,7 +3177,7 @@ ast_completion_on_struct_using_field_selector_directly :: proc(t: ^testing.T) {
 		},
 	)
 	source := test.Source {
-		main = `package main
+		main     = `package main
 		import "my_package"
 
 
@@ -3311,18 +3276,12 @@ ast_completion_multi_pointer_nested :: proc(t: ^testing.T) {
 ast_completion_struct_documentation :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+	append(&packages, test.Package{pkg = "my_package", source = `package my_package
 			My_Struct :: struct {
 			}
-		`,
-		},
-	)
+		`})
 	source := test.Source {
-		main = `package main
+		main     = `package main
 
 		import "my_package"
 
@@ -3440,7 +3399,7 @@ ast_completion_poly_struct_another_package :: proc(t: ^testing.T) {
 		},
 	)
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 		import "my_package"
 
@@ -3478,7 +3437,7 @@ ast_completion_poly_struct_another_package_field :: proc(t: ^testing.T) {
 		},
 	)
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 		import "my_package"
 
@@ -3514,18 +3473,15 @@ ast_completion_poly_proc_mixed_packages :: proc(t: ^testing.T) {
 		}
 		`,
 		},
-		test.Package {
-			pkg = "bar_package",
-			source = `package bar_package
+		test.Package{pkg = "bar_package", source = `package bar_package
 			Bar :: struct {
 				bar: int,
 			}
-		`,
-		},
+		`},
 	)
 
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 		import "foo_package"
 		import "bar_package"
@@ -3879,15 +3835,9 @@ ast_completion_proc_enum_param :: proc(t: ^testing.T) {
 ast_completion_using_aliased_package :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+	append(&packages, test.Package{pkg = "my_package", source = `package my_package
 			foo :: proc() {}
-		`,
-		},
-	)
+		`})
 
 	source := test.Source {
 		main     = `package test
@@ -3910,25 +3860,13 @@ ast_completion_using_aliased_package :: proc(t: ^testing.T) {
 ast_completion_using_aliased_package_multiple :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "foo_pkg",
-			source = `package foo_pkg
+	append(&packages, test.Package{pkg = "foo_pkg", source = `package foo_pkg
 			foo :: proc() {}
-		`,
-		},
-	)
+		`})
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "bar_pkg",
-			source = `package bar_pkg
+	append(&packages, test.Package{pkg = "bar_pkg", source = `package bar_pkg
 			bar :: proc() {}
-		`,
-		},
-	)
+		`})
 
 	source := test.Source {
 		main     = `package test
@@ -4118,7 +4056,7 @@ ast_completion_enum_array_in_proc_param :: proc(t: ^testing.T) {
 @(test)
 ast_completion_union_with_poly :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 
 		Foo :: union($T: typeid) {
 			T,
@@ -4130,12 +4068,7 @@ ast_completion_union_with_poly :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs(
-		t,
-		&source,
-		"",
-		{"test.foo: test.Foo(int)"},
-	)
+	test.expect_completion_docs(t, &source, "", {"test.foo: test.Foo(int)"})
 }
 
 @(test)
@@ -4144,15 +4077,12 @@ ast_completion_union_with_poly_from_package :: proc(t: ^testing.T) {
 
 	append(
 		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+		test.Package{pkg = "my_package", source = `package my_package
 
 			Foo :: union($T: typeid) {
 				T,
 			}
-		`,
-		},
+		`},
 	)
 	source := test.Source {
 		main     = `package test
@@ -4165,18 +4095,13 @@ ast_completion_union_with_poly_from_package :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_completion_docs(
-		t,
-		&source,
-		"",
-		{"test.foo: my_package.Foo(int)"},
-	)
+	test.expect_completion_docs(t, &source, "", {"test.foo: my_package.Foo(int)"})
 }
 
 @(test)
 ast_completion_chained_proc_call_params :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo :: struct {
 			data: int,
 		}
@@ -4194,13 +4119,13 @@ ast_completion_chained_proc_call_params :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"Foo.data: int"})
+	test.expect_completion_docs(t, &source, "", {"Foo.data: int"})
 }
 
 @(test)
-ast_completion_multiple_chained_call_expr  :: proc(t: ^testing.T) {
+ast_completion_multiple_chained_call_expr :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo :: struct {
 			someData: int,
 		}
@@ -4220,13 +4145,13 @@ ast_completion_multiple_chained_call_expr  :: proc(t: ^testing.T) {
 		foo :: proc() -> Bar {}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"Bazz.bazz: string"})
+	test.expect_completion_docs(t, &source, "", {"Bazz.bazz: string"})
 }
 
 @(test)
-ast_completion_nested_struct_with_enum_fields_unnamed  :: proc(t: ^testing.T) {
+ast_completion_nested_struct_with_enum_fields_unnamed :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo1 :: enum {
 			A, B,
 		}
@@ -4256,13 +4181,13 @@ ast_completion_nested_struct_with_enum_fields_unnamed  :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"C", "D"}, {"A", "B"})
+	test.expect_completion_docs(t, &source, "", {"C", "D"}, {"A", "B"})
 }
 
 @(test)
 ast_completion_poly_type :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		foo :: proc(array: $A/[]$T) {
 			for elem, i in array {
 				el{*}
@@ -4270,13 +4195,13 @@ ast_completion_poly_type :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"test.elem: $T"})
+	test.expect_completion_docs(t, &source, "", {"test.elem: $T"})
 }
 
 @(test)
 ast_completion_proc_field_names :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		foo :: proc(i: int, bar := "") {}
 
 		main :: proc() {
@@ -4284,13 +4209,13 @@ ast_completion_proc_field_names :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"test.bar: string"})
+	test.expect_completion_docs(t, &source, "", {"test.bar: string"})
 }
 
 @(test)
 ast_completion_enum_variadiac_args :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo :: enum {
 			A,
 			B,
@@ -4304,13 +4229,13 @@ ast_completion_enum_variadiac_args :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"A", "B", "C"})
+	test.expect_completion_docs(t, &source, "", {"A", "B", "C"})
 }
 
 @(test)
 ast_completion_proc_variadiac_arg :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo :: enum {
 			A,
 			B,
@@ -4320,13 +4245,13 @@ ast_completion_proc_variadiac_arg :: proc(t: ^testing.T) {
 		foo :: proc(foos: ..{*}) {}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"test.Foo: enum {..}"})
+	test.expect_completion_docs(t, &source, "", {"test.Foo: enum {..}"})
 }
 
 @(test)
 ast_completion_within_struct_decl :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
+		main = `package test
 		Foo :: enum {
 			A,
 			B,
@@ -4340,7 +4265,7 @@ ast_completion_within_struct_decl :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_completion_docs( t, &source, "", {"test.Foo: enum {..}"}, {"test.foo: proc(f: Foo)"})
+	test.expect_completion_docs(t, &source, "", {"test.Foo: enum {..}"}, {"test.foo: proc(f: Foo)"})
 }
 
 @(test)
@@ -4393,17 +4318,11 @@ ast_completion_enum_map_value_global :: proc(t: ^testing.T) {
 ast_completion_basic_type_other_pkg :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
+	append(&packages, test.Package{pkg = "my_package", source = `package my_package
 			foo: int
-		`,
-		},
-	)
+		`})
 	source := test.Source {
-		main = `package test
+		main     = `package test
 		import "my_package"
 
 		foo :: proc() {
@@ -4541,43 +4460,49 @@ ast_completion_bit_set_on_struct :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_completions_should_not_have_private_overloads :: proc(t: ^testing.T) {
-	packages := make([dynamic]test.Package, context.temp_allocator)
-
-	append(
-		&packages,
-		test.Package {
-			pkg = "my_package",
-			source = `package my_package
-
-			@(private)
-			foo_str :: proc(s: string) {}
-			@(private = "file")
-			foo_int :: proc(i: int) {}
-			foo :: proc {
-				foo_str,
-				foo_int,
-			}
-		`,
-		},
-	)
+ast_completions_handle_pointers_basic_types :: proc(t: ^testing.T) {
 	source := test.Source {
-		main     = `package test
-		import "my_package"
+		main = `package test
+
+		bar :: proc(i: ^int) {}
 
 		main :: proc() {
-			foo := my_package.f{*}
+			foo: int
+			bar(f{*})
 		}
 		`,
-		packages = packages[:],
 	}
-	test.expect_completion_docs(
-		t,
-		&source,
-		"",
-		{"my_package.foo: proc (..)"}, {
-			"@(private)\nmy_package.foo_str: proc(s: string)",
-			"@(private=\"file\")\nmy_package.foo_int: proc(i: int)",
-		},
-	)
+	test.expect_completion_insert_text(t, &source, "", {"&foo"})
+}
+
+@(test)
+ast_completions_handle_pointers_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Foo :: struct{}
+
+		bar :: proc(foo: ^Foo) {}
+
+		main :: proc() {
+			foo: Foo
+			bar(f{*})
+		}
+		`,
+	}
+	test.expect_completion_insert_text(t, &source, "", {"&foo"})
+}
+
+@(test)
+ast_completions_handle_pointers_append :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		main :: proc() {
+			foos: [dynamic]int
+			append(fo{*})
+		}
+		`,
+	}
+	test.expect_completion_insert_text(t, &source, "", {"&foos"})
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4471,6 +4471,9 @@ ast_completions_handle_pointers_basic_types :: proc(t: ^testing.T) {
 			bar(f{*})
 		}
 		`,
+		config = {
+			enable_completion_matching = true,
+		}
 	}
 	test.expect_completion_insert_text(t, &source, "", {"&foo"})
 }
@@ -4489,6 +4492,9 @@ ast_completions_handle_pointers_struct :: proc(t: ^testing.T) {
 			bar(f{*})
 		}
 		`,
+		config = {
+			enable_completion_matching = true,
+		}
 	}
 	test.expect_completion_insert_text(t, &source, "", {"&foo"})
 }
@@ -4503,6 +4509,9 @@ ast_completions_handle_pointers_append :: proc(t: ^testing.T) {
 			append(fo{*})
 		}
 		`,
+		config = {
+			enable_completion_matching = true,
+		}
 	}
 	test.expect_completion_insert_text(t, &source, "", {"&foos"})
 }


### PR DESCRIPTION
When using a completion for a procedure argument, if the arg and the variable you're trying to pass has different pointer values, it will try to add the necessary `&` and `^` for you so it's valid.

Seems to work reasonably well now. I've also added a configuration option to disable it for those who prefer to not use it.