### PR TITLE
Add region folding for vscode

### DIFF
--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -28,5 +28,10 @@
         "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$|^\\s*case.*:$",
         "decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
     },
-    
+    "folding": {
+        "markers": {
+            "start": "^\\s*//\\s*?region\\b",
+            "end": "^\\s*//\\s*?endregion\\b"
+        }
+    }  
 }


### PR DESCRIPTION
Usually people perfer to write code in one file in odin. Region folding makes code more clearly. 
When someone reads the code, this lets them know what each piece is. And other languages generally have this feature.
```odin
//region name
//endregion
```
