### PR TITLE
Use background worker for running the checker

### DIFF
--- a/src/main.odin
+++ b/src/main.odin
@@ -62,6 +62,10 @@ run :: proc(reader: ^server.Reader, writer: ^server.Writer) {
 		log.error("Starting Odin Language Server", VERSION)
 	}
 
+	server.create_and_start_check_worker()
+	defer server.stop_check_worker()
+
+
 	for common.config.running {
 		if common.config.verbose {
 			//Currently letting verbose use error, since some ast prints causes crashes - most likely a bug in core:fmt.

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -873,9 +873,7 @@ request_initialized :: proc(
 	config: ^common.Config,
 	writer: ^Writer,
 ) -> common.Error {
-	check(.Workspace, {}, config)
-	push_diagnostics(writer)
-
+	queue_check_request(.Workspace, {}, config, writer)
 	return .None
 }
 
@@ -1219,14 +1217,14 @@ notification_did_save :: proc(
 
 	corrected_uri := common.create_uri(fullpath, context.temp_allocator)
 
-	check(.Saved, corrected_uri, config)
-
 	document := document_get(save_params.textDocument.uri)
 	if document != nil {
 		check_unused_imports(document, config)
 	}
 
 	push_diagnostics(writer)
+
+	queue_check_request(.Saved, corrected_uri, config, writer)
 
 	return .None
 }
@@ -1697,8 +1695,7 @@ notification_did_change_watched_files :: proc(
 		}
 	}
 
-	check(.Workspace, {}, config)
-	push_diagnostics(writer)
+	queue_check_request(.Workspace, {}, config, writer)
 
 	return .None
 }
@@ -1726,9 +1723,7 @@ notification_workspace_did_change_configuration :: proc(
 	if uri, ok := common.parse_uri(config.workspace_folders[0].uri, context.temp_allocator); ok {
 		read_ols_initialize_options(config, ols_config, uri)
 	}
-
-	check(.Workspace, {}, config)
-	push_diagnostics(writer)
+	queue_check_request(.Workspace, {}, config, writer)
 
 	return .None
 }

--- a/src/server/writer.odin
+++ b/src/server/writer.odin
@@ -1,9 +1,5 @@
 package server
 
-import "core:os"
-import "core:mem"
-import "core:fmt"
-import "core:strings"
 import "core:sync"
 
 WriterFn :: proc(_: rawptr, _: []byte) -> (int, int)


### PR DESCRIPTION
Runs the checker via a background worker, stopping long running check requests from blocking any other incoming messages. Should help with https://github.com/DanielGavin/ols/issues/1334