### PR TITLE
Add a variable to set the odin branch/tag in the ci and nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+env:
+  ODIN_BRANCH: dev-2025-09
 
 on:
   push:
@@ -23,7 +25,7 @@ jobs:
       - name: Download Odin
         shell: cmd
         run: |
-          git clone https://github.com/odin-lang/Odin
+          git clone --depth 1 --branch %ODIN_BRANCH% https://github.com/odin-lang/Odin
       - name: Build Odin
         shell: cmd
         run: |
@@ -50,7 +52,7 @@ jobs:
           echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
       - name: Build Odin
         run: |
-          git clone --depth 1 https://github.com/odin-lang/Odin
+          git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
           cd Odin && ./build_odin.sh release
       - name: Build ols
         run: ./ci.sh CI
@@ -72,7 +74,7 @@ jobs:
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: Build Odin
         run: |
-          git clone --depth 1 https://github.com/odin-lang/Odin
+          git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
           cd Odin && ./build_odin.sh release
       - name: Build ols
         run: ./ci.sh CI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: nightly
+env:
+  ODIN_BRANCH: dev-2025-09
 
 on:
   workflow_dispatch:
@@ -17,7 +19,7 @@ jobs:
         echo "/opt/homebrew/opt/llvm@17/bin" >> $GITHUB_PATH
     - name: Download Odin
       run: |
-        git clone https://github.com/odin-lang/Odin
+        git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
     - name: Build Odin
       run: |
         cd Odin
@@ -47,7 +49,7 @@ jobs:
         echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
     - name: Download Odin
       run: |
-        git clone https://github.com/odin-lang/Odin
+        git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
     - name: Build Odin
       run: |
         cd Odin
@@ -77,7 +79,7 @@ jobs:
         echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
     - name: Download Odin
       run: |
-        git clone https://github.com/odin-lang/Odin
+        git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
     - name: Build Odin
       run: |
         cd Odin
@@ -107,7 +109,7 @@ jobs:
         echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
     - name: Download Odin
       run: |
-        git clone https://github.com/odin-lang/Odin
+        git clone --depth 1 --branch $ODIN_BRANCH https://github.com/odin-lang/Odin
     - name: Build Odin
       run: |
         cd Odin
@@ -134,7 +136,7 @@ jobs:
     - name: Download Odin
       shell: cmd
       run: |
-        git clone https://github.com/odin-lang/Odin
+        git clone --depth 1 --branch %ODIN_BRANCH% https://github.com/odin-lang/Odin
     - name: Build Odin
       shell: cmd
       run: |


### PR DESCRIPTION
Given the recent instability of the master branch of odin, it'd be good to build off of the most recent stable release. This was just the simplest option I could think of for now. Should allow us to quickly update the version we use or even go back to master if things become more stable again.