### PR TITLE
Improve hover documentation formatting

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1981,8 +1981,8 @@ resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, loca
 	return_symbol.flags |= {.Local}
 	return_symbol.value_expr = local.value_expr
 	return_symbol.type_expr = local.type_expr
-	return_symbol.doc = get_doc(local.docs, ast_context.allocator)
-	return_symbol.comment = get_comment(local.comment)
+	return_symbol.doc = get_comment(local.docs, ast_context.allocator)
+	return_symbol.comment = get_comment(local.comment, ast_context.allocator)
 
 	return return_symbol, ok
 }
@@ -2071,11 +2071,11 @@ resolve_global_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, glo
 	}
 
 	if global.docs != nil {
-		return_symbol.doc = get_doc(global.docs, ast_context.allocator)
+		return_symbol.doc = get_comment(global.docs, ast_context.allocator)
 	}
 
 	if global.comment != nil {
-		return_symbol.comment = get_comment(global.comment)
+		return_symbol.comment = get_comment(global.comment, ast_context.allocator)
 	}
 
 	return_symbol.type_expr = global.type_expr

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -705,12 +705,12 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 		symbol.range = common.get_token_range(expr.name_expr, file.src)
 		symbol.name = get_index_unique_string(collection, name)
 		symbol.type = token_type
-		symbol.doc = get_doc(expr.docs, collection.allocator)
+		symbol.doc = get_comment(expr.docs, collection.allocator)
 		symbol.uri = get_index_unique_string(collection, uri)
 		symbol.type_expr = clone_type(expr.type_expr, collection.allocator, &collection.unique_strings)
 		symbol.value_expr = clone_type(expr.value_expr, collection.allocator, &collection.unique_strings)
 		comment, _ := get_file_comment(file, symbol.range.start.line + 1)
