### PR TITLE
Always set semantic token full capabilities to true when enabled

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -748,7 +748,7 @@ request_initialize :: proc(
 				},
 				semanticTokensProvider = SemanticTokensOptions {
 					range = config.enable_semantic_tokens && semantic_range_support,
-					full = config.enable_semantic_tokens && !semantic_range_support,
+					full = config.enable_semantic_tokens,
 					legend = SemanticTokensLegend {
 						tokenTypes = semantic_token_type_names,
 						tokenModifiers = semantic_token_modifier_names,


### PR DESCRIPTION
Someone reported on discord they were having issues with neovim and semantic tokens when it was enabled. They found they `full` was set to `false` and by setting it to `true` it fixed the issue. Seems like we should be able to just keep this always as `true` and leave it up to the client whether they use the full or range tokens.