### PR TITLE
Fix issue with document symbols with invalid struct fields causing vscode errors

### DIFF
--- a/src/server/document_symbols.odin
+++ b/src/server/document_symbols.odin
@@ -1,19 +1,7 @@
 package server
 
-import "core:fmt"
 import "core:log"
-import "core:mem"
 import "core:odin/ast"
-import "core:odin/parser"
-import "core:odin/tokenizer"
-import "core:os"
-import "core:path/filepath"
-import path "core:path/slashpath"
-import "core:slice"
-import "core:sort"
-import "core:strconv"
-import "core:strings"
-
 
 import "src:common"
 
@@ -51,6 +39,9 @@ get_document_symbols :: proc(document: ^Document) -> []DocumentSymbol {
 				case SymbolStructValue:
 					children := make([dynamic]DocumentSymbol, context.temp_allocator)
 					for name, i in v.names {
+						if name == "" {
+							continue
+						}
 						child: DocumentSymbol
 						child.range = v.ranges[i]
 						child.selectionRange = v.ranges[i]
@@ -62,6 +53,9 @@ get_document_symbols :: proc(document: ^Document) -> []DocumentSymbol {
 				case SymbolBitFieldValue:
 					children := make([dynamic]DocumentSymbol, context.temp_allocator)
 					for name, i in v.names {
+						if name == "" {
+							continue
+						}
 						child: DocumentSymbol
 						child.range = v.ranges[i]
 						child.selectionRange = v.ranges[i]


### PR DESCRIPTION
In the following example:

```odin
package main

Foo :: struct {
    map
}

main :: proc() {
}
```

the parser seems to misunderstand this code, and so it creates 2 fields on the `Foo` struct, one with the name `"_"`, and one with the name `""`. The empty name triggers errors in vscode which pop up and is quite annoying. This will happen consistently as vscode uses the document symbols for some scoping logic, and so it will pop up as you type map, even if you were in the process of typing a valid struct, like 

```odin
Foo :: struct {
    map_foo: map[string]int,
}
```

To fix this we simply filter empty names.