-		symbol.comment = strings.clone(get_comment(comment), collection.allocator)
+		symbol.comment = get_comment(comment, collection.allocator)
 
 		if expr.builtin || strings.contains(uri, "builtin.odin") {
 			symbol.pkg = "$builtin"

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -6,6 +6,10 @@ import "core:odin/ast"
 import path "core:path/slashpath"
 import "core:strings"
 
+DOC_SECTION_DELIMITER :: "\n---\n"                                   // The string separating each section of documentation
+DOC_FMT_ODIN          :: "```odin\n%v\n```"                          // The format for wrapping odin code in a markdown codeblock
+DOC_FMT_MARKDOWN      :: DOC_FMT_ODIN + DOC_SECTION_DELIMITER + "%v" // The format for presenting documentation on hover
+
 // Adds signature and docs information to the provided symbol
 // This should only be used for a symbol created with the temp allocator
 build_documentation :: proc(ast_context: ^AstContext, symbol: ^Symbol, short_signature := true) {
@@ -20,21 +24,17 @@ build_documentation :: proc(ast_context: ^AstContext, symbol: ^Symbol, short_sig
 	}
 }
 
-construct_symbol_docs :: proc(symbol: Symbol, markdown := true, allocator := context.temp_allocator) -> string {
+construct_symbol_docs :: proc(symbol: Symbol, allocator := context.temp_allocator) -> string {
 	sb := strings.builder_make(allocator = allocator)
 	if symbol.doc != "" {
 		strings.write_string(&sb, symbol.doc)
-		if symbol.comment != "" {
-			strings.write_string(&sb, "\n")
-		}
 	}
 
 	if symbol.comment != "" {
-		if markdown {
-			fmt.sbprintf(&sb, "\n```odin\n%s\n```", symbol.comment)
-		} else {
-			fmt.sbprintf(&sb, "\n%s", symbol.comment)
+		if symbol.doc != "" {
+			strings.write_string(&sb, DOC_SECTION_DELIMITER)
 		}
+		strings.write_string(&sb, symbol.comment)
 	}
 
 	return strings.to_string(sb)

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -16,7 +16,11 @@ write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupC
 
 	if cat != "" {
 		content.kind = "markdown"
-		content.value = fmt.tprintf("```odin\n%v\n```%v", cat, doc)
+		if doc != "" {
+			content.value = fmt.tprintf(DOC_FMT_MARKDOWN, cat, doc)
+		} else {
+			content.value = fmt.tprintf(DOC_FMT_ODIN, cat)
+		}
 	} else {
 		content.kind = "plaintext"
 	}

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -110,7 +110,7 @@ get_signature_information :: proc(
 				&signature_information,
 				SignatureInformation {
 					label = get_signature(symbol),
-					documentation = construct_symbol_docs(symbol, markdown = false),
+					documentation = construct_symbol_docs(symbol),
 				},
 			)
 		}
@@ -176,7 +176,7 @@ add_proc_signature :: proc(
 
 		info := SignatureInformation {
 			label         = get_signature(call),
-			documentation = construct_symbol_docs(call, markdown = false),
+			documentation = construct_symbol_docs(call),
 			parameters    = parameters,
 		}
 		append(signature_information, info)
@@ -204,7 +204,7 @@ add_proc_signature :: proc(
 
 				info := SignatureInformation {
 					label         = get_signature(symbol),
-					documentation = construct_symbol_docs(symbol, markdown = false),
+					documentation = construct_symbol_docs(symbol),
 					parameters    = parameters,
 				}
 

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -922,8 +922,8 @@ construct_struct_field_symbol :: proc(symbol: ^Symbol, parent_name: string, valu
 	symbol.name = value.names[index]
 	symbol.type = .Field
 	symbol.parent_name = parent_name
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
-	symbol.comment = get_comment(value.comments[index])
+	symbol.doc = get_comment(value.docs[index], context.temp_allocator)
+	symbol.comment = get_comment(value.comments[index], context.temp_allocator)
 	symbol.range = value.ranges[index]
 }
 
@@ -936,16 +936,16 @@ construct_bit_field_field_symbol :: proc(
 	symbol.name = value.names[index]
 	symbol.parent_name = parent_name
 	symbol.type = .Field
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
-	symbol.comment = get_comment(value.comments[index])
+	symbol.doc = get_comment(value.docs[index], context.temp_allocator)
+	symbol.comment = get_comment(value.comments[index], context.temp_allocator)
 	symbol.signature = get_bit_field_field_signature(value, index)
 	symbol.range = value.ranges[index]
 }
 
 construct_enum_field_symbol :: proc(symbol: ^Symbol, value: SymbolEnumValue, index: int) {
 	symbol.type = .Field
-	symbol.doc = get_doc(value.docs[index], context.temp_allocator)
-	symbol.comment = get_comment(value.comments[index])
+	symbol.doc = get_comment(value.docs[index], context.temp_allocator)
+	symbol.comment = get_comment(value.comments[index], context.temp_allocator)
 	symbol.signature = get_enum_field_signature(value, index)
 	symbol.range = value.ranges[index]
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -28,7 +28,7 @@ ast_simple_struct_completion :: proc(t: ^testing.T) {
 		t,
 		&source,
 		".",
-		{"My_Struct.one: int", "My_Struct.two: int\n// test comment", "My_Struct.three: int"},
+		{"My_Struct.one: int", "My_Struct.two: int\n---\ntest comment", "My_Struct.three: int"},
 	)
 }
 
@@ -3296,7 +3296,7 @@ ast_completion_struct_documentation :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_completion_docs(t, &source, "", {"Foo.bazz: my_package.My_Struct\n// bazz"})
+	test.expect_completion_docs(t, &source, "", {"Foo.bazz: my_package.My_Struct\n---\nbazz"})
 }
 
 @(test)
@@ -3417,7 +3417,7 @@ ast_completion_poly_struct_another_package :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_completion_docs(t, &source, "", {"Runner.state: test.State\n// state"})
+	test.expect_completion_docs(t, &source, "", {"Runner.state: test.State\n---\nstate"})
 }
 
 @(test)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -401,7 +401,7 @@ ast_hover_proc_group :: proc(t: ^testing.T) {
 		packages = {},
 	}
 
-	test.expect_hover(t, &source, "test.add :: proc(a, b: int) -> int\n docs\n\n// comment")
+	test.expect_hover(t, &source, "test.add :: proc(a, b: int) -> int\n---\ndocs\n---\ncomment")
 }
 
 @(test)
@@ -672,7 +672,7 @@ ast_hover_struct_field_complex_definition :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "Foo.bar: ^test.Bar\n Docs\n\n// inline docs")
+	test.expect_hover(t, &source, "Foo.bar: ^test.Bar\n---\nDocs\n---\ninline docs")
 }
 
 @(test)
