### PR TITLE
Add search paths for the ols builtin folder as well as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd ols
 ./odinfmt.sh
 ```
 
-In order for `ols` to find symbols for builtin types and procedures, the `builtin` folder in the repo needs to be located next to the `ols` binary.
+In order for `ols` to find symbols for builtin types and procedures, the `builtin` folder in the repo needs to be located next to the `ols` binary. Alternatively you can specify the path to this folder using the `OLS_BUILTIN_FOLDER` environment variable.
 
 ### Configuration
 


### PR DESCRIPTION
Adds some search paths for the builtin folder as well as adding an environment `OLS_BUILTIN_FOLDER` to specify the location.

Resolves https://github.com/DanielGavin/ols/issues/1309