### PR TITLE
os2 fixes getting executable path fail

### DIFF
--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -5,6 +5,7 @@ import "core:fmt"
 import "core:log"
 import "core:mem"
 import "core:os"
+import "core:os/os2"
 import "core:path/filepath"
 import "core:path/slashpath"
 import "core:strings"
@@ -126,12 +127,13 @@ when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .Linux || ODIN_OS =
 }
 
 get_executable_path :: proc(allocator := context.temp_allocator) -> string {
-	exe_path, ok := filepath.abs(os.args[0], context.temp_allocator)
+	exe_dir, err := os2.get_executable_directory(context.temp_allocator)
 
-	if !ok {
-		log.error("Failed to resolve executable path")
+	if err != nil {
+		log.error("Failed to resolve executable path: ", err)
 		return ""
 	}
 
-	return filepath.dir(exe_path, allocator)
+	return exe_dir
 }
+


### PR DESCRIPTION
`get_executable_path` kept crashing for me on Linux (on latest git commit) so I fixed it by using the new function from `os2`