### PR TITLE
Free and clone Or_Branch_Expr

### DIFF
--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -830,6 +830,9 @@ free_ast_node :: proc(node: ^ast.Node, allocator: mem.Allocator) {
 		free_ast(n.y, allocator)
 	case ^ast.Or_Return_Expr:
 		free_ast(n.expr, allocator)
+	case ^ast.Or_Branch_Expr:
+		free_ast(n.expr, allocator)
+		free_ast(n.label, allocator)
 	case:
 		panic(fmt.aprintf("free Unhandled node kind: %v", node.derived))
 	}

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -293,6 +293,9 @@ clone_node :: proc(node: ^ast.Node, allocator: mem.Allocator, unique_strings: ^m
 	case ^Or_Else_Expr:
 		r.x = clone_type(r.x, allocator, unique_strings)
 		r.y = clone_type(r.y, allocator, unique_strings)
+	case ^Or_Branch_Expr:
+		r.expr = clone_type(r.expr, allocator, unique_strings)
+		r.label = clone_type(r.label, allocator, unique_strings)
 	case ^Comment_Group:
 		list := make([dynamic]tokenizer.Token, 0, len(r.list), allocator)
 		for t in r.list {


### PR DESCRIPTION
The `panic(fmt.aprintf("free Unhandled node kind: %v", node.derived))` was causing a server crash for me with malformed syntax.