### PR TITLE
Delete root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "ols",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
I think this package-lock.json was created by mistake here, it has no contents. It's not necessary for anything, right?