### PR TITLE
Put `invert_if` code action behind a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Options:
 
 - `enable_comp_lit_signature_help_use_docs`: Put signature help for comp lits in the documentation. This will allow it to be rendered nicely using markdown in editors that render the label without colour on one line.
 
+- `enable_code_action_invert_if`: Enables a code action to invert if statements.
+
 - `odin_command`: Specify the location to your Odin executable, rather than relying on the environment path.
 
 - `odin_root_override`: Allows you to specify a custom `ODIN_ROOT` that `ols` will use to look for `odin` core libraries when implementing custom runtimes.

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -107,6 +107,11 @@
 			"description": "Put signature help for comp lits in the documentation. This will allow it to be rendered nicely using markdown in editors that render the label without colour on one line.",
 			"default": false
 		},
+		"enable_code_action_invert_if": {
+			"type": "boolean",
+			"description": "Enables a code action to invert if statements.",
+			"default": false
+		},
 		"disable_parser_errors": { "type": "boolean" },
 		"verbose": {
 			"type": "boolean",

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -41,6 +41,7 @@ Config :: struct {
 	enable_document_links:                   bool,
 	enable_comp_lit_signature_help:          bool,
 	enable_comp_lit_signature_help_use_docs: bool,
+	enable_code_action_invert_if:            bool,
 	disable_parser_errors:                   bool,
 	thread_count:                            int,
 	file_log:                                bool,

--- a/src/server/action.odin
+++ b/src/server/action.odin
@@ -79,7 +79,10 @@ get_code_actions :: proc(document: ^Document, range: common.Range, config: ^comm
 			&actions,
 		)
 	}
-	add_invert_if_action(document, position_context.position, strings.clone(document.uri.uri), &actions)
+
+	if config.enable_code_action_invert_if {
+		add_invert_if_action(document, position_context.position, strings.clone(document.uri.uri), &actions)
+	}
 
 	return actions[:], true
 }

--- a/src/server/action_invert_if_statements.odin
+++ b/src/server/action_invert_if_statements.odin
@@ -3,10 +3,8 @@
 package server
 
 import "core:fmt"
-import "core:log"
 import "core:odin/ast"
 import "core:odin/tokenizer"
-import path "core:path/slashpath"
 import "core:strings"
 
 import "src:common"

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -214,12 +214,7 @@ read_and_parse_body :: proc(reader: ^Reader, header: Header) -> (json.Value, boo
 	return value, true
 }
 
