### PR TITLE
Update ols to use the new os and filepath packages

### DIFF
--- a/src/common/uri.odin
+++ b/src/common/uri.odin
@@ -45,7 +45,7 @@ parse_uri :: proc(value: string, allocator: mem.Allocator) -> (Uri, bool) {
 
 //Note(Daniel, Again some really incomplete and scuffed uri writer)
 create_uri :: proc(path: string, allocator: mem.Allocator) -> Uri {
-	path_forward, _ := filepath.to_slash(path, context.temp_allocator)
+	path_forward, _ := filepath.replace_path_separators(path, '/', context.temp_allocator)
 
 	builder := strings.builder_make(allocator)
 

--- a/src/main.odin
+++ b/src/main.odin
@@ -14,14 +14,14 @@ import "src:server"
 VERSION := #config(VERSION, "dev")
 
 os_read :: proc(handle: rawptr, data: []byte) -> (int, int) {
-	ptr := cast(^os.Handle)handle
-	a, b := os.read(ptr^, data)
+	ptr := cast(^os.File)handle
+	a, b := os.read(ptr, data)
 	return a, cast(int)(b != nil)
 }
 
 os_write :: proc(handle: rawptr, data: []byte) -> (int, int) {
-	ptr := cast(^os.Handle)handle
-	a, b := os.write(ptr^, data)
+	ptr := cast(^os.File)handle
+	a, b := os.write(ptr, data)
 	return a, cast(int)(b != nil)
 }
 
@@ -102,8 +102,8 @@ main :: proc() {
 		fmt.println("ols version", VERSION)
 		os.exit(0)
 	}
-	reader := server.make_reader(os_read, cast(rawptr)&os.stdin)
-	writer := server.make_writer(os_write, cast(rawptr)&os.stdout)
+	reader := server.make_reader(os_read, cast(rawptr)os.stdin)
+	writer := server.make_writer(os_write, cast(rawptr)os.stdout)
 
 	/*
 	fh, err := os.open("log.txt", os.O_RDWR|os.O_CREATE) 

--- a/src/odin/format/format.odin
+++ b/src/odin/format/format.odin
@@ -18,8 +18,8 @@ find_config_file_or_default :: proc(path: string) -> printer.Config {
 	//go up the directory until we find odinfmt.json
 	path := path
 
-	ok: bool
-	if path, ok = filepath.abs(path); !ok {
+	err: os.Error
+	if path, err = filepath.abs(path, context.temp_allocator); err != nil {
 		return default_style
 	}
 
@@ -27,14 +27,14 @@ find_config_file_or_default :: proc(path: string) -> printer.Config {
 	found := false
 	config := default_style
 
-	if (os.exists(name)) {
-		if data, ok := os.read_entire_file(name, context.temp_allocator); ok {
+	if os.exists(name) {
+		if data, err := os.read_entire_file(name, context.temp_allocator); err != nil {
 			if json.unmarshal(data, &config) == nil {
 				found = true
 			}
 		}
 	} else {
-		new_path := filepath.join(elems = {path, ".."}, allocator = context.temp_allocator)
+		new_path, _ := filepath.join(elems = {path, ".."}, allocator = context.temp_allocator)
 		//Currently the filepath implementation seems to stop at the root level, this might not be the best solution.
 		if new_path == path {
 			return default_style
@@ -53,13 +53,13 @@ find_config_file_or_default :: proc(path: string) -> printer.Config {
 // of searching for it up a directory tree of a path
 read_config_file_from_path_or_default :: proc(config_path: string) -> printer.Config {
     path := config_path
-    ok: bool
-	if path, ok = filepath.abs(config_path); !ok {
+	err: os.Error
+	if path, err = filepath.abs(config_path, context.temp_allocator); err != nil {
 		return default_style
 	}
     config := default_style
-    if (os.exists(path)) {
-        if data, ok := os.read_entire_file(path, context.temp_allocator); ok {
+    if os.exists(path) {
+        if data, err := os.read_entire_file(path, context.temp_allocator); err != nil {
             if json.unmarshal(data, &config) == nil {
                 return config
             }

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -1,7 +1,5 @@
 package odin_printer
 
-import "core:fmt"
-import "core:log"
 import "core:mem"
 import "core:odin/ast"
 import "core:odin/tokenizer"

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1,7 +1,6 @@
 #+feature using-stmt
 package odin_printer
 
-import "core:fmt"
 import "core:log"
 import "core:odin/ast"
 import "core:odin/parser"

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3409,7 +3409,7 @@ get_package_from_node :: proc(node: ast.Node) -> string {
 }
 
 get_package_from_filepath :: proc(file_path: string) -> string {
-	slashed, _ := filepath.to_slash(file_path, context.temp_allocator)
+	slashed, _ := filepath.replace_path_separators(file_path, '/', context.temp_allocator)
 	ret := path.dir(slashed, context.temp_allocator)
 	return ret
 }

--- a/src/server/caches.odin
+++ b/src/server/caches.odin
@@ -76,26 +76,13 @@ clear_all_package_aliases :: proc() {
 
 //Go through all the collections to find all the possible packages that exists
 find_all_package_aliases :: proc() {
-	walk_proc :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Errno, skip_dir: bool) {
-		data := cast(^[dynamic]string)user_data
-
-		if !info.is_dir && filepath.ext(info.name) == ".odin" {
-			dir := filepath.dir(info.fullpath, context.temp_allocator)
-			if !slice.contains(data[:], dir) {
-				append(data, dir)
-			}
-		}
-
-		return in_err, false
-	}
-
 	for k, v in common.config.collections {
 		pkgs := make([dynamic]string, context.temp_allocator)
-		filepath.walk(v, walk_proc, &pkgs)
+		append_packages(v, &pkgs, context.temp_allocator)
 
 		for pkg in pkgs {
 			if pkg, err := filepath.rel(v, pkg, context.temp_allocator); err == .None {
-				forward_pkg, _ := filepath.to_slash(pkg, context.temp_allocator)
+				forward_pkg, _ := filepath.replace_path_separators(pkg, '/', context.temp_allocator)
 				if k not_in build_cache.pkg_aliases {
 					build_cache.pkg_aliases[k] = make([dynamic]string)
 				}

--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -36,24 +36,11 @@ Json_Errors :: struct {
 
 //If the user does not specify where to call odin check, it'll just find all directory with odin, and call them seperately.
 fallback_find_odin_directories :: proc(config: ^common.Config) -> []string {
-	walk_proc :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Errno, skip_dir: bool) {
-		data := cast(^[dynamic]string)user_data
-
-		if !info.is_dir && filepath.ext(info.name) == ".odin" {
-			dir := filepath.dir(info.fullpath, context.temp_allocator)
-			if !slice.contains(data[:], dir) {
-				append(data, dir)
-			}
-		}
-
-		return in_err, false
-	}
-
 	data := make([dynamic]string, context.temp_allocator)
 
 	if len(config.workspace_folders) > 0 {
 		if uri, ok := common.parse_uri(config.workspace_folders[0].uri, context.temp_allocator); ok {
-			filepath.walk(uri.path, walk_proc, &data)
+			append_packages(uri.path, &data, context.temp_allocator)
 		}
 	}
 

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -679,11 +679,11 @@ get_symbol_package_name :: proc(
 	}
 
 	if strings.contains(uri, "intrinsics.odin") {
-		intrinsics_path := filepath.join(
+		intrinsics_path, _ := filepath.join(
 			elems = {common.config.collections["base"], "/intrinsics"},
 			allocator = context.temp_allocator,
 		)
-		intrinsics_path, _ = filepath.to_slash(intrinsics_path, context.temp_allocator)
+		intrinsics_path, _ = filepath.replace_path_separators(intrinsics_path, '/', context.temp_allocator)
 		return get_index_unique_string(collection, intrinsics_path)
 	}
 
@@ -712,7 +712,7 @@ write_doc_string :: proc(sb: ^strings.Builder, doc: string) {
 }
 
 collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: string) -> common.Error {
-	forward, _ := filepath.to_slash(file.fullpath, context.temp_allocator)
+	forward, _ := filepath.replace_path_separators(file.fullpath, '/', context.temp_allocator)
 	directory := path.dir(forward, context.temp_allocator)
 	package_map := get_package_mapping(file, collection.config, directory)
 	exprs := collect_globals(file)

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1878,7 +1878,7 @@ get_package_completion :: proc(
 		c := without_quotes[0:colon_index]
 
 		if colon_index + 1 < len(without_quotes) {
-			absolute_path = filepath.join(
+			absolute_path, _ = filepath.join(
 				elems = {
 					config.collections[c],
 					filepath.dir(without_quotes[colon_index + 1:], context.temp_allocator),
@@ -1891,7 +1891,7 @@ get_package_completion :: proc(
 	} else {
 		import_file_dir := filepath.dir(position_context.import_stmt.pos.file, context.temp_allocator)
 		import_dir := filepath.dir(without_quotes, context.temp_allocator)
-		absolute_path = filepath.join(elems = {import_file_dir, import_dir}, allocator = context.temp_allocator)
+		absolute_path, _ = filepath.join(elems = {import_file_dir, import_dir}, allocator = context.temp_allocator)
 	}
 
 	if !strings.contains(position_context.import_stmt.fullpath, "/") &&
@@ -1941,7 +1941,7 @@ search_for_packages :: proc(fullpath: string) -> []string {
 
 	if files, err := os.read_dir(fh, 0, context.temp_allocator); err == 0 {
 		for file in files {
-			if file.is_dir {
+			if file.type == .Directory {
 				append(&packages, file.fullpath)
 			}
 		}

--- a/src/server/format.odin
+++ b/src/server/format.odin
@@ -5,8 +5,6 @@ import "src:common"
 import "src:odin/format"
 import "src:odin/printer"
 
-import "core:log"
-
 FormattingOptions :: struct {
 	tabSize:                uint,
 	insertSpaces:           bool, //tabs or spaces

--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -1,12 +1,9 @@
 package odinfmt
 
-import "core:encoding/json"
 import "core:flags"
 import "core:fmt"
-import "core:io"
 import "core:mem"
 import vmem "core:mem/virtual"
-import "core:odin/tokenizer"
 import "core:os"
 import "core:path/filepath"
 import "core:strings"
@@ -15,34 +12,25 @@ import "src:odin/format"
 import "src:odin/printer"
 
 Args :: struct {
-	write: bool `args:"name=w" usage:"write the new format to file"`,
-	stdin: bool `usage:"formats code from standard input"`,
-	path:  string `args:"pos=0" usage:"set the file or directory to format"`,
-    config: string `usage:"path to a config file"`
+	write:  bool `args:"name=w" usage:"write the new format to file"`,
+	stdin:  bool `usage:"formats code from standard input"`,
+	path:   string `args:"pos=0" usage:"set the file or directory to format"`,
+	config: string `usage:"path to a config file"`,
 }
 
-format_file :: proc(filepath: string, config: printer.Config, allocator := context.allocator) -> (string, bool) {
-	if data, ok := os.read_entire_file(filepath, allocator); ok {
+format_file :: proc(
+	filepath: string,
+	config: printer.Config,
+	allocator := context.allocator,
+) -> (
+	string,
+	bool,
+) {
+	if data, err := os.read_entire_file(filepath, allocator); err == nil {
 		return format.format(filepath, string(data), config, {.Optional_Semicolons}, allocator)
 	} else {
 		return "", false
 	}
-}
-
-files: [dynamic]string
-
-walk_files :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Error, skip_dir: bool) {
-	if info.is_dir {
-		return nil, false
-	}
-
-	if filepath.ext(info.name) != ".odin" {
-		return nil, false
-	}
-
-	append(&files, strings.clone(info.fullpath))
-
-	return nil, false
 }
 
 main :: proc() {
@@ -63,7 +51,7 @@ main :: proc() {
 			args.path = "."
 		} else {
 			fmt.fprint(os.stderr, "Missing path to format\n")
-			flags.write_usage(os.stream_from_handle(os.stderr), Args, os.args[0])
+			flags.write_usage(os.to_stream(os.stderr), Args, os.args[0])
 			os.exit(1)
 		}
 	}
@@ -72,14 +60,14 @@ main :: proc() {
 
 	write_failure := false
 
-	watermark : uint = 0
+	watermark: uint = 0
 
-    config: printer.Config
-    if args.config == "" {
-	    config = format.find_config_file_or_default(args.path)
-    } else {
-        config = format.read_config_file_from_path_or_default(args.config)
-    }
+	config: printer.Config
+	if args.config == "" {
+		config = format.find_config_file_or_default(args.path)
+	} else {
+		config = format.read_config_file_from_path_or_default(args.config)
+	}
 
 	if args.stdin {
 		data := make([dynamic]byte, arena_allocator)
@@ -93,7 +81,13 @@ main :: proc() {
 			append(&data, ..tmp[:r])
 		}
 
-		source, ok := format.format("<stdin>", string(data[:]), config, {.Optional_Semicolons}, arena_allocator)
+		source, ok := format.format(
+			"<stdin>",
+			string(data[:]),
+			config,
+			{.Optional_Semicolons},
+			arena_allocator,
+		)
 
 		if ok {
 			fmt.println(source)
@@ -108,7 +102,7 @@ main :: proc() {
 			if data, ok := format_file(args.path, config, arena_allocator); ok {
 				os.rename(args.path, backup_path)
 
-				if os.write_entire_file(args.path, transmute([]byte)data) {
+				if err := os.write_entire_file(args.path, transmute([]byte)data); err == nil {
 					os.remove(backup_path)
 				}
 			} else {
@@ -121,7 +115,19 @@ main :: proc() {
 			}
 		}
 	} else if os.is_dir(args.path) {
-		filepath.walk(args.path, walk_files, nil)
+		files: [dynamic]string
+		w := os.walker_create(args.path)
+		for info in os.walker_walk(&w) {
+			if info.type == .Directory {
+				continue
+			}
+
+			if filepath.ext(info.name) != ".odin" {
+				continue
+			}
+
+			append(&files, strings.clone(info.fullpath))
+		}
 
 		for file in files {
 			fmt.println(file)
@@ -133,7 +139,7 @@ main :: proc() {
 				if args.write {
 					os.rename(file, backup_path)
 
-					if os.write_entire_file(file, transmute([]byte)data) {
+					if err := os.write_entire_file(file, transmute([]byte)data); err == nil {
 						os.remove(backup_path)
 					}
 				} else {

--- a/tools/odinfmt/tests.odin
+++ b/tools/odinfmt/tests.odin
@@ -1,8 +1,6 @@
 package odinfmt_tests
 
-import "core:testing"
 import "core:os"
-import "core:fmt"
 import "core:mem"
 
 import "snapshot"


### PR DESCRIPTION
Updates `ols` to use the new `os` package and support the updated `filepath` packages. Seems to run fine for me so hopefully everything has been translated correctly.