### PR TITLE
Improvement to resolving numeric binary expressions

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2872,8 +2872,15 @@ resolve_binary_expression :: proc(ast_context: ^AstContext, binary: ^ast.Binary_
 		return symbol_b, true
 	}
 
-	if _, ok := symbol_a.value.(SymbolUntypedValue); ok {
-		return symbol_b, ok_b
+	if value_a, ok := symbol_a.value.(SymbolUntypedValue); ok {
+		if value_b, ok := symbol_b.value.(SymbolUntypedValue); ok {
+			if value_a.type == .Float {
+				return symbol_a, true
+			}
+			return symbol_b, true
+		} else {
+			return symbol_b, ok_b
+		}
 	}
 	//Otherwise just choose the first type, we do not handle error cases - that is done with the checker
 	return symbol_a, ok_a

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -18,22 +18,6 @@ import "src:common"
 
 write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupContent {
 	content: MarkupContent
-
-	symbol := symbol
-
-	if untyped, ok := symbol.value.(SymbolUntypedValue); ok {
-		switch untyped.type {
-		case .String:
-			symbol.signature = "string"
-		case .Bool:
-			symbol.signature = "bool"
-		case .Float:
-			symbol.signature = "float"
-		case .Integer:
-			symbol.signature = "int"
-		}
-	}
-
 	cat := construct_symbol_information(ast_context, symbol)
 	doc := construct_symbol_docs(symbol)
 

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -4470,6 +4470,19 @@ ast_hover_casted_variable :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.foo: int")
 }
+
+@(test)
+ast_hover_float_binary_expr :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		main :: proc() {
+			foo := 2.1
+			b{*}ar := foo - 2
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.bar: float")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Just a minor improvement, before it would say `bar` was an `int` before in the tests. This will make it say float, however it seems in this example:
```odin
i := 2.1
j := i - 1
```
odin actually types `j` as a `f64`, but if you instead do 
```odin
i :: 2.1
j :: i - 1
```
it's now an `untyped float`.

Seems to be a lot of semantics around this that would be a pain to replicate, so I think for now just keeping it as `int` or `float` is enough for us 😅 