### PR TITLE
Remove completions when entering bit_field or struct field names

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1661,6 +1661,28 @@ get_identifier_completion :: proc(
 	lookup_name := ""
 	is_incomplete := true
 
+	if position_context.value_decl != nil {
+		for value in position_context.value_decl.values {
+			if struct_type, ok := value.derived.(^ast.Struct_Type); ok {
+				if struct_type.fields != nil {
+					for field in struct_type.fields.list {
+						for name in field.names {
+							if position_in_node(name, position_context.position) {
+								return false
+							}
+						}
+					}
+				}
+			} else if bit_field_type, ok := value.derived.(^ast.Bit_Field_Type); ok {
+				for field in bit_field_type.fields {
+					if position_in_node(field.name, position_context.position) {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	if position_context.identifier != nil {
 		if ident, ok := position_context.identifier.derived.(^ast.Ident); ok {
 			lookup_name = ident.name

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4668,3 +4668,33 @@ ast_completion_union_with_enums_from_package :: proc(t: ^testing.T) {
 		{"my_package.Foo.A", "my_package.Foo.B", "my_package.Bar.A", "my_package.Bar.C"},
 	)
 }
+
+@(test)
+ast_completion_struct_field_name :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Foo :: struct{}
+
+		Bar :: struct {
+			f{*}
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {}, {"test.Foo: struct {}"})
+}
+
+@(test)
+ast_completion_struct_field_value :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Foo :: struct{}
+
+		Bar :: struct {
+			foo: F{*}
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {"test.Foo: struct {}"})
+}


### PR DESCRIPTION
Removes all completions when entering names for `bit_field` or `struct` types. I don't think there's ever a case where it's actually valid to provide a symbol as a struct name? So we just remove all completions in this case, which is also how `rust-analyzer` behaves.

Resolves https://github.com/DanielGavin/ols/issues/482