### PR TITLE
Use `strings.equal_fold` when comparing references to fix casing issues on windows

### DIFF
--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -324,7 +324,7 @@ resolve_references :: proc(
 			if in_pkg || symbol.pkg == document.package_name {
 				symbols_and_nodes := resolve_entire_file(&document, resolve_flag, context.allocator)
 				for k, v in symbols_and_nodes {
-					if v.symbol.uri == symbol.uri && v.symbol.range == symbol.range {
+					if strings.equal_fold(v.symbol.uri, symbol.uri) && v.symbol.range == symbol.range {
 						node_uri := common.create_uri(v.node.pos.file, ast_context.allocator)
 						range := common.get_token_range(v.node^, string(document.text))
 						//We don't have to have the `.` with, otherwise it renames the dot.
@@ -347,7 +347,7 @@ resolve_references :: proc(
 	symbols_and_nodes := resolve_entire_file(document, resolve_flag, context.allocator)
 
 	for k, v in symbols_and_nodes {
-		if v.symbol.uri == symbol.uri && v.symbol.range == symbol.range {
+		if strings.equal_fold(v.symbol.uri, symbol.uri) && v.symbol.range == symbol.range {
 			node_uri := common.create_uri(v.node.pos.file, ast_context.allocator)
 
 			range := common.get_token_range(v.node^, ast_context.file.src)


### PR DESCRIPTION
It was raised on discord that when you have something like this

```odin
main :: proc() {
    foo : enum {A, B} = .A
}
```
and you try to find references/rename `A` from inside the definition it fails (from where you assign it it would work fine). I tested this on mac and everything worked as expected, but when I tested on windows it was using `c:\` for the symbol but only when you were specifically referring it to from within the definition, otherwise it would use `C:\`. This was causing it to fail. So instead we can just perform the check case insensitively.