### PR TITLE
Substitute poly types for generic maps

### DIFF
--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -452,6 +452,17 @@ find_and_replace_poly_type :: proc(expr: ^ast.Expr, poly_map: ^map[string]^ast.E
 				v.pos.file = expr.pos.file
 				v.end.file = expr.end.file
 			}
+		case ^ast.Map_Type:
+			if expr, ok := get_poly_map(v.key, poly_map); ok {
+				v.key = expr
+				v.pos.file = expr.pos.file
+				v.end.file = expr.end.file
+			}
+			if expr, ok := get_poly_map(v.value, poly_map); ok {
+				v.value = expr
+				v.pos.file = expr.pos.file
+				v.end.file = expr.end.file
+			}
 		}
 
 		return visitor

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -4980,6 +4980,25 @@ ast_hover_proc_impl :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.foo :: proc(a: int) -> int")
 }
+
+@(test)
+ast_hover_proc_overload_generic_map :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		clear_dynamic_array :: proc "contextless" (array: ^$T/[dynamic]$E) {}
+		clear_map :: proc "contextless" (m: ^$T/map[$K]$V) {}
+		clear :: proc{
+			clear_dynamic_array,
+			clear_map,
+		}
+		main :: proc() {
+			foo: map[int]string
+			c{*}lear(&foo)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.clear :: proc(m: ^$T/map[$K]$V)")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Fixes issues resolving overloaded procs that use poly maps such as the builtin `clear`