### PR TITLE
Remove `.` when doing implicit selector completions in a union type switch

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2034,6 +2034,11 @@ get_type_switch_completion :: proc(
 						)
 						item.detail = item.label
 					}
+					if position_context.implicit_selector_expr != nil {
+						if remove_edit, ok := create_implicit_selector_remove_edit(position_context); ok {
+							item.additionalTextEdits = remove_edit
+						}
+					}
 
 					append(results, CompletionResult{completion_item = item})
 				}


### PR DESCRIPTION
You can prompt completions for a union type switch using `.`, however the `.` will persist after you make the selection. This just removes it through a text edit. For example:

```odin
Foo :: union {
	string,
	int,
}

main :: proc() {
	foo: Foo

	switch v in foo {
	case .//completions here
	}
}
```

This is useful to keep as currently with the odin parser, we can't get the completions when there is nothing typed after the `.`.