### PR TITLE
First pass at scoring completion items

### DIFF
--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -376,6 +376,7 @@ CompletionItem :: struct {
 	deprecated:          bool,
 	command:             Maybe(Command),
 	labelDetails:        Maybe(CompletionItemLabelDetails),
+	sortText:            Maybe(string),
 }
 
 CompletionItemLabelDetails :: struct {
@@ -578,5 +579,3 @@ WorkspaceSymbol :: struct {
 DidChangeConfigurationParams :: struct {
 	settings: OlsConfig,
 }
-
-


### PR DESCRIPTION
Applies a very basic scoring system to the completion items. Also sorts by length when scores are the same which is similar to how other LSPs behave.