### PR TITLE
Add optional feature for displaying signature help for comp literals

### DIFF
--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -92,6 +92,11 @@
 			"description": "Follow links when opening documentation.",
 			"default": true
 		},
+		"enable_comp_lit_signature_help": {
+			"type": "boolean",
+			"description": "Provide signature help for comp lits such as when instanciating structs. Will not display correctly on some editors such as vscode.",
+			"default": false
+		},
 		"disable_parser_errors": { "type": "boolean" },
 		"verbose": {
 			"type": "boolean",

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -38,6 +38,7 @@ Config :: struct {
 	enable_auto_import:                 bool,
 	enable_completion_matching:         bool,
 	enable_document_links:              bool,
+	enable_comp_lit_signature_help:     bool,
 	disable_parser_errors:              bool,
 	thread_count:                       int,
 	file_log:                           bool,

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -374,6 +374,8 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 	config.enable_completion_matching =
 		ols_config.enable_completion_matching.(bool) or_else config.enable_completion_matching
 	config.enable_document_links = ols_config.enable_document_links.(bool) or_else config.enable_document_links
+	config.enable_comp_lit_signature_help =
+		ols_config.enable_comp_lit_signature_help.(bool) or_else config.enable_comp_lit_signature_help
 	config.verbose = ols_config.verbose.(bool) or_else config.verbose
 	config.file_log = ols_config.file_log.(bool) or_else config.file_log
 
@@ -648,6 +650,7 @@ request_initialize :: proc(
 	config.enable_document_highlights = true
 	config.enable_completion_matching = true
 	config.enable_document_links = true
+	config.enable_comp_lit_signature_help = false
 	config.verbose = false
 	config.file_log = false
 	config.odin_command = ""
@@ -977,7 +980,7 @@ request_signature_help :: proc(
 	}
 
 	help: SignatureHelp
-	help, ok = get_signature_information(document, signature_params.position)
+	help, ok = get_signature_information(document, signature_params.position, config)
 
 	if !ok {
 		return .InternalError

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -411,6 +411,9 @@ write_struct_type :: proc(
 			}
 		}
 	}
+    s := Symbol{
+        
+    }
 
 	if _, ok := get_attribute_objc_class_name(attributes); ok {
 		b.symbol.flags |= {.ObjC}

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -422,6 +422,7 @@ OlsConfig :: struct {
 	enable_references:                 Maybe(bool),
 	enable_document_highlights:        Maybe(bool),
 	enable_document_links:             Maybe(bool),
+	enable_comp_lit_signature_help:    Maybe(bool),
 	enable_completion_matching:        Maybe(bool),
 	enable_inlay_hints_params:         Maybe(bool),
 	enable_inlay_hints_default_params: Maybe(bool),

--- a/tests/signatures_test.odin
+++ b/tests/signatures_test.odin
@@ -1,6 +1,5 @@
 package tests
 
-import "core:fmt"
 import "core:testing"
 
 import test "src:testing"
@@ -559,6 +558,94 @@ proc_signature_move_outside :: proc(t: ^testing.T) {
 		t,
 		&source,
 		{"test.my_cool_function :: proc(aa: int, ba: int, c: int)"},
+	)
+}
+
+@(test)
+signature_comp_lit_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			a: int,
+			b: string,
+		}
+
+		main :: proc() {
+			foo := Foo{
+				{*}
+			}
+		}
+		`,
+		packages = {},
+		config = {
+			enable_comp_lit_signature_help = true,
+		}
+	}
+
+	test.expect_signature_labels(
+		t,
+		&source,
+		{"test.Foo :: struct {\n\ta: int,\n\tb: string,\n}"},
+	)
+}
+
+@(test)
+signature_comp_lit_struct_pre_declared :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			a: int, // comment for a
+			b: string,
+		}
+
+		main :: proc() {
+			foo: Foo
+			foo = {
+				{*}
+			}
+		}
+		`,
+		packages = {},
+		config = {
+			enable_comp_lit_signature_help = true,
+		}
+	}
+
+	test.expect_signature_labels(
+		t,
+		&source,
+		{"test.Foo :: struct {\n\ta: int, // comment for a\n\tb: string,\n}"},
+	)
+}
+
+@(test)
+signature_comp_lit_bit_set :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		Foo :: struct {
+			A,
+			B,
+		}
+
+		Bar :: bit_set[Foo]
+
+		main :: proc() {
+			bar: Bar
+			bar = {
+				{*}
+			}
+		}
+		`,
+		packages = {},
+		config = {
+			enable_comp_lit_signature_help = true,
+		}
+	}
+
+	test.expect_signature_labels(
+		t,
+		&source,
+		{"test.Bar :: bit_set[Foo]"},
 	)
 }
 


### PR DESCRIPTION
Disabled by default as since `textDocument/signatureHelp` doesn't really support markdown, it looks terrible in certain editors such as vscode, but the markdown is properly rendered in others such as neovim and zed.