### PR TITLE
Use the same create_uri function to ensure the uri is consistant when sending diagnostics.

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -72,12 +72,14 @@ check_unused_imports :: proc(document: ^Document, config: ^common.Config) {
 
 	unused_imports := find_unused_imports(document, context.temp_allocator)
 
-	remove_diagnostics(.Unused, document.uri.uri)
+	uri := common.create_uri(document.uri.path, context.temp_allocator)
+
+	remove_diagnostics(.Unused, uri.uri)
 
 	for imp in unused_imports {
 		add_diagnostics(
 			.Unused,
-			document.uri.uri,
+			uri.uri,
 			Diagnostic {
 				range = common.get_token_range(imp.import_decl, document.ast.src),
 				severity = DiagnosticSeverity.Hint,

--- a/src/server/diagnostics.odin
+++ b/src/server/diagnostics.odin
@@ -20,12 +20,6 @@ add_diagnostics :: proc(type: DiagnosticType, uri: string, diagnostic: Diagnosti
 		return
 	}
 
-	uri := uri
-
-	when ODIN_OS == .Windows {
-		uri = strings.to_lower(uri, context.temp_allocator)
-	}
-
 	diagnostic_array := &diagnostic_type[uri]
 
 	if diagnostic_array == nil {
@@ -47,12 +41,6 @@ remove_diagnostics :: proc(type: DiagnosticType, uri: string) {
 	if diagnostic_type == nil {
 		log.errorf("Diagnostic type did not exist: %v", type)
 		return
-	}
-
-	uri := uri
-
-	when ODIN_OS == .Windows {
-		uri = strings.to_lower(uri, context.temp_allocator)
 	}
 
 	diagnostic_array := &diagnostic_type[uri]

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -326,10 +326,12 @@ document_refresh :: proc(document: ^Document, config: ^common.Config, writer: ^W
 	if writer != nil && !config.disable_parser_errors {
 		document.diagnosed_errors = true
 
+		uri := common.create_uri(document.uri.path, context.temp_allocator)
+
 		for error, i in errors {
 			add_diagnostics(
 				.Syntax,
-				document.uri.uri,
+				uri.uri,
 				Diagnostic {
 					range = common.Range {
 						start = common.Position{line = error.line - 1, character = 0},


### PR DESCRIPTION
Don't use the uri from the document that is received from the client on document open. Instead create it again from the path to ensure consistency in all diagnostics from "unused", "checker", "syntax". Checker can't use the document uri, because it gets the path from `odin check`.

The clients can send different encodings:
```
file:///c:/project/readme.md
file:///C%3A/project/readme.md
```