### PR TITLE
Fix indentation for doc comments using `/**/` within other procedures

### DIFF
--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -2,7 +2,6 @@
 package server
 
 import "core:fmt"
-import "core:log"
 import "core:mem"
 import "core:odin/ast"
 import "core:odin/parser"
@@ -572,7 +571,26 @@ get_doc :: proc(comment: ^ast.Comment_Group, allocator: mem.Allocator) -> string
 	tmp: string
 
 	for doc in comment.list {
-		tmp = strings.concatenate({tmp, "\n", doc.text}, context.temp_allocator)
+		if strings.starts_with(doc.text, "/*") && doc.pos.column != 1 {
+			lines := strings.split(doc.text, "\n", context.temp_allocator)
+			for line, i in lines {
+				if i != 0 && len(line) > 0 {
+					column := 0
+					for column < doc.pos.column - 1 {
+						if line[column] == '\t' || line[column] == ' ' {
+							column += 1
+						} else {
+							break
+						}
+					}
+					tmp = strings.concatenate({tmp, "\n", line[column:]}, context.temp_allocator)
+				} else {
+					tmp = strings.concatenate({tmp, "\n", line}, context.temp_allocator)
+				}
+			}
+		} else {
+			tmp = strings.concatenate({tmp, "\n", doc.text}, context.temp_allocator)
+		}
 	}
 
 	if tmp != "" {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -5770,6 +5770,40 @@ ast_hover_type_assertion_unary_value_ok :: proc(t: ^testing.T) {
 	}
 	test.expect_hover(t, &source, "test.ok: bool")
 }
+
+@(test)
+ast_hover_nested_proc_docs_tabs :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		main :: proc() {
+			/*
+			Docs!
+				Docs2
+			*/
+			f{*}oo :: proc() {}
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.foo :: proc()\n\nDocs!\n\tDocs2\n")
+}
+
+@(test)
+ast_hover_nested_proc_docs_spaces :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		main :: proc() {
+            /*
+            Docs!
+                Docs2
+            */
+			f{*}oo :: proc() {}
+		}
+		`,
+	}
+	test.expect_hover(t, &source, "test.foo :: proc()\n\nDocs!\n    Docs2\n")
+}
 /*
 
 Waiting for odin fix


### PR DESCRIPTION
Resolves https://github.com/DanielGavin/ols/issues/1192