### PR TITLE
Fix formatting structs with long field definitions

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -2094,7 +2094,7 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 			if len(field.names) != 0 {
 				document = cons(document, text(" :" if p.config.spaces_around_colons else ":"), align)
 			}
-			document = cons_with_opl(document, visit_expr(p, field.type))
+			document = cons_with_nopl(document, visit_expr(p, field.type))
 		} else {
 			document = cons(document, text(":"), text("="))
 			document = cons_with_opl(document, visit_expr(p, field.default_value))


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/999

Formats the file mentioned in the issue as 

```odin
package main

My_Struct_With_Proc :: struct {
	long_proc: proc(
		argument1: int,
		argument2: int,
		argument3: int,
		allocator := context.allocator,
	) -> (
		string,
		string,
	),
	foo:       int,
	bar:       string,
	baz:       bool,
}
My_Struct_With_Short_Proc :: struct {
	long_proc: proc(argument1: int, argument2: int, argument3: int) -> (string, string),
	foo:       int,
	bar:       string,
	baz:       bool,
}

My_Struct_With_Struct :: struct {
	long_struct: struct {
		field1: int,
		field2: int,
		field3: int,
		field4: string,
		field5: string,
		field6: bool,
	},
	foo:         int,
	bar:         string,
	baz:         bool,
}

main :: proc() {
}

```