### PR TITLE
Propagate docs and comments for aliases defined in other packages

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2658,6 +2658,12 @@ resolve_unresolved_symbol :: proc(ast_context: ^AstContext, symbol: ^Symbol) -> 
 			symbol.value = ret.value
 			symbol.pkg = ret.pkg
 			symbol.flags |= ret.flags
+			if symbol.doc == "" {
+				symbol.doc = ret.doc
+			}
+			if symbol.comment == "" {
+				symbol.comment = ret.comment
+			}
 		} else {
 			return false
 		}


### PR DESCRIPTION
I noticed docs weren't working with `strings.starts_with` since it's an alias of `strings.has_prefix`. This propagates the comments and docs correctly.