### PR TITLE
Fix checker diagnostics on BSD

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -148,7 +148,7 @@ check :: proc(paths: []string, uri: common.Uri, config: ^common.Config) {
 				entry_point_opt,
 				config.checker_args,
 				"-json-errors",
-				ODIN_OS == .Linux || ODIN_OS == .Darwin ? "2>&1" : "",
+				ODIN_OS in runtime.Odin_OS_Types{.Linux, .Darwin, .FreeBSD, .OpenBSD, .NetBSD} ? "2>&1" : "",
 			),
 			&data,
 		); !ok {


### PR DESCRIPTION
The output of the `check` command must be redirected to stdout on `BSD` systems too, otherwise the diagnostics cannot be processed. To reduce repetition, the separate conditional checks for `ODIN_OS` are combined into one `bit_set` test.

`Haiku` is probably also affected, but I have no experience with it and therefore didn't include it here.