### PR TITLE
Only check unused imports if the document is not nil on save

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -1145,8 +1145,9 @@ notification_did_save :: proc(
 	check(config.profile.checker_path[:], corrected_uri, config)
 
 	document := document_get(save_params.textDocument.uri)
-
-	check_unused_imports(document, config)
+	if document != nil {
+		check_unused_imports(document, config)
+	}
 
 	push_diagnostics(writer)
 


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1099.

This would happen as `ols` would be notified that the `odinfmt.json` file had been updated, but we don't have a `document` for that as it's not an odin file so it would be `nil`.