### PR TITLE
Display hover information for untyped complex numbers and quaternions correctly

### DIFF
--- a/src/server/builtins.odin
+++ b/src/server/builtins.odin
@@ -1,7 +1,6 @@
 package server
 
 import "core:fmt"
-import "core:log"
 import "core:odin/ast"
 import "core:strconv"
 

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -445,6 +445,10 @@ write_short_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, sy
 				strings.write_string(sb, "bool")
 			case .Integer:
 				strings.write_string(sb, "int")
+			case .Complex:
+				strings.write_string(sb, "complex")
+			case .Quaternion:
+				strings.write_string(sb, "quaternion")
 			}
 			return
 		}

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -138,6 +138,8 @@ SymbolBitSetValue :: struct {
 SymbolUntypedValueType :: enum {
 	Integer,
 	Float,
+	Complex,
+	Quaternion,
 	String,
 	Bool,
 }

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -1,6 +1,5 @@
 package tests
 
-import "core:fmt"
 import "core:testing"
 
 import test "src:testing"
@@ -5321,6 +5320,32 @@ ast_hover_proc_arg_generic_bit_set :: proc(t: ^testing.T) {
 		`,
 	}
 	test.expect_hover(t, &source, "test.foo :: proc($T: typeid/bit_set[$F; $E])")
+}
+
+@(test)
+ast_hover_complex_number_literal :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			f{*}oo := 1 + 1i
+		}
+
+		`,
+	}
+	test.expect_hover(t, &source, "test.foo: complex")
+}
+
+@(test)
+ast_hover_quaternion_literal :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			f{*}oo := 1 + 2i + 3j + 4k
+		}
+
+		`,
+	}
+	test.expect_hover(t, &source, "test.foo: quaternion")
 }
 /*
 


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1128