### PR TITLE
Switch to arm based macos for ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         path: ./dist
 
   dist-x86_64-darwin:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
With the macos 13 intel runners closing soon, it seems like a good time to switch to uses `macos-latest` arm runners for the ci and to`macos-15-intel` for the releases: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#notice-of-macos-x86_64-intel-architecture-deprecation