### PR TITLE
Correctly provide completions when calling a proc immediately after a proc overload call

### DIFF
--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4738,3 +4738,52 @@ ast_completion_handle_matching_field_with_unary :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_insert_text(t, &source, "", {"foo"})
 }
+
+@(test)
+ast_completion_overload_proc_returning_proc_complete_comp_lit_arg_local :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			bar: int,
+			bazz: string,
+		}
+
+		foo_none :: proc() -> proc(config: Foo) -> bool {}
+		foo_string :: proc(s: string) -> proc(config: Foo) -> bool {}
+
+		foo :: proc{foo_none, foo_string}
+
+		main :: proc() {
+			result := foo()
+			result({
+				{*}
+			})
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {"Foo.bar: int", "Foo.bazz: string"})
+}
+
+@(test)
+ast_completion_overload_proc_returning_proc_complete_comp_lit_arg_direct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+			bar: int,
+			bazz: string,
+		}
+
+		foo_none :: proc() -> proc(config: Foo) -> bool {}
+		foo_string :: proc(s: string) -> proc(config: Foo) -> bool {}
+
+		foo :: proc{foo_none, foo_string}
+
+		main :: proc() {
+			foo()({
+				{*}
+			})
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {"Foo.bar: int", "Foo.bazz: string"})
+}


### PR DESCRIPTION
Resolves issues with calling procs returned from a proc overload that was raised in the discord, in particular when using `clay` the UI got updated to use a proc group, so

```odin
@(deferred_none = _CloseElement)
UI_WithId :: proc(id: ElementId) -> proc (config: ElementDeclaration) -> bool {
    _OpenElementWithId(id)
    return ConfigureOpenElement
}

@(deferred_none = _CloseElement)
UI_AutoId :: proc() -> proc (config: ElementDeclaration) -> bool {
    _OpenElement()
    return ConfigureOpenElement
}

UI :: proc{UI_WithId, UI_AutoId}

...

if clay.UI()({
  layout = {
    // no completions here now
  }
}){}
```

This should fix this. It's getting messy now with all the flags determining the proc overload behave, should probably take a look at that in the future to try and streamline it a bit.