### PR TITLE
Update nightly release action to allow creating releases tied to odin versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set ODIN_BRANCH from tag if available
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      run: echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      run: |
+        echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "OLS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
     - name: Download LLVM and setup PATH
       run: |
         brew install llvm@17
@@ -39,7 +41,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: dist-arm64-darwin 
+        name: dist-arm64-darwin
         path: ./dist
 
   dist-x86_64-darwin:
@@ -49,7 +51,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set ODIN_BRANCH from tag if available
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      run: echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      run: |
+        echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "OLS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
     - name: Download LLVM and setup PATH
       run: |
         brew install llvm@17
@@ -82,7 +86,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set ODIN_BRANCH from tag if available
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      run: echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      run: |
+        echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "OLS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
     - name: Download LLVM
       run:  |
         wget https://apt.llvm.org/llvm.sh
@@ -115,7 +121,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set ODIN_BRANCH from tag if available
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      run: echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      run: |
+        echo "ODIN_BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "OLS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
     - name: Download LLVM
       run:  |
         wget https://apt.llvm.org/llvm.sh
@@ -154,6 +162,7 @@ jobs:
       run: |
         $tagName = $env:GITHUB_REF.Replace('refs/tags/', '')
         echo "ODIN_BRANCH=$tagName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "OLS_VERSION=$tagName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Download Odin
       shell: cmd
       run: |

--- a/ci.bat
+++ b/ci.bat
@@ -2,20 +2,21 @@
 
 setlocal enabledelayedexpansion
 
-for /f %%a in ('git rev-parse --short HEAD 2^>NUL') do set commit_hash=%%a
-for /f %%d in ('powershell -command "[DateTime]::UtcNow.ToString('yyyy-MM-dd')"') do set today=%%d
-set version=nightly-%today%-%commit_hash%
-
+if not defined OLS_VERSION (
+    for /f %%a in ('git rev-parse --short HEAD 2^>NUL') do set commit_hash=%%a
+    for /f %%d in ('powershell -command "[DateTime]::UtcNow.ToString('yyyy-MM-dd')"') do set today=%%d
+    set "OLS_VERSION=nightly-!today!-!commit_hash!"
+)
 if "%1" == "CI" (
     set "PATH=%cd%\Odin;!PATH!"
 
     odin test tests -collection:src=src -define:ODIN_TEST_THREADS=1
     if %errorlevel% neq 0 exit /b 1
 
-    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
+    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%OLS_VERSION%
 
     call "tools/odinfmt/tests.bat"
     if %errorlevel% neq 0 exit /b 1
 ) else (
-    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%version%
+    odin build src\ -collection:src=src -out:ols.exe -o:speed  -no-bounds-check -extra-linker-flags:"/STACK:4000000,2000000" -define:VERSION=%OLS_VERSION%
 )

--- a/ci.sh
+++ b/ci.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-VERSION="nightly-$(date -u '+%Y-%m-%d')-$(git rev-parse --short HEAD)"
+if [[ -z "$OLS_VERSION" ]]; then
+	OLS_VERSION="nightly-$(date -u '+%Y-%m-%d')-$(git rev-parse --short HEAD)"
+fi
 
 if [[ $1 == "CI" ]]
 then
@@ -37,4 +39,4 @@ then
 fi
 
 
-odin build src/ -show-timings -collection:src=src -out:ols -no-bounds-check -o:speed -define:VERSION=$VERSION $@
+odin build src/ -show-timings -collection:src=src -out:ols -no-bounds-check -o:speed -define:VERSION=$OLS_VERSION $@


### PR DESCRIPTION
It's been asked/discussed in the past to have 'stable' releases tied to odin versions that people can use. 

This PR updates/renames the nightly workflow to allow us to create releases based on the odin version. You create a tag such as `dev-2025-10` and it will create a new release with that name using that version of odin. 

The standard nightly process should work the same as normal. 

This releases won't really be 'stable' as `ols` in general is under active development, but it would mark points where people who are using older versions of odin would be able to use a version of `ols` that they can build.