### PR TITLE
Correctly format types with a long value decl

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -353,7 +353,7 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 
 		if len(v.values) > 0 {
 			if is_values_nestable_assign(v.values) {
-				return cons(document, group(nest(cons_with_opl(lhs, group(rhs)))))
+				return cons(document, nest(cons_with_opl(lhs, group(rhs))))
 			} else if is_values_nestable_if_break_assign(v.values) {
 				assignments := cons(lhs, group(nest(break_with_space()), Document_Group_Options{id = "assignments"}))
 				assignments = cons(assignments, nest_if_break(group(rhs), "assignments"))

--- a/tools/odinfmt/tests/.snapshots/procedures.odin
+++ b/tools/odinfmt/tests/.snapshots/procedures.odin
@@ -12,3 +12,11 @@ tracking_allocator_check_leaks :: proc(
 
 
 }
+
+ init: proc(
+		window_width: int,
+		window_height: int,
+		window_title: string,
+		allocator := context.allocator,
+		loc := #caller_location,
+	) -> ^State : _init

--- a/tools/odinfmt/tests/procedures.odin
+++ b/tools/odinfmt/tests/procedures.odin
@@ -8,3 +8,6 @@ tracking_allocator_check_leaks :: proc(tracking_allocator: ^mem.Tracking_Allocat
 
 
 }
+
+init: proc(window_width: int, window_height: int, window_title: string,
+           allocator := context.allocator, loc := #caller_location) -> ^State : _init


### PR DESCRIPTION
The formatter currently formats long value decl types as 
```odin
Foo : <long type> : Bar
// becomes
Foo : <long type>
    : Bar // Syntax error: Expected a statement, got ':'
```
This just removes the new line after `<long type>`

Resolves https://github.com/DanielGavin/ols/issues/929