### PR TITLE
Feat: Add support for odinfmt custom config path

### DIFF
--- a/src/odin/format/format.odin
+++ b/src/odin/format/format.odin
@@ -49,6 +49,26 @@ find_config_file_or_default :: proc(path: string) -> printer.Config {
 	return config
 }
 
+// Tries to read the config file from a given path instead
+// of searching for it up a directory tree of a path
+read_config_file_from_path_or_default :: proc(config_path: string) -> printer.Config {
+    path := config_path
+    ok: bool
+	if path, ok = filepath.abs(config_path); !ok {
+		return default_style
+	}
+    config := default_style
+    if (os.exists(path)) {
+        if data, ok := os.read_entire_file(path, context.temp_allocator); ok {
+            if json.unmarshal(data, &config) == nil {
+                return config
+            }
+        }
+    }
+
+    return default_style
+}
+
 format :: proc(
 	filepath: string,
 	source: string,

--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -17,6 +17,7 @@ Args :: struct {
 	write: bool `args:"name=w" usage:"write the new format to file"`,
 	stdin: bool `usage:"formats code from standard input"`,
 	path:  string `args:"pos=0" usage:"set the file or directory to format"`,
+    config: string `usage:"path to a config file"`
 }
 
 format_file :: proc(filepath: string, config: printer.Config, allocator := context.allocator) -> (string, bool) {
@@ -72,7 +73,12 @@ main :: proc() {
 
 	watermark := 0
 
-	config := format.find_config_file_or_default(args.path)
+    config: printer.Config
+    if args.config == "" {
+	    config = format.find_config_file_or_default(args.path)
+    } else {
+        config = format.read_config_file_from_path_or_default(args.config)
+    }
 
 	if args.stdin {
 		data := make([dynamic]byte, arena_allocator)


### PR DESCRIPTION
Introduces a new argument to -config which allows a user to pass a json config for the formatter which is not neccesarilly in the path of the files we are formatting. For now the function will use the default_style if any errors occur. This was done due to that being the pattern in the source code. I think it would be useful to know if reading a config has failed or has defaulted to a default style but, I wanted to not include that in this. Maybe in the future this can be addressed in another pull request. There has been a few occasions where I noticed that the formatter was not using the config that I was expecting.