### PR TITLE
Use temp_allocator for read_entire_file on file change

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -1550,7 +1550,7 @@ notification_did_change_watched_files :: proc(
 			find_all_package_aliases()
 		} else {
 			if uri, ok := common.parse_uri(change.uri, context.temp_allocator); ok {
-				if data, ok := os.read_entire_file(uri.path); ok {
+				if data, ok := os.read_entire_file(uri.path, context.temp_allocator); ok {
 					index_file(uri, cast(string)data)
 				}
 			}
@@ -1559,8 +1559,6 @@ notification_did_change_watched_files :: proc(
 				find_all_package_aliases()
 			}
 		}
-
-
 	}
 
 	return .None


### PR DESCRIPTION
I think that the source code is supposed to be stored in a temp-allocator (or freed), since every string and ast node is being cloned when smbols are collected anyway.