@@ -1084,7 +1084,7 @@ ast_hover_proc_overloading_named_arg_with_selector_expr_with_another_package :: 
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "my_package.foo :: proc(x := 1) -> (_: int, _: bool)\n Docs\n\n// comment")
+	test.expect_hover(t, &source, "my_package.foo :: proc(x := 1) -> (_: int, _: bool)\n---\nDocs\n---\ncomment")
 }
 
 @(test)
@@ -1479,7 +1479,7 @@ ast_hover_proc_comments :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "test.foo :: proc()\n doc\n\n// do foo")
+	test.expect_hover(t, &source, "test.foo :: proc()\n---\ndoc\n---\ndo foo")
 }
 
 @(test)
@@ -1507,7 +1507,7 @@ ast_hover_proc_comments_package :: proc(t: ^testing.T) {
 		packages = packages[:],
 	}
 
-	test.expect_hover(t, &source, "my_package.foo :: proc()\n// do foo")
+	test.expect_hover(t, &source, "my_package.foo :: proc()\n---\ndo foo")
 }
 
 @(test)
@@ -1525,7 +1525,7 @@ ast_hover_struct_field_distinct :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_hover(t, &source, "S.fb: test.B\n// type: fb")
+	test.expect_hover(t, &source, "S.fb: test.B\n---\ntype: fb")
 }
 
 @(test)
@@ -2135,7 +2135,7 @@ ast_hover_bit_field_field :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.foo_aa: uint | 6\n// last 6 bits")
+	test.expect_hover(t, &source, "Foo.foo_aa: uint | 6\n---\nlast 6 bits")
 }
 
 @(test)
@@ -2154,7 +2154,7 @@ ast_hover_bit_field_variable_with_docs :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.foo_a: uint | 2\n doc\n\n// foo a")
+	test.expect_hover(t, &source, "Foo.foo_a: uint | 2\n---\ndoc\n---\nfoo a")
 }
 
 @(test)
@@ -2353,7 +2353,7 @@ ast_hover_struct_field_should_show_docs_and_comments :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.a: int\n a docs\n\n// a comment")
+	test.expect_hover(t, &source, "Foo.a: int\n---\na docs\n---\na comment")
 }
 
 @(test)
@@ -2367,7 +2367,7 @@ ast_hover_struct_field_should_show_docs_and_comments_field :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.a: int\n a docs\n\n// a comment")
+	test.expect_hover(t, &source, "Foo.a: int\n---\na docs\n---\na comment")
 }
 
 @(test)
