### PR TITLE
Resolve decls in when statements to fix incorrectly flagging imports as unused

### DIFF
--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -51,10 +51,6 @@ resolve_ranged_file :: proc(
 	margin := 20
 
 	for decl in document.ast.decls {
-		if _, is_value := decl.derived.(^ast.Value_Decl); !is_value {
-			continue
-		}
-
 		//Look for declarations that overlap with range
 		if range.start.line - margin <= decl.end.line && decl.pos.line <= range.end.line + margin {
 			resolve_decl(&position_context, &ast_context, document, decl, &symbols, .None, allocator)
@@ -88,10 +84,6 @@ resolve_entire_file :: proc(
 	symbols := make(map[uintptr]SymbolAndNode, 10000, allocator)
 
 	for decl in document.ast.decls {
-		if _, is_value := decl.derived.(^ast.Value_Decl); !is_value {
-			continue
-		}
-
 		resolve_decl(&position_context, &ast_context, document, decl, &symbols, flag, allocator)
 		clear(&ast_context.locals)
 	}

--- a/tests/actions_test.odin
+++ b/tests/actions_test.odin
@@ -1,0 +1,23 @@
+package tests
+
+import "core:testing"
+
+import test "src:testing"
+
+@(test)
+action_remove_unsed_import_when_stmt :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+		import "core:fm{*}t"
+
+		when true {
+			main :: proc() {
+				_ = fmt.printf
+			}
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_action(t, &source, {})
+}


### PR DESCRIPTION
Currently an import will be flagged as unused if it is used within a `when` statement. This fixes that.