### PR TITLE
Resolve types from usings before global scope

### DIFF
--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -5151,6 +5151,34 @@ ast_hover_generic_proc_with_inlining :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.foo :: #force_inline proc(data: $T)")
 }
+
+@(test)
+ast_hover_using_import_statement_name_conflict :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(&packages, test.Package{pkg = "my_package", source = `package my_package
+			Bar :: struct {
+				b: string,
+			}
+		`})
+
+	source := test.Source {
+		main = `package test
+		import "my_package"
+
+		Bar :: struct {
+			a: int,
+		}
+
+		main :: proc() {
+			using my_package
+			bar := Ba{*}r{}
+		}
+		`,
+		packages = packages[:],
+	}
+	test.expect_hover(t, &source, "my_package.Bar :: struct {\n\tb: string,\n}")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
When looking at the `clone_node` proc for this PR https://github.com/DanielGavin/ols/pull/1049, I noticed interacting with the package type below would not behave correctly.

```odin
clone_node :: proc(node: ^ast.Node, allocator: mem.Allocator, unique_strings: ^map[string]string) -> ^ast.Node {
	using ast
...
	#partial switch _ in node.derived {
	case ^Package, ^File: <-- Package would map to the Package type in the server package
		panic("Cannot clone this node type")
	}
...
}
```

These changes make sure that we check `usings` before we check the global scope.

The extra flag `use_usings` was added as I attempted to put the using check behind `use_locals`, but that caused references to behave weirdly when trying to find all references to `Package` above, it would also include some random fields such as `imp.base` here: https://github.com/DanielGavin/ols/blob/master/src/server/analysis.odin#L1625