### PR TITLE
Always collect private symbols and filter them when resolving

### DIFF
--- a/src/server/builtins.odin
+++ b/src/server/builtins.odin
@@ -20,7 +20,10 @@ check_builtin_proc_return_type :: proc(
 	symbol: Symbol,
 	call: ^ast.Call_Expr,
 	is_mutable: bool,
-) -> (^ast.Expr, bool) {
+) -> (
+	^ast.Expr,
+	bool,
+) {
 	if symbol.pkg == "$builtin" {
 		switch symbol.name {
 		case "max", "min":
@@ -133,9 +136,9 @@ check_builtin_proc_return_type :: proc(
 	return nil, false
 }
 
-@(private="file")
+@(private = "file")
 get_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr, is_mutable: bool) -> ^ast.Expr {
-	if v, ok := expr.derived.(^ast.Field_Value); ok {
+if v, ok := expr.derived.(^ast.Field_Value); ok {
 		return get_return_expr(ast_context, v.value, is_mutable)
 	}
 	if ident, ok := expr.derived.(^ast.Ident); ok {
@@ -153,7 +156,7 @@ get_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr, is_mutable: b
 	return expr
 }
 
-@(private="file")
+@(private = "file")
 convert_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool) -> ^ast.Expr {
 	if is_mutable {
 		ident := ast.new(ast.Ident, candidate.pos, candidate.end)
@@ -168,7 +171,7 @@ convert_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool) -> ^ast.E
 	return candidate
 }
 
-@(private="file")
+@(private = "file")
 get_complex_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) -> ^ast.Expr {
 	if v, ok := expr.derived.(^ast.Field_Value); ok {
 		return get_complex_return_expr(ast_context, v.value)
@@ -189,7 +192,7 @@ get_complex_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) -> ^a
 	return expr
 }
 
-@(private="file")
+@(private = "file")
 convert_complex_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool) -> ^ast.Expr {
 	if is_mutable {
 		ident := ast.new(ast.Ident, candidate.pos, candidate.end)
@@ -200,7 +203,7 @@ convert_complex_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool) -
 	return candidate
 }
 
-@(private="file")
+@(private = "file")
 get_quaternion_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) -> ^ast.Expr {
 	if v, ok := expr.derived.(^ast.Field_Value); ok {
 		return get_quaternion_return_expr(ast_context, v.value)
@@ -221,7 +224,7 @@ get_quaternion_return_expr :: proc(ast_context: ^AstContext, expr: ^ast.Expr) ->
 	return expr
 }
 
-@(private="file")
+@(private = "file")
 convert_quaternion_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool) -> ^ast.Expr {
 	if is_mutable {
 		ident := ast.new(ast.Ident, candidate.pos, candidate.end)
@@ -232,7 +235,7 @@ convert_quaternion_candidate :: proc(candidate: ^ast.Basic_Lit, is_mutable: bool
 	return candidate
 }
 
-@(private="file")
+@(private = "file")
 get_basic_lit_value :: proc(n: ^ast.Expr) -> (^ast.Basic_Lit, f64, bool) {
 	n := n
 	if v, ok := n.derived.(^ast.Field_Value); ok {
@@ -261,7 +264,7 @@ get_basic_lit_value :: proc(n: ^ast.Expr) -> (^ast.Basic_Lit, f64, bool) {
 	return nil, 0, false
 }
 
-@(private="file")
+@(private = "file")
 compare_basic_lit_value :: proc(a, b: f64, name: string) -> bool {
 	if name == "max" {
 		return a > b

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -502,7 +502,7 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 	forward, _ := filepath.to_slash(file.fullpath, context.temp_allocator)
 	directory := path.dir(forward, context.temp_allocator)
 	package_map := get_package_mapping(file, collection.config, directory)
-	exprs := collect_globals(file, true)
+	exprs := collect_globals(file)
 
 	for expr in exprs {
 		symbol: Symbol

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -885,7 +885,7 @@ get_selector_completion :: proc(
 
 		pkg := selector.pkg
 
-		if searched, ok := fuzzy_search(field, {pkg}); ok {
+		if searched, ok := fuzzy_search(field, {pkg}, ast_context.fullpath); ok {
 			for search in searched {
 				symbol := search.symbol
 
@@ -1409,7 +1409,7 @@ get_identifier_completion :: proc(
 	append(&pkgs, ast_context.document_package)
 	append(&pkgs, "$builtin")
 
-	if fuzzy_results, ok := fuzzy_search(lookup_name, pkgs[:]); ok {
+	if fuzzy_results, ok := fuzzy_search(lookup_name, pkgs[:], ast_context.fullpath); ok {
 		for r in fuzzy_results {
 			r := r
 			resolve_unresolved_symbol(ast_context, &r.symbol)

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -335,7 +335,7 @@ write_short_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, sy
 	case SymbolProcedureValue:
 		write_procedure_symbol_signature(sb, v, detailed_signature = true)
 		return
-	case SymbolAggregateValue:
+	case SymbolAggregateValue, SymbolProcedureGroupValue:
 		strings.write_string(sb, "proc (..)")
 		return
 	case SymbolStructValue:

--- a/src/server/indexer.odin
+++ b/src/server/indexer.odin
@@ -3,6 +3,7 @@ package server
 import "core:fmt"
 import "core:log"
 import "core:odin/ast"
+import "core:path/filepath"
 import "core:slice"
 import "core:strings"
 
@@ -25,20 +26,41 @@ clear_index_cache :: proc() {
 	memory_index_clear_cache(&indexer.index)
 }
 
-lookup :: proc(name: string, pkg: string, loc := #caller_location) -> (Symbol, bool) {
+should_skip_private_symbol :: proc(symbol: Symbol, current_file: string) -> bool {
+	if .PrivateFile not_in symbol.flags && .PrivatePackage not_in symbol.flags {
+		return false
+	}
+
+	symbol_file := strings.trim_prefix(symbol.uri, "file://")
+	current_file := strings.trim_prefix(current_file, "file://")
+	if .PrivateFile in symbol.flags && symbol_file != current_file {
+		return true
+	}
+
+	current_pkg := filepath.dir(current_file, context.temp_allocator)
+	if .PrivatePackage in symbol.flags && current_pkg != symbol.pkg {
+		return true
+	}
+	return false
+}
+
+lookup :: proc(name: string, pkg: string, current_file: string, loc := #caller_location) -> (Symbol, bool) {
 	if name == "" {
 		return {}, false
 	}
 
 	if symbol, ok := memory_index_lookup(&indexer.index, name, pkg); ok {
+		if should_skip_private_symbol(symbol, current_file) {
+			return {}, false
+		}
 		return symbol, true
 	}
 
 	return {}, false
 }
 
-fuzzy_search :: proc(name: string, pkgs: []string) -> ([]FuzzyResult, bool) {
-	results, ok := memory_index_fuzzy_search(&indexer.index, name, pkgs)
+fuzzy_search :: proc(name: string, pkgs: []string, current_file: string) -> ([]FuzzyResult, bool) {
+	results, ok := memory_index_fuzzy_search(&indexer.index, name, pkgs, current_file)
 	result := make([dynamic]FuzzyResult, context.temp_allocator)
 
 	if !ok {

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -19,7 +19,13 @@ import "src:common"
 
 
 @(private)
-create_remove_edit :: proc(position_context: ^DocumentPositionContext, strip_leading_period := false) -> ([]TextEdit, bool) {
+create_remove_edit :: proc(
+	position_context: ^DocumentPositionContext,
+	strip_leading_period := false,
+) -> (
+	[]TextEdit,
+	bool,
+) {
 	range, ok := get_range_from_selection_start_to_dot(position_context)
 
 	if !ok {
@@ -110,6 +116,9 @@ collect_methods :: proc(
 	for k, v in indexer.index.collection.packages {
 		if symbols, ok := &v.methods[method]; ok {
 			for &symbol in symbols {
+				if should_skip_private_symbol(symbol, ast_context.fullpath) {
+					continue
+				}
 				resolve_unresolved_symbol(ast_context, &symbol)
 
 				range, ok := get_range_from_selection_start_to_dot(position_context)

--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -67,7 +67,7 @@ get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceS
 
 		try_build_package(pkg)
 
-		if results, ok := fuzzy_search(query, {pkg}); ok {
+		if results, ok := fuzzy_search(query, {pkg}, ""); ok {
 			for result in results {
 				symbol := WorkspaceSymbol {
 					name = result.symbol.name,

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -4341,6 +4341,41 @@ ast_hover_soa_pointer_field_variable :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.a: int")
 }
+
+@(test)
+ast_hover_overload_private_procs :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package {
+			pkg = "my_package",
+			source = `package my_package
+
+			@(private = "file")
+			foo_str :: proc(s: string) {}
+			@(private = "file")
+			foo_int :: proc(i: int) {}
+			foo :: proc {
+				foo_str,
+				foo_int,
+			}
+		`,
+		},
+	)
+	source := test.Source {
+		main     = `package test
+		import "my_package"
+
+		main :: proc() {
+			s: string
+			foo := my_package.fo{*}o(s)
+		}
+		`,
+		packages = packages[:],
+	}
+	test.expect_hover(t, &source, "@(private=\"file\")\nmy_package.foo: proc(s: string)")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
From https://github.com/DanielGavin/ols/issues/922, because the procs within the proc group are all private they fail to be resolved and so you receive no information. To fix this, rather than filter out private symbols when we collect, filter them when we do the resolutions.  

Currently we show all the attributes of the "child" proc when we hover on a overloaded proc, and in this case it will show that the proc is indeed private.

From the example in the issue: 
<img width="1019" height="137" alt="image" src="https://github.com/user-attachments/assets/ddc29071-e542-4e54-bb5d-c215604b301f" />

Not sure how we would want to handle this but I'm not sure it's too big of a deal, and the proc may have other important attributes that we want to see so I don't think it's better to strip them or only display the parent proc groups attributes or something. As a silly example:

```odin
@(private = "file", require_results)
foo_str :: proc(s: string) -> string {
	return s
}
@(private = "file")
foo_int :: proc(i: int) {}
foo :: proc {
	foo_str,
	foo_int,
}
```