### PR TITLE
Ensure the lines and columns for diagnostics are non negative

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -159,8 +159,9 @@ check :: proc(paths: []string, uri: common.Uri, writer: ^Writer, config: ^common
 					code = "checker",
 					severity = .Error,
 					range = {
-						start = {character = error.pos.column - 1, line = error.pos.line - 1},
-						end = {character = error.pos.end_column - 1, line = error.pos.line - 1},
+						// odin will sometimes report errors on column 0, so we ensure we don't provide a negative column/line to the client
+						start = {character = max(error.pos.column - 1, 0), line = max(error.pos.line - 1, 0)},
+						end = {character = max(error.pos.end_column - 1, 0), line = max(error.pos.line - 1, 0)},
 					},
 					message = message,
 				},


### PR DESCRIPTION
With this example program (empty newline at the end is important)

```odin
package examples

foo :: proc() {

```

`odin check` will report the error on column 0

```sh
❯ odin check main.odin -file
/Users/bradlewis/repos/ols/main.odin(5:0) Syntax Error: Expected '}', got 'EOF'
        ( empty line )
```

This causes the server to report the column as `-1`, which is invalid and will provide a nice long error message in editors such as vscode.

This check is just to ensure we always respond with valid lines and columns