### PR TITLE
Add complete types for untyped expr as we now show full values for constants

### DIFF
--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -438,7 +438,7 @@ write_short_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, sy
 		if .Mutable in symbol.flags || symbol.type == .Field {
 			switch v.type {
 			case .Float:
-				strings.write_string(sb, "float")
+				strings.write_string(sb, "f64")
 			case .String:
 				strings.write_string(sb, "string")
 			case .Bool:
@@ -446,9 +446,9 @@ write_short_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, sy
 			case .Integer:
 				strings.write_string(sb, "int")
 			case .Complex:
-				strings.write_string(sb, "complex")
+				strings.write_string(sb, "complex128")
 			case .Quaternion:
-				strings.write_string(sb, "quaternion")
+				strings.write_string(sb, "quaternion256")
 			}
 			return
 		}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -4506,7 +4506,7 @@ ast_hover_float_binary_expr :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.bar: float")
+	test.expect_hover(t, &source, "test.bar: f64")
 }
 
 @(test)
@@ -5332,7 +5332,7 @@ ast_hover_complex_number_literal :: proc(t: ^testing.T) {
 
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo: complex")
+	test.expect_hover(t, &source, "test.foo: complex128")
 }
 
 @(test)
@@ -5345,7 +5345,7 @@ ast_hover_quaternion_literal :: proc(t: ^testing.T) {
 
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo: quaternion")
+	test.expect_hover(t, &source, "test.foo: quaternion256")
 }
 /*
 


### PR DESCRIPTION
Part 2 for https://github.com/DanielGavin/ols/issues/1128

With the recent improvements to constants, these "untyped" values are actually typed by the checker. We now show the full default types instead.