### PR TITLE
Fix crash with typing for for in statement

### DIFF
--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -677,21 +677,23 @@ get_locals_for_range_stmt :: proc(
 		case SymbolProcedureValue:
 			calls := make(map[int]struct{}, context.temp_allocator)
 			get_generic_assignment(file, stmt.expr, ast_context, &results, &calls, {}, false)
-			for val, i in stmt.vals {
-				if ident, ok := unwrap_ident(val); ok {
-					result_i := min(len(results) - 1, i)
-					store_local(
-						ast_context,
-						ident,
-						results[result_i],
-						ident.pos.offset,
-						ident.name,
-						ast_context.non_mutable_only,
-						false,
-						{.Mutable},
-						symbol.pkg,
-						false,
-					)
+			if len(results) > 0 {
+				for val, i in stmt.vals {
+					if ident, ok := unwrap_ident(val); ok {
+						result_i := min(len(results) - 1, i)
+						store_local(
+							ast_context,
+							ident,
+							results[result_i],
+							ident.pos.offset,
+							ident.name,
+							ast_context.non_mutable_only,
+							false,
+							{.Mutable},
+							symbol.pkg,
+							false,
+						)
+					}
 				}
 			}
 		case SymbolUntypedValue:


### PR DESCRIPTION
It's been a semi frequently raised issue where for loops would cause ols to crash. I was finally able to reproduce it from the code here: https://github.com/Stannic-7863/LemonGui/blob/0a55f13895aecec33e9b2815a620f81505b54a13/example/widgets/widgets.odin#L392. Trying to recreate those for loops in the code would cause it to crash due to trying to index `results` with `-1`