### PR TITLE
Correctly provide completions for an empty selector before a label

### DIFF
--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4951,3 +4951,24 @@ ast_completion_selector_after_selector_call_expr :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs(t, &source, "", {"Data.x: int", "Data.y: int"})
 }
+
+@(test)
+ast_completion_selector_before_label :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Foo :: struct {
+		  bar: int,
+		}
+
+		main :: proc() {
+		  foo: Foo
+		  foo.{*}
+
+		  Label: {
+
+		  }
+		}
+		`,
+	}
+	test.expect_completion_docs(t, &source, "", {"Foo.bar: int"})
+}


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1158

As mentioned on discord, this was due to the selector being followed by a label. Since the label is added as part of the following statement, and the position is not in the statement itself, it was skipped.