### PR TITLE
Use default heap allocator instead of fixed 50 MB arena for odinfmt

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -46,7 +46,7 @@ walk_files :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (
 
 main :: proc() {
 	arena: vmem.Arena
-	arena_err := vmem.arena_init_growing(&arena, 50)
+	arena_err := vmem.arena_init_growing(&arena)
 	ensure(arena_err == nil)
 	arena_allocator := vmem.arena_allocator(&arena)
 


### PR DESCRIPTION
Root cause of my issue #1248 (barring having a Very Large Source File) was that the 50 MB arena allocator wasn't enough. I don't think its much of a solution to just up the number and I don't want to get into the headache of dynamic arrays and arenas, so the simple solution is just not use a custom arena and instead take from the heap as much as needed...

Sadly peak memory used statistic can no longer be tracked but maybe that is OK.

Sorry for a bit of a "cold drop" and let me know if you have any thoughts. :pray: