### PR TITLE
Cache workspace pkgs so we don't walk the file system each workspace symbol request

### DIFF
--- a/src/server/indexer.odin
+++ b/src/server/indexer.odin
@@ -73,19 +73,8 @@ fuzzy_search :: proc(
 	bool,
 ) {
 	results, ok := memory_index_fuzzy_search(&indexer.index, name, pkgs, current_file, resolve_fields)
-	result := make([dynamic]FuzzyResult, context.temp_allocator)
-
 	if !ok {
 		return {}, false
 	}
-
-	for r in results {
-		append(&result, r)
-	}
-
-	slice.sort_by(result[:], proc(i, j: FuzzyResult) -> bool {
-		return j.score < i.score
-	})
-
-	return result[:], true
+	return results[:], true
 }

--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -1,15 +1,23 @@
 package server
 
-
 import "core:fmt"
 import "core:log"
 import "core:os"
 import "core:path/filepath"
 import "core:strings"
+import "core:time"
 
 import "src:common"
 
 dir_blacklist :: []string{"node_modules", ".git"}
+
+WorkspaceCache :: struct {
+	time:      time.Time,
+	pkgs:      [dynamic]string,
+}
+
+@(thread_local, private = "file")
+cache: WorkspaceCache
 
 @(private)
 walk_dir :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Error, skip_dir: bool) {
@@ -31,50 +39,58 @@ walk_dir :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (er
 }
 
 get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceSymbol, ok: bool) {
-	workspace := common.config.workspace_folders[0]
-	uri := common.parse_uri(workspace.uri, context.temp_allocator) or_return
-	pkgs := make([dynamic]string, 0, context.temp_allocator)
+	if time.since(cache.time) > 1 * time.Minute {
+		for pkg in cache.pkgs {
+			delete(pkg)
+		}
+		clear(&cache.pkgs)
+		workspace := common.config.workspace_folders[0]
+		uri := common.parse_uri(workspace.uri, context.temp_allocator) or_return
+		pkgs := make([dynamic]string, 0, context.temp_allocator)
+
+		filepath.walk(uri.path, walk_dir, &pkgs)
+
+		_pkg: for pkg in pkgs {
+			matches, err := filepath.glob(fmt.tprintf("%v/*.odin", pkg), context.temp_allocator)
+
+			if len(matches) == 0 {
+				continue
+			}
+
+			for exclude_path in common.config.profile.exclude_path {
+				exclude_forward, _ := filepath.to_slash(exclude_path, context.temp_allocator)
+
+				if exclude_forward[len(exclude_forward) - 2:] == "**" {
+					lower_pkg := strings.to_lower(pkg)
+					lower_exclude := strings.to_lower(exclude_forward[:len(exclude_forward) - 3])
+					if strings.contains(lower_pkg, lower_exclude) {
+						continue _pkg
+					}
+				} else {
+					lower_pkg := strings.to_lower(pkg)
+					lower_exclude := strings.to_lower(exclude_forward)
+					if lower_pkg == lower_exclude {
+						continue _pkg
+					}
+				}
+			}
+
+			try_build_package(pkg)
+			append(&cache.pkgs, strings.clone(pkg, context.allocator))
+		}
+		cache.time = time.now()
+	}
+
 	symbols := make([dynamic]WorkspaceSymbol, 0, 100, context.temp_allocator)
-
-	filepath.walk(uri.path, walk_dir, &pkgs)
-
-	_pkg: for pkg in pkgs {
-		matches, err := filepath.glob(fmt.tprintf("%v/*.odin", pkg), context.temp_allocator)
-
-		if len(matches) == 0 {
-			continue
-		}
-
-		for exclude_path in common.config.profile.exclude_path {
-			exclude_forward, _ := filepath.to_slash(exclude_path, context.temp_allocator)
-
-			if exclude_forward[len(exclude_forward) - 2:] == "**" {
-				lower_pkg := strings.to_lower(pkg)
-				lower_exclude := strings.to_lower(exclude_forward[:len(exclude_forward) - 3])
-				if strings.contains(lower_pkg, lower_exclude) {
-					continue _pkg
-				}
-			} else {
-				lower_pkg := strings.to_lower(pkg)
-				lower_exclude := strings.to_lower(exclude_forward)
-				if lower_pkg == lower_exclude {
-					continue _pkg
-				}
+	if results, ok := fuzzy_search(query, cache.pkgs[:], "", resolve_fields = false); ok {
+		for result in results {
+			symbol := WorkspaceSymbol {
+				name = result.symbol.name,
+				location = {range = result.symbol.range, uri = result.symbol.uri},
+				kind = symbol_kind_to_type(result.symbol.type),
 			}
-		}
 
-		try_build_package(pkg)
-
-		if results, ok := fuzzy_search(query, {pkg}, "", resolve_fields = true); ok {
-			for result in results {
-				symbol := WorkspaceSymbol {
-					name = result.symbol.name,
-					location = {range = result.symbol.range, uri = result.symbol.uri},
-					kind = symbol_kind_to_type(result.symbol.type),
-				}
-
-				append(&symbols, symbol)
-			}
+			append(&symbols, symbol)
 		}
 	}
 


### PR DESCRIPTION
It was mentioned on the discord that the workspace symbols can be slow for large codebases. After a brief look into it I noticed we were walking the filesystem to find the files to check. This is fine as a one off but since it makes the request many times when you filter the symbols (basically every time you pause typing) this adds up and is noticeable. 

With this we basically just cache the packages with a 1 minute TTL so we don't continuously do this walk. On the Odin repo on my m1 pro it took the average response time from 50ms on the low end to up to 300ms on the high end, to a very consistent 40ms or so on average.