### PR TITLE
Fix issue calculating the absolute range with a file starting with a new line

### DIFF
--- a/src/common/position.odin
+++ b/src/common/position.odin
@@ -159,6 +159,10 @@ get_absolute_range :: proc(range: Range, document_text: []u8) -> (AbsoluteRange,
 	line_count := 0
 	index := 1
 	last := document_text[0]
+	if last == '\n' {
+		// if we start with a new line, we set the index back to 0 to ensure it gets accounted for
+		index = 0
+	}
 
 	if !get_index_at_line(&index, &line_count, &last, document_text, range.start.line) {
 		return absolute, false
@@ -168,7 +172,7 @@ get_absolute_range :: proc(range: Range, document_text: []u8) -> (AbsoluteRange,
 
 	//if the last line was indexed at zero we have to move it back to index 1.
 	//This happens when line = 0
-	if index == 0 {
+	if index == 0 && last != '\n' {
 		index = 1
 	}
 

--- a/src/server/diagnostics.odin
+++ b/src/server/diagnostics.odin
@@ -3,7 +3,6 @@ package server
 import "core:log"
 import "core:slice"
 import "core:strings"
-import "src:common"
 
 DiagnosticType :: enum {
 	Syntax,

--- a/tests/common_test.odin
+++ b/tests/common_test.odin
@@ -1,0 +1,36 @@
+package tests
+
+import "core:log"
+import "src:common"
+import "core:testing"
+
+@(test)
+common_get_absolute_range_starting_newline :: proc(t: ^testing.T) {
+	src := `
+	package foo
+
+	main :: proc() {
+
+	}
+	`
+
+	range := common.Range{
+		start = {
+			line = 0,
+			character = 0,
+		},
+		end = {
+			line = 1,
+			character = 0,
+		}
+	}
+
+	absolute_range, ok := common.get_absolute_range(range, transmute([]u8)(src))
+	if !ok {
+		log.error(t, "failed to get absolute_range")
+	}
+
+	if absolute_range != {0, 1} {
+		log.error(t, "incorrect absolute_range", absolute_range, ok)
+	}
+}


### PR DESCRIPTION
This would lead to the incremental updates being incorrect and corrupting `ols`s version of the file, requiring a restart to fix.