-call_map: map[string]proc(
-	_: json.Value,
-	_: RequestId,
-	_: ^common.Config,
-	_: ^Writer,
-) -> common.Error = {
+call_map: map[string]proc(_: json.Value, _: RequestId, _: ^common.Config, _: ^Writer) -> common.Error = {
 	"initialize"                        = request_initialize,
 	"initialized"                       = request_initialized,
 	"shutdown"                          = request_shutdown,
@@ -331,10 +326,7 @@ call :: proc(value: json.Value, id: RequestId, writer: ^Writer, config: ^common.
 
 	if !ok {
 		log.errorf("Failed to find method: %#v", root)
-		response := make_response_message_error(
-			id = id,
-			error = ResponseError{code = .MethodNotFound, message = ""},
-		)
+		response := make_response_message_error(id = id, error = ResponseError{code = .MethodNotFound, message = ""})
 		send_error(response, writer)
 		return
 	}
@@ -352,10 +344,7 @@ call :: proc(value: json.Value, id: RequestId, writer: ^Writer, config: ^common.
 		} else {
 			err := fn(root["params"], id, config, writer)
 			if err != .None {
-				response := make_response_message_error(
-					id = id,
-					error = ResponseError{code = err, message = ""},
-				)
+				response := make_response_message_error(id = id, error = ResponseError{code = err, message = ""})
 				send_error(response, writer)
 			}
 		}
@@ -364,20 +353,13 @@ call :: proc(value: json.Value, id: RequestId, writer: ^Writer, config: ^common.
 	//log.errorf("time duration %v for %v", time.duration_milliseconds(diff), method)
 }
 
-read_ols_initialize_options :: proc(
-	config: ^common.Config,
-	ols_config: OlsConfig,
-	uri: common.Uri,
-) {
-	config.disable_parser_errors =
-		ols_config.disable_parser_errors.(bool) or_else config.disable_parser_errors
+read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfig, uri: common.Uri) {
+	config.disable_parser_errors = ols_config.disable_parser_errors.(bool) or_else config.disable_parser_errors
 	config.thread_count = ols_config.thread_pool_count.(int) or_else config.thread_count
-	config.enable_document_symbols =
-		ols_config.enable_document_symbols.(bool) or_else config.enable_document_symbols
+	config.enable_document_symbols = ols_config.enable_document_symbols.(bool) or_else config.enable_document_symbols
 	config.enable_format = ols_config.enable_format.(bool) or_else config.enable_format
 	config.enable_hover = ols_config.enable_hover.(bool) or_else config.enable_hover
-	config.enable_semantic_tokens =
-		ols_config.enable_semantic_tokens.(bool) or_else config.enable_semantic_tokens
+	config.enable_semantic_tokens = ols_config.enable_semantic_tokens.(bool) or_else config.enable_semantic_tokens
 	config.enable_unused_imports_reporting =
 		ols_config.enable_unused_imports_reporting.(bool) or_else config.enable_unused_imports_reporting
 	config.enable_procedure_context =
@@ -388,20 +370,20 @@ read_ols_initialize_options :: proc(
 		ols_config.enable_document_highlights.(bool) or_else config.enable_document_highlights
 	config.enable_completion_matching =
 		ols_config.enable_completion_matching.(bool) or_else config.enable_completion_matching
-	config.enable_document_links =
-		ols_config.enable_document_links.(bool) or_else config.enable_document_links
+	config.enable_document_links = ols_config.enable_document_links.(bool) or_else config.enable_document_links
 	config.enable_comp_lit_signature_help =
 		ols_config.enable_comp_lit_signature_help.(bool) or_else config.enable_comp_lit_signature_help
 	config.enable_comp_lit_signature_help_use_docs =
 		ols_config.enable_comp_lit_signature_help_use_docs.(bool) or_else config.enable_comp_lit_signature_help_use_docs
+	config.enable_code_action_invert_if =
+		ols_config.enable_code_action_invert_if.(bool) or_else config.enable_code_action_invert_if
 	config.verbose = ols_config.verbose.(bool) or_else config.verbose
 	config.file_log = ols_config.file_log.(bool) or_else config.file_log
 
 	config.enable_procedure_snippet =
 		ols_config.enable_procedure_snippet.(bool) or_else config.enable_procedure_snippet
 
-	config.enable_auto_import =
-		ols_config.enable_auto_import.(bool) or_else config.enable_auto_import
+	config.enable_auto_import = ols_config.enable_auto_import.(bool) or_else config.enable_auto_import
 
 	config.enable_checker_only_saved =
 		ols_config.enable_checker_only_saved.(bool) or_else config.enable_checker_only_saved
@@ -417,10 +399,7 @@ read_ols_initialize_options :: proc(
 	}
 
 	if ols_config.odin_root_override != "" {
-		config.odin_root_override = strings.clone(
-			ols_config.odin_root_override,
-			context.temp_allocator,
-		)
+		config.odin_root_override = strings.clone(ols_config.odin_root_override, context.temp_allocator)
 
 		allocated: bool
 		config.odin_root_override, allocated = common.resolve_home_dir(config.odin_root_override)
@@ -473,8 +452,7 @@ read_ols_initialize_options :: proc(
 	config.enable_inlay_hints_implicit_return =
 		ols_config.enable_inlay_hints_implicit_return.(bool) or_else config.enable_inlay_hints_implicit_return
 
-	config.enable_fake_method =
-		ols_config.enable_fake_methods.(bool) or_else config.enable_fake_method
+	config.enable_fake_method = ols_config.enable_fake_methods.(bool) or_else config.enable_fake_method
 	config.enable_overload_resolution =
 		ols_config.enable_overload_resolution.(bool) or_else config.enable_overload_resolution
 
@@ -512,10 +490,7 @@ read_ols_initialize_options :: proc(
 			} else {
 				final_path, _ = filepath.replace_path_separators(
 					common.get_case_sensitive_path(
-						path.join(
-							elems = {uri.path, forward_path},
-							allocator = context.temp_allocator,
-						),
+						path.join(elems = {uri.path, forward_path}, allocator = context.temp_allocator),
 						context.temp_allocator,
 					),
 					'/',
@@ -537,11 +512,7 @@ read_ols_initialize_options :: proc(
 			log.errorf("Failed to find absolute address of collection: %v", final_path, err)
 			config.collections[strings.clone(it.name)] = strings.clone(final_path)
 		} else {
-			slashed_path, _ := filepath.replace_path_separators(
-				abs_final_path,
-				'/',
-				context.temp_allocator,
-			)
+			slashed_path, _ := filepath.replace_path_separators(abs_final_path, '/', context.temp_allocator)
 
 			config.collections[strings.clone(it.name)] = strings.clone(slashed_path)
 		}
@@ -587,8 +558,7 @@ read_ols_initialize_options :: proc(
 			}
 
 			if odin_core_env != "" {
-				if abs_core_env, err := filepath.abs(odin_core_env, context.temp_allocator);
-				   err == nil {
+				if abs_core_env, err := filepath.abs(odin_core_env, context.temp_allocator); err == nil {
 					odin_core_env = abs_core_env
 				}
 			}
@@ -599,11 +569,7 @@ read_ols_initialize_options :: proc(
 
 	// Insert the default collections if they are not specified in the config.
 	if odin_core_env != "" {
-		forward_path, _ := filepath.replace_path_separators(
-			odin_core_env,
-			'/',
-			context.temp_allocator,
-		)
+		forward_path, _ := filepath.replace_path_separators(odin_core_env, '/', context.temp_allocator)
 
 		// base
 		if "base" not_in config.collections {
@@ -631,10 +597,7 @@ read_ols_initialize_options :: proc(
 
 		// shared
 		if "shared" not_in config.collections {
-			shared_path := path.join(
-				elems = {forward_path, "shared"},
-				allocator = context.allocator,
-			)
+			shared_path := path.join(elems = {forward_path, "shared"}, allocator = context.allocator)
 			if os.exists(shared_path) {
 				config.collections[strings.clone("shared")] = shared_path
 			} else {
@@ -739,10 +702,7 @@ request_initialize :: proc(
 		read_ols_initialize_options(config, initialize_params.initializationOptions, uri)
 
 		// Apply ols.json config.
-		ols_config_path := path.join(
-			elems = {uri.path, "ols.json"},
-			allocator = context.temp_allocator,
-		)
+		ols_config_path := path.join(elems = {uri.path, "ols.json"}, allocator = context.temp_allocator)
 		read_ols_config(ols_config_path, config, uri)
 	} else {
 		read_ols_initialize_options(config, initialize_params.initializationOptions, {})
@@ -763,8 +723,7 @@ request_initialize :: proc(
 	config.enable_label_details =
 		initialize_params.capabilities.textDocument.completion.completionItem.labelDetailsSupport
 
-	config.enable_snippets &=
-		initialize_params.capabilities.textDocument.completion.completionItem.snippetSupport
+	config.enable_snippets &= initialize_params.capabilities.textDocument.completion.completionItem.snippetSupport
 
 	config.signature_offset_support =
 		initialize_params.capabilities.textDocument.signatureHelp.signatureInformation.parameterInformation.labelOffsetSupport
@@ -773,17 +732,12 @@ request_initialize :: proc(
 	signatureTriggerCharacters := []string{"(", ","}
 	signatureRetriggerCharacters := []string{","}
 
-	semantic_range_support :=
-		initialize_params.capabilities.textDocument.semanticTokens.requests.range
+	semantic_range_support := initialize_params.capabilities.textDocument.semanticTokens.requests.range
 
 	response := make_response_message(
 		params = ResponseInitializeParams {
 			capabilities = ServerCapabilities {
-				textDocumentSync = TextDocumentSyncOptions {
-					openClose = true,
-					change = 2,
-					save = {includeText = true},
-				},
+				textDocumentSync = TextDocumentSyncOptions{openClose = true, change = 2, save = {includeText = true}},
 				renameProvider = RenameOptions{prepareProvider = true},
 				workspaceSymbolProvider = true,
 				referencesProvider = config.enable_references,
@@ -814,10 +768,7 @@ request_initialize :: proc(
 				hoverProvider = config.enable_hover,
 				documentFormattingProvider = config.enable_format,
 				documentLinkProvider = {resolveProvider = false},
-				codeActionProvider = {
-					resolveProvider = false,
-					codeActionKinds = {"refactor.rewrite"},
-				},
+				codeActionProvider = {resolveProvider = false, codeActionKinds = {"refactor.rewrite"}},
 			},
 		},
 		id = id,
@@ -883,12 +834,7 @@ request_initialized :: proc(
 	return .None
 }
 
-request_shutdown :: proc(
-	params: json.Value,
-	id: RequestId,
-	config: ^common.Config,
-	writer: ^Writer,
-) -> common.Error {
+request_shutdown :: proc(params: json.Value, id: RequestId, config: ^common.Config, writer: ^Writer) -> common.Error {
 	response := make_response_message(params = nil, id = id)
 
 	send_response(response, writer)
@@ -1003,12 +949,7 @@ request_completion :: proc(
 	}
 
 	list: CompletionList
-	list, ok = get_completion_list(
-		document,
-		completition_params.position,
-		completition_params.context_,
-		config,
-	)
+	list, ok = get_completion_list(document, completition_params.position, completition_params.context_, config)
 
 	if !ok {
 		return .InternalError
@@ -1102,12 +1043,7 @@ request_format_document :: proc(
 	return .None
 }
 
-notification_exit :: proc(
-	params: json.Value,
-	id: RequestId,
-	config: ^common.Config,
-	writer: ^Writer,
-) -> common.Error {
+notification_exit :: proc(params: json.Value, id: RequestId, config: ^common.Config, writer: ^Writer) -> common.Error {
 	config.running = false
 	return .None
 }
@@ -1134,12 +1070,7 @@ notification_did_open :: proc(
 
 	defer delete(open_params.textDocument.uri)
 
-	if n := document_open(
-		open_params.textDocument.uri,
-		open_params.textDocument.text,
-		config,
-		writer,
-	); n != .None {
+	if n := document_open(open_params.textDocument.uri, open_params.textDocument.text, config, writer); n != .None {
 		return .InternalError
 	}
 
@@ -1375,12 +1306,7 @@ request_document_symbols :: proc(
 	return .None
 }
 
-request_hover :: proc(
-	params: json.Value,
-	id: RequestId,
-	config: ^common.Config,
-	writer: ^Writer,
-) -> common.Error {
+request_hover :: proc(params: json.Value, id: RequestId, config: ^common.Config, writer: ^Writer) -> common.Error {
 	params_object, ok := params.(json.Object)
 
 	if !ok {
@@ -1528,12 +1454,7 @@ request_prepare_rename :: proc(
 	return .None
 }
 
-request_rename :: proc(
-	params: json.Value,
-	id: RequestId,
-	config: ^common.Config,
-	writer: ^Writer,
-) -> common.Error {
+request_rename :: proc(params: json.Value, id: RequestId, config: ^common.Config, writer: ^Writer) -> common.Error {
 	params_object, ok := params.(json.Object)
 
 	if !ok {
@@ -1783,11 +1704,6 @@ request_workspace_symbols :: proc(
 	return .None
 }
 
-request_noop :: proc(
-	params: json.Value,
-	id: RequestId,
-	config: ^common.Config,
-	writer: ^Writer,
-) -> common.Error {
+request_noop :: proc(params: json.Value, id: RequestId, config: ^common.Config, writer: ^Writer) -> common.Error {
 	return .None
 }

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -436,6 +436,7 @@ OlsConfig :: struct {
 	enable_procedure_snippet:                Maybe(bool),
 	enable_checker_only_saved:               Maybe(bool),
 	enable_auto_import:                      Maybe(bool),
+	enable_code_action_invert_if:            Maybe(bool),
 	disable_parser_errors:                   Maybe(bool),
 	verbose:                                 Maybe(bool),
 	file_log:                                Maybe(bool),

--- a/tests/action_invert_if_test.odin
+++ b/tests/action_invert_if_test.odin
@@ -19,6 +19,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	test.expect_action(t, &source, {INVERT_IF_ACTION})
@@ -27,7 +28,7 @@ main :: proc() {
 @(test)
 action_invert_if_simple_edit :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := 5
@@ -37,6 +38,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x < 0 {
@@ -50,7 +52,7 @@ main :: proc() {
 @(test)
 action_invert_if_with_else :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := 5
@@ -62,6 +64,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	test.expect_action(t, &source, {INVERT_IF_ACTION})
@@ -70,7 +73,7 @@ main :: proc() {
 @(test)
 action_invert_if_with_else_edit :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := 5
@@ -82,6 +85,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x != 0 {
@@ -96,7 +100,7 @@ main :: proc() {
 @(test)
 action_invert_if_with_init :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} := foo(); x < 0 {
@@ -105,6 +109,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	test.expect_action(t, &source, {INVERT_IF_ACTION})
@@ -113,7 +118,7 @@ main :: proc() {
 @(test)
 action_invert_if_with_init_edit :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} := foo(); x < 0 {
@@ -122,6 +127,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x := foo(); x >= 0 {
@@ -135,13 +141,14 @@ main :: proc() {
 @(test)
 action_invert_if_not_on_if :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x :={*} 5
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	// Should not have the invert action when not on an if statement
@@ -152,7 +159,7 @@ main :: proc() {
 @(test)
 action_invert_if_inside_of_statement :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x != 0 {
@@ -161,6 +168,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	test.expect_action(t, &source, {})
@@ -169,7 +177,7 @@ main :: proc() {
 @(test)
 action_invert_if_not_eq :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} != 0 {
@@ -178,6 +186,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x == 0 {
@@ -191,7 +200,7 @@ main :: proc() {
 @(test)
 action_invert_if_lt :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} < 5 {
@@ -200,6 +209,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x >= 5 {
@@ -213,7 +223,7 @@ main :: proc() {
 @(test)
 action_invert_if_gt :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} > 5 {
@@ -222,6 +232,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x <= 5 {
@@ -235,7 +246,7 @@ main :: proc() {
 @(test)
 action_invert_if_le :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} <= 5 {
@@ -244,6 +255,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x > 5 {
@@ -257,7 +269,7 @@ main :: proc() {
 @(test)
 action_invert_if_negated :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if !x{*} {
@@ -266,6 +278,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x {
@@ -279,7 +292,7 @@ main :: proc() {
 @(test)
 action_invert_if_boolean :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	if x{*} {
@@ -288,6 +301,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if !x {
@@ -301,7 +315,7 @@ main :: proc() {
 @(test)
 action_invert_if_else_if_chain :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := something()
@@ -315,6 +329,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	expected := `if x <= 0 {
@@ -333,7 +348,7 @@ main :: proc() {
 @(test)
 action_invert_if_not_on_else_if :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := something()
@@ -347,6 +362,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	// Should not have the invert action when on an else-if statement
@@ -356,7 +372,7 @@ main :: proc() {
 @(test)
 action_invert_if_not_on_else :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := something()
@@ -368,6 +384,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	// Should not have the invert action when in the else block (not on an if)
@@ -377,7 +394,7 @@ main :: proc() {
 @(test)
 action_invert_if_nested_in_else_if_body :: proc(t: ^testing.T) {
 	source := test.Source {
-		main = `package test
+		main     = `package test
 
 main :: proc() {
 	x := something()
@@ -393,6 +410,7 @@ main :: proc() {
 }
 `,
 		packages = {},
+		config = {enable_code_action_invert_if = true},
 	}
 
 	// Should have the invert action for an if statement nested inside an else-if body


### PR DESCRIPTION
Request from the discord to put this behind a flag so it can be disabled. Seems like you can't disable the little icon that appears in vscode unfortunately.