@@ -2388,7 +2388,7 @@ ast_hover_struct_field_should_show_docs_and_comments_struct_types :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: test.Bar\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2407,7 +2407,7 @@ ast_hover_struct_field_should_show_docs_and_comments_procs :: proc(t: ^testing.T
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2428,7 +2428,7 @@ ast_hover_struct_field_should_show_docs_and_comments_named_procs :: proc(t: ^tes
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> string\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: proc(a: int) -> string\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2447,7 +2447,7 @@ ast_hover_struct_field_should_show_docs_and_comments_maps :: proc(t: ^testing.T)
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: map[int]int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: map[int]int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2466,7 +2466,7 @@ ast_hover_struct_field_should_show_docs_and_comments_bit_sets :: proc(t: ^testin
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: bit_set[0 ..< 10]\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: bit_set[0 ..< 10]\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2490,7 +2490,7 @@ ast_hover_struct_field_should_show_docs_and_comments_unions :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: test.Bar\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: test.Bar\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2509,7 +2509,7 @@ ast_hover_struct_field_should_show_docs_and_comments_multipointers :: proc(t: ^t
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [^]int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: [^]int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2528,7 +2528,7 @@ ast_hover_struct_field_should_show_docs_and_comments_dynamic_arrays :: proc(t: ^
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [dynamic]int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: [dynamic]int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2547,7 +2547,7 @@ ast_hover_struct_field_should_show_docs_and_comments_fixed_arrays :: proc(t: ^te
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: [5]int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: [5]int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -2566,7 +2566,7 @@ ast_hover_struct_field_should_show_docs_and_comments_matrix :: proc(t: ^testing.
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "Foo.bar: matrix[4,5]int\n bar docs\n\n// bar comment")
+	test.expect_hover(t, &source, "Foo.bar: matrix[4,5]int\n---\nbar docs\n---\nbar comment")
 }
 
 @(test)
@@ -3191,7 +3191,7 @@ ast_hover_documentation_reexported :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_hover(t, &source, "my_package.Foo :: struct{}\n Documentation for Foo")
+	test.expect_hover(t, &source, "my_package.Foo :: struct{}\n---\nDocumentation for Foo")
 }
 
 @(test)
@@ -3217,7 +3217,7 @@ ast_hover_override_documentation_reexported :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_hover(t, &source, "my_package.Foo :: struct{}\n New docs for Foo")
+	test.expect_hover(t, &source, "my_package.Foo :: struct{}\n---\nNew docs for Foo")
 }
 
 @(test)
@@ -3495,7 +3495,7 @@ ast_hover_enum_field_directly :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.Foo: .A\n Doc for A and B\n Mulitple lines!\n\n// comment for A and B")
+	test.expect_hover(t, &source, "test.Foo: .A\n---\nDoc for A and B\nMulitple lines!\n---\ncomment for A and B")
 }
 
 @(test)
@@ -3624,7 +3624,7 @@ ast_hover_bit_set_intersection :: proc(t: ^testing.T) {
 		foo_{*}b := foo_bar & {.Foo}  // hover for foo_b
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo_b: distinct bit_set[Flag]\n// hover for foo_b")
+	test.expect_hover(t, &source, "test.foo_b: distinct bit_set[Flag]\n---\nhover for foo_b")
 }
 
 @(test)
@@ -3638,7 +3638,7 @@ ast_hover_bit_set_union :: proc(t: ^testing.T) {
 		foo_{*}b := {.Foo} | foo_bar  // hover for foo_b
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo_b: distinct bit_set[Flag]\n// hover for foo_b")
+	test.expect_hover(t, &source, "test.foo_b: distinct bit_set[Flag]\n---\nhover for foo_b")
 }
 
 @(test)
@@ -5366,7 +5366,7 @@ ast_hover_parapoly_other_package :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_hover(t, &source, "my_package.bar :: proc(_: $T)\n Docs!\n\n// Comment!")
+	test.expect_hover(t, &source, "my_package.bar :: proc(_: $T)\n---\nDocs!\n---\nComment!")
 }
 
 @(test)
@@ -5610,7 +5610,7 @@ ast_hover_local_proc_docs :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo :: proc()\n foo doc")
+	test.expect_hover(t, &source, "test.foo :: proc()\n---\nfoo doc")
 }
 
 @(test)
@@ -5785,7 +5785,7 @@ ast_hover_nested_proc_docs_tabs :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo :: proc()\n\nDocs!\n\tDocs2\n")
+	test.expect_hover(t, &source, "test.foo :: proc()\n---\nDocs!\n\tDocs2\n")
 }
 
 @(test)
@@ -5802,7 +5802,7 @@ ast_hover_nested_proc_docs_spaces :: proc(t: ^testing.T) {
 		}
 		`,
 	}
-	test.expect_hover(t, &source, "test.foo :: proc()\n\nDocs!\n    Docs2\n")
+	test.expect_hover(t, &source, "test.foo :: proc()\n---\nDocs!\n    Docs2\n")
 }
 
 @(test)
@@ -5825,7 +5825,7 @@ ast_hover_propagate_docs_alias_in_package :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_hover(t, &source, "my_package.bar :: proc()\n Docs!\n\n// Comment!")
+	test.expect_hover(t, &source, "my_package.bar :: proc()\n---\nDocs!\n---\nComment!")
 }
 
 @(test)
@@ -5849,7 +5849,7 @@ ast_hover_propagate_docs_alias_in_package_override :: proc(t: ^testing.T) {
 		`,
 		packages = packages[:],
 	}
-	test.expect_hover(t, &source, "my_package.bar :: proc()\n Overridden\n\n// Comment!")
+	test.expect_hover(t, &source, "my_package.bar :: proc()\n---\nOverridden\n---\nComment!")
 }
 
 @(test)


### PR DESCRIPTION
## Summary

- Merged `get_doc` and `get_comment` for standardised comment aggregation and presentation
- Delimit hoverdoc sections with horizontal rules, similar to many other LSP implementations
- Removed odin codeblock wrapping the whole hoverdoc (yes some internal docs will no longer be highlighted but it's arguably better to meet convention and allow arbitrary markdown codeblocks in doc comments.)
- Updated expected content in hover tests

## Example

<img width="1080" height="692" alt="image" src="https://github.com/user-attachments/assets/020d42e0-14dc-44b1-806a-3a95add37e5c" />
