### PR TITLE
Replace struct_field_value_by_name with custom find_derived

### DIFF
--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -113,6 +113,7 @@ clone_node :: proc(node: ^ast.Node, allocator: mem.Allocator, unique_strings: ^m
 
 	res_ptr := reflect.deref(res_ptr_any)
 
+	// Recursively search for ast.Expr.derived_expr or ast.Stmt.derived_stmt field
 	find_derived :: proc(a: any) -> any {
 		if a == nil {return nil}
 


### PR DESCRIPTION
I'm not exactly sure what this code does.
It looked like it searched the types for `ast.Expr.derived_expr` or `ast.Stmt.derived_stmt`.
Which could be rewritten a bit to replace comparing field names with field types.
It gives the same results based on my tests.
But I don't know if it doesn't miss something as everything still works even if I completely remove it.