### PR TITLE
Add support for documentHighlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Options:
 
 - `enable_references`: Turns on finding references for a symbol. _(Enabled by default)_
 
+- `enable_document_highlights`: Turns on highlighting of symbol references in file. _(Enabled by default)_
+
 - `enable_document_links`: Follow links when opening documentation. This is usually done via `<ctrl+click>` and will open the documentation in a browser (or similar). _(Enabled by default)_
 
 - `enable_completion_matching`: Attempt to match types and pointers when passing arguments to procedures. _(Enabled by default)_

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -72,6 +72,11 @@
 			"description": "Turns on finding references for a symbol.",
 			"default": true
 		},
+		"enable_document_highlights": {
+			"type": "boolean",
+			"description": "Turns on highlighting of symbol references in file.",
+			"default": true
+		},
 		"enable_completion_matching": {
 			"type": "boolean",
 			"description": "Attempt to match types and pointers when passing arguments to procedures.",

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -28,6 +28,7 @@ Config :: struct {
 	enable_procedure_context:           bool,
 	enable_snippets:                    bool,
 	enable_references:                  bool,
+	enable_document_highlights:         bool,
 	enable_label_details:               bool,
 	enable_std_references:              bool,
 	enable_import_fixer:                bool,

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -236,6 +236,7 @@ resolve_references :: proc(
 	document: ^Document,
 	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,
+	current_file_only := false,
 ) -> (
 	[]common.Location,
 	bool,
@@ -269,7 +270,7 @@ resolve_references :: proc(
 
 	fullpaths := slice.unique(fullpaths[:])
 
-	if .Local not_in symbol.flags {
+	if .Local not_in symbol.flags && !current_file_only {
 		for fullpath in fullpaths {
 			dir := filepath.dir(fullpath)
 			base := filepath.base(dir)
@@ -384,7 +385,7 @@ resolve_references :: proc(
 	return locations[:], true
 }
 
-get_references :: proc(document: ^Document, position: common.Position) -> ([]common.Location, bool) {
+get_references :: proc(document: ^Document, position: common.Position, current_file_only := false) -> ([]common.Location, bool) {
 	ast_context := make_ast_context(
 		document.ast,
 		document.imports,
@@ -410,7 +411,7 @@ get_references :: proc(document: ^Document, position: common.Position) -> ([]com
 		get_locals(document.ast, position_context.function, &ast_context, &position_context)
 	}
 
-	locations, ok2 := resolve_references(document, &ast_context, &position_context)
+	locations, ok2 := resolve_references(document, &ast_context, &position_context, current_file_only)
 
 	temp_locations := make([dynamic]common.Location, 0, context.temp_allocator)
 

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -32,6 +32,7 @@ ResponseParams :: union {
 	WorkspaceEdit,
 	common.Range,
 	[]CodeAction,
+	[]DocumentHighlight,
 }
 
 RequestMessage :: struct {
@@ -143,6 +144,7 @@ ServerCapabilities :: struct {
 	inlayHintProvider:          bool,
 	renameProvider:             RenameOptions,
 	referencesProvider:         bool,
+	documentHighlightProvider:  bool,
 	workspaceSymbolProvider:    bool,
 	documentLinkProvider:       DocumentLinkOptions,
 	codeActionProvider:         CodeActionOptions,
@@ -418,6 +420,7 @@ OlsConfig :: struct {
 	enable_document_symbols:           Maybe(bool),
 	enable_fake_methods:               Maybe(bool),
 	enable_references:                 Maybe(bool),
+	enable_document_highlights:        Maybe(bool),
 	enable_document_links:             Maybe(bool),
 	enable_completion_matching:        Maybe(bool),
 	enable_inlay_hints_params:         Maybe(bool),
@@ -560,6 +563,11 @@ ReferenceParams :: struct {
 	position:     common.Position,
 }
 
+HighlightParams :: struct {
+	textDocument: TextDocumentIdentifier,
+	position:     common.Position,
+}
+
 OptionalVersionedTextDocumentIdentifier :: struct {
 	uri:     string,
 	version: Maybe(int),
@@ -586,4 +594,15 @@ WorkspaceSymbol :: struct {
 
 DidChangeConfigurationParams :: struct {
 	settings: OlsConfig,
+}
+
+DocumentHighlight :: struct {
+	range: common.Range,
+	kind:  DocumentHighlightKind,
+}
+
+DocumentHighlightKind :: enum {
+	Text  = 1,
+	Read  = 2,
+	Write = 3,
 }


### PR DESCRIPTION
This PR implements (basic) support for [documentHighlight](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight).

I noticed that Helix/Zed has support for this and "complained" that ols does not.

From the spec 
> For programming languages this usually highlights all references to the symbol scoped to this file.

so I did just that. Reused everything possible from 'references' and just added what's strictly necessary to support this.
