### PR TITLE
Improvements to bitset completions with named bitsets and selector chains

### DIFF
--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -19,7 +19,7 @@ import "src:common"
 
 
 @(private)
-create_remove_edit :: proc(position_context: ^DocumentPositionContext) -> ([]TextEdit, bool) {
+create_remove_edit :: proc(position_context: ^DocumentPositionContext, strip_leading_period := false) -> ([]TextEdit, bool) {
 	range, ok := get_range_from_selection_start_to_dot(position_context)
 
 	if !ok {
@@ -29,6 +29,10 @@ create_remove_edit :: proc(position_context: ^DocumentPositionContext) -> ([]Tex
 	remove_range := common.Range {
 		start = range.start,
 		end   = range.end,
+	}
+
+	if strip_leading_period {
+		remove_range.end.character -= 1
 	}
 
 	remove_edit := TextEdit {

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4472,3 +4472,70 @@ ast_completion_soa_pointer :: proc(t: ^testing.T) {
 
 	test.expect_completion_docs(t, &source, "", {"Foo.x: int", "Foo.y: string"})
 }
+
+@(test)
+ast_completion_bit_set_in_not_in :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+		}
+
+		main :: proc() {
+			foos: bit_set[Foo]
+			foos.{*}
+		}
+		`,
+	}
+
+	test.expect_completion_docs(t, &source, "", {".A in foos", ".A not_in foos", ".B in foos", ".B not_in foos"})
+}
+
+@(test)
+ast_completion_bit_set_type_in_not_in :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+		}
+		Foos :: bit_set[Foo]
+
+		main :: proc() {
+			foos: Foos
+			foos.{*}
+		}
+		`,
+	}
+
+	test.expect_completion_docs(t, &source, "", {".A in foos", ".A not_in foos", ".B in foos", ".B not_in foos"})
+}
+
+@(test)
+ast_completion_bit_set_on_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+		}
+
+		Bar :: struct {
+			foos: bit_set[Foo],
+		}
+
+		main :: proc() {
+			bar: Bar
+			bar.foos.{*}
+		}
+		`,
+	}
+
+	test.expect_completion_docs(
+		t,
+		&source,
+		"",
+		{".A in bar.foos", ".A not_in bar.foos", ".B in bar.foos", ".B not_in bar.foos"},
+	)
+}


### PR DESCRIPTION
Correctly handles cases now with 

```odin
Foo :: enum {
    A,
    B,
}

Foos :: bit_set[Foo]

Bar :: struct {
    foos: Foos,
}

bar: Bar
bar.foos.{*}

foos: Foos
foos.{*}
```

Also fixes issue with an extra `.` persisting with vscode.