### PR TITLE
Fix issues adding ast struct comments with the temporary allocator

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3294,6 +3294,8 @@ make_symbol_bit_field_from_ast :: proc(
 	name: string,
 	inlined := false,
 ) -> Symbol {
+	// We clone this so we don't override docs and comments with temp allocated docs and comments
+	v := cast(^ast.Bit_Field_Type)clone_node(v, ast_context.allocator, nil)
 	construct_bit_field_field_docs(ast_context.file, v)
 	symbol := Symbol {
 		range = common.get_token_range(v, ast_context.file.src),

--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -1299,6 +1299,8 @@ repeat :: proc(value: string, count: int, allocator := context.allocator) -> str
 	return strings.repeat(value, count, allocator)
 }
 
+// Corrects docs and comments on a Struct_Type. Creates new nodes and adds them to the provided struct
+// using the provided allocator, so `v` should have the same lifetime as the allocator.
 construct_struct_field_docs :: proc(file: ast.File, v: ^ast.Struct_Type, allocator := context.temp_allocator) {
 	for field, i in v.fields.list {
 		// There is currently a bug in the odin parser where it adds line comments for a field to the
@@ -1320,11 +1322,11 @@ construct_struct_field_docs :: proc(file: ast.File, v: ^ast.Struct_Type, allocat
 				if list[0].pos.line == field.pos.line {
 					// if the comment is missing from the appropriate field, we add it (for older versions of the parser)
 					if field.comment == nil {
-						field.comment = ast.new(ast.Comment_Group, list[0].pos, parser.end_pos(list[0]))
+						field.comment = new_type(ast.Comment_Group, list[0].pos, parser.end_pos(list[0]), allocator)
 						field.comment.list = list[:1]
 					}
 					if len(list) > 1 {
-						next_field.docs = ast.new(ast.Comment_Group, list[1].pos, parser.end_pos(list[len(list) - 2]))
+						next_field.docs = new_type(ast.Comment_Group, list[1].pos, parser.end_pos(list[len(list) - 2]), allocator)
 						next_field.docs.list = list[1:]
 					} else {
 						next_field.docs = nil
@@ -1338,6 +1340,8 @@ construct_struct_field_docs :: proc(file: ast.File, v: ^ast.Struct_Type, allocat
 	}
 }
 
+// Corrects docs and comments on a Bit_Field_Type. Creates new nodes and adds them to the provided bit_field
+// using the provided allocator, so `v` should have the same lifetime as the allocator.
 construct_bit_field_field_docs :: proc(file: ast.File, v: ^ast.Bit_Field_Type, allocator := context.temp_allocator) {
 	for field, i in v.fields {
 		// There is currently a bug in the odin parser where it adds line comments for a field to the

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -318,7 +318,10 @@ clone_calling_convention :: proc(
 
 	switch v in cc {
 	case string:
-		return get_index_unique_string(unique_strings, allocator, v)
+		if unique_strings != nil {
+			return get_index_unique_string(unique_strings, allocator, v)
+		}
+		return strings.clone(v, allocator)
 	case ast.Proc_Calling_Convention_Extra:
 		return v
 	}

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -369,7 +369,9 @@ write_struct_type :: proc(
 	inlined := false,
 ) {
 	b.poly = v.poly_params
-	construct_struct_field_docs(ast_context.file, v)
+	// We clone this so we don't override docs and comments with temp allocated docs and comments
+	v := cast(^ast.Struct_Type)clone_node(v, ast_context.allocator, nil)
+	construct_struct_field_docs(ast_context.file, v, ast_context.allocator)
 	for field in v.fields.list {
 		for n in field.names {
 			if identifier, ok := n.derived.(^ast.Ident); ok && field.type != nil {


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/907

Basically when correcting the comments and docs on structs, the corrected entries would be allocated on the temp allocator, but the provided type could be cached and so the entries would end up corrupted.