### PR TITLE
Correctly provide completions for proc default args that are a selector expr

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1535,6 +1535,8 @@ get_implicit_completion :: proc(
 					if type == nil {
 						if comp_lit, ok := arg_type.default_value.derived.(^ast.Comp_Lit); ok {
 							type = comp_lit.type
+						} else if selector, ok := arg_type.default_value.derived.(^ast.Selector_Expr); ok {
+							type = selector.expr
 						}
 					}
 

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4846,3 +4846,23 @@ ast_completion_fixed_array_enum :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs(t, &source, "", {"A", "B", "C"})
 }
+
+@(test)
+ast_completion_proc_enum_default_value :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: enum {
+			A,
+			B,
+			C,
+		}
+
+		bar :: proc(foo := Foo.A) {}
+
+		main :: proc() {
+			bar(.{*})
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {"A", "B", "C"})
+}


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1119