### PR TITLE
Clone and free Selector_Call_Expr

### DIFF
--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -659,6 +659,9 @@ free_ast_node :: proc(node: ^ast.Node, allocator: mem.Allocator) {
 	case ^Selector_Expr:
 		free_ast(n.expr, allocator)
 		free_ast(n.field, allocator)
+	case ^Selector_Call_Expr:
+		free_ast(n.expr, allocator)
+		free_ast(n.call, allocator)
 	case ^Implicit_Selector_Expr:
 		free_ast(n.field, allocator)
 	case ^Index_Expr:

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -175,6 +175,9 @@ clone_node :: proc(node: ^ast.Node, allocator: mem.Allocator, unique_strings: ^m
 	case ^Selector_Expr:
 		r.expr = clone_type(r.expr, allocator, unique_strings)
 		r.field = auto_cast clone_type(r.field, allocator, unique_strings)
+	case ^Selector_Call_Expr:
+		r.expr = clone_type(r.expr, allocator, unique_strings)
+		r.call = auto_cast clone_type(r.call, allocator, unique_strings)
 	case ^Implicit_Selector_Expr:
 		r.field = auto_cast clone_type(r.field, allocator, unique_strings)
 	case ^Slice_Expr:


### PR DESCRIPTION
It was raised in discord ols was crashing when trying to free a `Selector_Call_Expr`:

```
2025-10-22 09:25:04.220 [error] Starting Odin Language Server nightly-2025-10-05-317b9b7
2025-10-22 09:30:09.485 [error] D:/a/ols/ols/src/server/ast.odin(834:3) panic: free Unhandled node kind: &Selector_Call_Expr{node = Expr{expr_base = Node{pos = Pos{file = "E:/dev/dx12/main.odin", offset = 29604, line = 1153, column = 2}, end = Pos{file = "E:/dev/dx12/main.odin", offset = 29788, line = 1161, column = 3}, state_flags = Node_State_Flags{}, derived = 0x1C0FD6668F8}, derived_expr = 0x1C0FD6668F8}, expr = 0x1C0F056B358, call = 0x1C0F056C0C8, modified_call = false}
```

Should fix this.