### PR TITLE
Revert selector within selector call expression changes

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -101,8 +101,6 @@ get_completion_list :: proc(
 				if !position_in_node(selector_call.call, position_context.position) {
 					completion_type = .Selector
 				}
-			} else if selector, ok := position_context.selector_expr.derived.(^ast.Selector_Expr); ok {
-				completion_type = .Selector
 			}
 		} else if _, ok := position_context.selector.derived.(^ast.Implicit_Selector_Expr); !ok {
 			// variadic args seem to work by setting it as an implicit selector expr, in that case

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -96,9 +96,7 @@ get_completion_list :: proc(
 	}
 
 	if position_context.selector != nil {
-		if _, ok := position_context.selector.derived.(^ast.Ident); ok {
-			completion_type = .Selector
-		} else if position_context.selector_expr != nil {
+		if position_context.selector_expr != nil {
 			if selector_call, ok := position_context.selector_expr.derived.(^ast.Selector_Call_Expr); ok {
 				if !position_in_node(selector_call.call, position_context.position) {
 					completion_type = .Selector
@@ -1403,10 +1401,7 @@ get_implicit_completion :: proc(
 		}
 
 		if len(position_context.assign.lhs) > rhs_index {
-			if enum_value, unwrapped_super_enum, ok := unwrap_enum(
-				ast_context,
-				position_context.assign.lhs[rhs_index],
-			); ok {
+			if enum_value, unwrapped_super_enum, ok := unwrap_enum(ast_context, position_context.assign.lhs[rhs_index]); ok {
 				for name in enum_value.names {
 					item := CompletionItem {
 						label  = name,

--- a/src/server/position_context.odin
+++ b/src/server/position_context.odin
@@ -138,7 +138,7 @@ get_document_position_context :: proc(
 		position_context.parent_binary = nil
 	}
 
-	if hint == .Completion {
+	if hint == .Completion && position_context.selector == nil && position_context.field == nil {
 		fallback_position_context_completion(document, position, &position_context)
 	}
 

--- a/src/server/position_context.odin
+++ b/src/server/position_context.odin
@@ -649,10 +649,7 @@ get_document_position_node :: proc(node: ^ast.Node, position_context: ^DocumentP
 			}
 		}
 	case ^Selector_Expr:
-		if position_context.hint == .Definition ||
-		   position_context.hint == .Hover ||
-		   position_context.hint == .SignatureHelp ||
-		   position_context.hint == .Completion {
+		if position_context.hint == .Definition || position_context.hint == .Hover && n.field != nil {
 			position_context.selector = n.expr
 			position_context.field = n.field
 			position_context.selector_expr = node

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4720,37 +4720,9 @@ ast_completion_selector_within_selector_call_expr :: proc(t: ^testing.T) {
 				bar = print,
 			}
 
-			foo->bar(data.{*})
+			foo->bar(data.x{*})
 		}
 		`,
 	}
 	test.expect_completion_docs(t, &source, "", {"Data.x: int", "Data.y: int"})
-}
-
-@(test)
-ast_completion_ident_within_selector_call_expr :: proc(t: ^testing.T) {
-	source := test.Source {
-		main = `package test
-
-		Data :: struct {
-			x, y: int,
-		}
-
-		IFoo :: struct {
-			bar: proc(self: IFoo, x: int),
-		}
-
-		print :: proc(self: IFoo, x: int) {}
-
-		main :: proc() {
-			data := Data{}
-			foo := IFoo {
-				bar = print,
-			}
-
-			foo->bar(d{*})
-		}
-		`,
-	}
-	test.expect_completion_docs(t, &source, "", {"test.data: test.Data"})
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4698,31 +4698,3 @@ ast_completion_struct_field_value :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs(t, &source, "", {"test.Foo: struct {}"})
 }
-
-@(test)
-ast_completion_selector_within_selector_call_expr :: proc(t: ^testing.T) {
-	source := test.Source {
-		main = `package test
-
-		Data :: struct {
-			x, y: int,
-		}
-
-		IFoo :: struct {
-			bar: proc(self: IFoo, x: int),
-		}
-
-		print :: proc(self: IFoo, x: int) {}
-
-		main :: proc() {
-			data := Data{}
-			foo := IFoo {
-				bar = print,
-			}
-
-			foo->bar(data.x{*})
-		}
-		`,
-	}
-	test.expect_completion_docs(t, &source, "", {"Data.x: int", "Data.y: int"})
-}


### PR DESCRIPTION
I'm not too confident this is working correctly and I suspect it might cause some issues with the regular behaviour. I'll revert for now and take a look at a later point.