### PR TITLE
Avoid passing `-collection:shared=...` to odin invocation

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -118,7 +118,7 @@ check :: proc(paths: []string, uri: common.Uri, config: ^common.Config) {
 	collection_builder := strings.builder_make(context.temp_allocator)
 
 	for k, v in common.config.collections {
-		if k == "" || k == "core" || k == "vendor" || k == "base" {
+		if k == "" || k == "core" || k == "vendor" || k == "base" || k == "shared" {
 			continue
 		}
 		strings.write_string(&collection_builder, fmt.aprintf("-collection:%v=\"%v\" ", k, v))


### PR DESCRIPTION
On ols version `dev-2025-12-30-16cd61e-debug` with odin version `dev-2025-12:c46e65809`, I am getting error logs because ols seems to pass a `-collection:shared=...` flag:

`Failed to unmarshal check results: Invalid_Data, Library collection 'shared' path must be a directory, got '/usr/local/bin/shared'`

The full odin invocation is:

```
odin check "/home/username/project/dir" -collection:shared="/usr/local/bin/shared" <checker_opts>  
 -json-errors 2>&1
```

I only seem to have this problem on the zed editor.

Also not entirely sure why this shared collection path is relative to the ols executable (basedir \<ols path\> / shared) (as per common.config.collections):

https://github.com/DanielGavin/ols/blob/16cd61e0f5ad5409f1747c24bdca545423892fdb/src/server/check.odin#L120