### PR TITLE
Find and replace poly types for call expr

### DIFF
--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -463,6 +463,12 @@ find_and_replace_poly_type :: proc(expr: ^ast.Expr, poly_map: ^map[string]^ast.E
 				v.pos.file = expr.pos.file
 				v.end.file = expr.end.file
 			}
+		case ^ast.Call_Expr:
+			for &arg in v.args {
+				if expr, ok := get_poly_map(arg, poly_map); ok {
+					arg = expr
+				}
+			}
 		}
 
 		return visitor

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -5112,6 +5112,29 @@ ast_hover_matrix_index_twice :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.b: f32")
 }
+
+@(test)
+ast_hover_parapoly_proc_slice_param_return :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		Iter :: struct(T: typeid) {
+			slice: []T,
+			index: int,
+		}
+
+		make_iter :: proc(slice: []$T) -> Iter(T) {
+			return { slice, 0 }
+		}
+
+		main :: proc() {
+			slice := []string{}
+			i{*}t := make_iter(slice)
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.it: test.Iter(string)")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1067

This is used for when a proc returns a parapoly struct. The return type is a call expr in the ast.