### PR TITLE
added stdout flag to odinfmt

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -87,7 +87,7 @@ main :: proc() {
 			append(&data, ..tmp[:r])
 		}
 
-		source, ok := format.format("<stdin>", string(data[:]), config, {.Optional_Semicolons}, arena_allocator)
+		source, ok := format.format("<stdin>", transmute(string)data[:], config, {.Optional_Semicolons}, arena_allocator)
 
 		if ok {
 			if args.stdout {
@@ -101,7 +101,6 @@ main :: proc() {
 		} else {
 			write_failure = true
 		}
-
 	} else if os.is_file(args.path) {
 		if args.write {
 			backup_path := strings.concatenate({args.path, "_bk"})


### PR DESCRIPTION
Added `stdout` flag to odinfmt to allow outputting to stdout. Is only valid when also using stdin. I considered just making this the default behaviour when using stdin instead of fmt.println but decided to leave that decision to someone else. 