### PR TITLE
Use current package rather than file path to filter private symbols

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1035,8 +1035,9 @@ get_selector_completion :: proc(
 		is_incomplete = true
 
 		pkg := selector.pkg
+		current_pkg := ast_context.current_package
 
-		if searched, ok := fuzzy_search(field, {pkg}, ast_context.fullpath); ok {
+		if searched, ok := fuzzy_search(field, {pkg}, current_pkg, ast_context.fullpath); ok {
 			for search in searched {
 				symbol := search.symbol
 
@@ -1567,7 +1568,7 @@ get_identifier_completion :: proc(
 	append(&pkgs, ast_context.document_package)
 	append(&pkgs, "$builtin")
 
-	if fuzzy_results, ok := fuzzy_search(lookup_name, pkgs[:], ast_context.fullpath); ok {
+	if fuzzy_results, ok := fuzzy_search(lookup_name, pkgs[:], ast_context.current_package,  ast_context.fullpath); ok {
 		for r in fuzzy_results {
 			r := r
 			resolve_unresolved_symbol(ast_context, &r.symbol)

--- a/src/server/memory_index.odin
+++ b/src/server/memory_index.odin
@@ -44,6 +44,7 @@ memory_index_fuzzy_search :: proc(
 	index: ^MemoryIndex,
 	name: string,
 	pkgs: []string,
+	current_pkg: string,
 	current_file: string,
 	resolve_fields := false,
 ) -> (
@@ -59,7 +60,7 @@ memory_index_fuzzy_search :: proc(
 	for pkg in pkgs {
 		if pkg, ok := index.collection.packages[pkg]; ok {
 			for _, symbol in pkg.symbols {
-				if should_skip_private_symbol(symbol, current_file) {
+				if should_skip_private_symbol(symbol, current_pkg, current_file) {
 					continue
 				}
 				if resolve_fields {

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -116,7 +116,7 @@ collect_methods :: proc(
 	for k, v in indexer.index.collection.packages {
 		if symbols, ok := &v.methods[method]; ok {
 			for &symbol in symbols {
-				if should_skip_private_symbol(symbol, ast_context.fullpath) {
+				if should_skip_private_symbol(symbol, ast_context.current_package, ast_context.fullpath) {
 					continue
 				}
 				resolve_unresolved_symbol(ast_context, &symbol)

--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -65,7 +65,7 @@ get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceS
 
 		try_build_package(pkg)
 
-		if results, ok := fuzzy_search(query, {pkg}, "", resolve_fields = true); ok {
+		if results, ok := fuzzy_search(query, {pkg}, "", "", resolve_fields = true); ok {
 			for result in results {
 				symbol := WorkspaceSymbol {
 					name = result.symbol.name,


### PR DESCRIPTION
Fixes issue on windows where completions would not have private symbols included from symbols within the package