### PR TITLE
added #all_or_none

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1613,6 +1613,10 @@ visit_expr :: proc(
 			document = cons_with_nopl(document, text("#no_copy"))
 		}
 
+		if v.is_all_or_none {
+			document = cons_with_nopl(document, text("#all_or_none"))
+		}
+
 		if v.align != nil {
 			document = cons_with_nopl(document, text("#align"))
 			document = cons_with_nopl(document, visit_expr(p, v.align))

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -166,6 +166,9 @@ collect_struct_fields :: proc(
 	b.align = clone_expr(struct_type.align, collection.allocator, &collection.unique_strings)
 	b.max_field_align = clone_expr(struct_type.max_field_align, collection.allocator, &collection.unique_strings)
 	b.min_field_align = clone_expr(struct_type.min_field_align, collection.allocator, &collection.unique_strings)
+	if struct_type.is_all_or_none {
+		b.tags |= {.Is_All_Or_None}
+	}
 	if struct_type.is_no_copy {
 		b.tags |= {.Is_No_Copy}
 	}

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -586,6 +586,7 @@ DIRECTIVE_NAME_LIST :: []string {
 	"packed",
 	"raw_union",
 	"align",
+	"all_or_none",
 	/* union type */
 	"no_nil",
 	"shared_nil",

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -634,6 +634,9 @@ write_struct_hover :: proc(sb: ^strings.Builder, ast_context: ^AstContext, v: Sy
 		case .Is_No_Copy:
 			wrote_tag = true
 			strings.write_string(sb, " #no_copy")
+		case .Is_All_Or_None:
+			wrote_tag = true
+			strings.write_string(sb, " #all_or_none")
 		}
 	}
 

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -16,6 +16,7 @@ SymbolStructTag :: enum {
 	Is_Packed,
 	Is_Raw_Union,
 	Is_No_Copy,
+	Is_All_Or_None,
 }
 
 SymbolStructTags :: bit_set[SymbolStructTag]
@@ -427,6 +428,9 @@ write_struct_type :: proc(
 		b.align = v.align
 		b.max_field_align = v.max_field_align
 		b.min_field_align = v.min_field_align
+		if v.is_all_or_none {
+			b.tags |= {.Is_All_Or_None}
+		}
 		if v.is_no_copy {
 			b.tags |= {.Is_No_Copy}
 		}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3972,11 +3972,11 @@ ast_hover_struct_tags :: proc(t: ^testing.T) {
 ast_hover_struct_tags_packed :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
-		Fo{*}o :: struct($T: typeid) #packed {
+		Fo{*}o :: struct($T: typeid) #packed #all_or_none {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.Foo :: struct($T: typeid) #packed {}")
+	test.expect_hover(t, &source, "test.Foo :: struct($T: typeid) #packed #all_or_none {}")
 }
 
 @(test)


### PR DESCRIPTION
this adds the `#all_or_none` directive. ~~this still doesn't show up in the errors pre-compilation but that seems to be because `odin check . -json-errors` reports `null` for the `pos` field so more work is probably going to be needed upstream~~ edit: fixed by pulling latest `master`