### PR TITLE
Use slice instead of map for struct usings

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -1,13 +1,9 @@
 package server
 
-import "core:fmt"
-import "core:hash"
-import "core:log"
 import "core:mem"
 import "core:odin/ast"
 import "core:path/filepath"
 import path "core:path/slashpath"
-import "core:strconv"
 import "core:strings"
 
 import "src:common"
@@ -153,7 +149,7 @@ collect_struct_fields :: proc(
 
 				if .Using in field.flags {
 					append(&b.unexpanded_usings, len(b.names) - 1)
-					b.usings[len(b.names) - 1] = struct{}{}
+					append(&b.usings, len(b.names) - 1)
 				}
 
 				append(&b.ranges, common.get_token_range(n, file.src))

--- a/src/server/document_symbols.odin
+++ b/src/server/document_symbols.odin
@@ -1,6 +1,5 @@
 package server
 
-import "core:log"
 import "core:odin/ast"
 
 import "src:common"

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -2,7 +2,6 @@
 package server
 
 import "core:fmt"
-import "core:log"
 import "core:odin/ast"
 import path "core:path/slashpath"
 import "core:strings"
@@ -651,7 +650,7 @@ write_struct_hover :: proc(sb: ^strings.Builder, ast_context: ^AstContext, v: Sy
 	longestNameLen := 0
 	for name, i in v.names {
 		l := len(name)
-		if _, ok := v.usings[i]; ok {
+		if symbol_struct_value_has_using(v, i) {
 			l += len(using_prefix)
 		}
 		if l > longestNameLen {
@@ -692,7 +691,7 @@ write_struct_hover :: proc(sb: ^strings.Builder, ast_context: ^AstContext, v: Sy
 		write_indent(sb, depth + 1)
 
 		name_len := len(v.names[i])
-		if _, ok := v.usings[i]; ok {
+		if symbol_struct_value_has_using(v, i) {
 			strings.write_string(sb, using_prefix)
 			name_len += len(using_prefix)
 		}


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1097

Since this map has had pretty consistent problems as outlined in the above issue and https://github.com/DanielGavin/ols/pull/788, seems best to simply replace it with an array instead.