### PR TITLE
Remove broken references to 'is_all_or_none' field

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1613,10 +1613,6 @@ visit_expr :: proc(
 			document = cons_with_nopl(document, text("#no_copy"))
 		}
 
-		if v.is_all_or_none {
-			document = cons_with_nopl(document, text("#all_or_none"))
-		}
-
 		if v.align != nil {
 			document = cons_with_nopl(document, text("#align"))
 			document = cons_with_nopl(document, visit_expr(p, v.align))

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -166,9 +166,6 @@ collect_struct_fields :: proc(
 	b.align = clone_expr(struct_type.align, collection.allocator, &collection.unique_strings)
 	b.max_field_align = clone_expr(struct_type.max_field_align, collection.allocator, &collection.unique_strings)
 	b.min_field_align = clone_expr(struct_type.min_field_align, collection.allocator, &collection.unique_strings)
-	if struct_type.is_all_or_none {
-		b.tags |= {.Is_All_Or_None}
-	}
 	if struct_type.is_no_copy {
 		b.tags |= {.Is_No_Copy}
 	}

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -430,9 +430,6 @@ write_struct_type :: proc(
 		b.align = v.align
 		b.max_field_align = v.max_field_align
 		b.min_field_align = v.min_field_align
-		if v.is_all_or_none {
-			b.tags |= {.Is_All_Or_None}
-		}
 		if v.is_no_copy {
 			b.tags |= {.Is_No_Copy}
 		}


### PR DESCRIPTION
### Changes made
Remove bad references to `is_all_or_none` field.

Fixes https://github.com/DanielGavin/ols/issues/1245.