### PR TITLE
Only inline single line switch if line is not too long

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1086,7 +1086,7 @@ visit_stmt :: proc(
 		if count := len(v.body); count > 0 {
 			set_source_position(p, v.body[0].pos)
 			if count == 1 && p.config.inline_single_stmt_case {
-				document = cons_with_opl(document, nest(visit_stmt(p, v.body[0])))
+				document = group(nest(cons_with_opl(document, nest(visit_stmt(p, v.body[0])))))
 			} else {
 				document = cons(document, nest(cons(newline(1), visit_block_stmts(p, v.body))))
 			}

--- a/tools/odinfmt/tests/single_line_switch/.snapshots/switch.odin
+++ b/tools/odinfmt/tests/single_line_switch/.snapshots/switch.odin
@@ -1,0 +1,27 @@
+package single_line_switch
+
+Barrr :: enum {
+	A,
+	B,
+}
+
+main :: proc() {
+	bar: Barrr
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa := 1
+	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb := 2
+	cccccccccccccccccccc := 3
+
+	switch bar {
+	case .A:
+		foo := this_is_a_really_long_proc_name(
+				aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+				bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+				cccccccccccccccccccc,
+			)
+	case .B: foo := this_is_a_really_long_proc_name(1, 2, 3)
+	}
+}
+
+this_is_a_really_long_proc_name :: proc(a, b, c: int) -> int {
+	return a + b + c
+}

--- a/tools/odinfmt/tests/single_line_switch/odinfmt.json
+++ b/tools/odinfmt/tests/single_line_switch/odinfmt.json
@@ -1,0 +1,3 @@
+{
+	"inline_single_stmt_case": true
+}

--- a/tools/odinfmt/tests/single_line_switch/switch.odin
+++ b/tools/odinfmt/tests/single_line_switch/switch.odin
@@ -1,0 +1,28 @@
+package single_line_switch
+
+Barrr :: enum {
+	A,
+	B,
+}
+
+main :: proc() {
+	bar: Barrr
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa := 1
+	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb := 2
+	cccccccccccccccccccc := 3
+
+	switch bar {
+	case .A: 
+
+		foo := this_is_a_really_long_proc_name(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+	case .B: 
+
+		foo := this_is_a_really_long_proc_name(1, 
+			2, 
+			3)
+	}
+}
+
+this_is_a_really_long_proc_name :: proc(a, b, c: int) -> int {
+	return a + b + c
+}


### PR DESCRIPTION
I'm sure there's a better way to handle this but I wasn't able to figure it out. Essentially just want it to optionally insert a newline if the resulting line is too long. Currently enabling this means that things like long proc calls won't be wrapped across multiple lines as you would expect; it just adds the whole thing to the one line even if it's 200 characters long.

This is just an easy check to only go down the single line path the resulting line would fit within the character limit. This definitely feels like a hack though as none of the other parts of the code require knowing the character width, that's just something that's used when handling the printing.

Let me know if you know of the proper way to do this.