### PR TITLE
Run check unused imports on document refresh

### DIFF
--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -321,6 +321,8 @@ document_refresh :: proc(document: ^Document, config: ^common.Config, writer: ^W
 	remove_diagnostics(.Syntax, document.uri.uri)
 	remove_diagnostics(.Check, document.uri.uri)
 
+	check_unused_imports(document, config)
+
 	if writer != nil && !config.disable_parser_errors {
 		document.diagnosed_errors = true
 


### PR DESCRIPTION
Ensures the notification is removed when you delete the unused import. Currently it requires you to save and so it looks a little weird as the diagnostic will persist