### PR TITLE
Parallelise odin check

### DIFF
--- a/src/main.odin
+++ b/src/main.odin
@@ -62,6 +62,7 @@ run :: proc(reader: ^server.Reader, writer: ^server.Writer) {
 		log.error("Starting Odin Language Server", VERSION)
 	}
 
+	context.logger = logger^
 	server.create_and_start_check_worker()
 	defer server.stop_check_worker()
 

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -164,7 +164,11 @@ document_setup :: proc(document: ^Document) {
 	//Right now not all clients return the case correct windows path, and that causes issues with indexing, so we ensure that it's case correct.
 	when ODIN_OS == .Windows {
 		package_name := path.dir(document.uri.path, context.temp_allocator)
-		forward, _ := filepath.replace_path_separators(common.get_case_sensitive_path(package_name), '/', context.temp_allocator)
+		forward, _ := filepath.replace_path_separators(
+			common.get_case_sensitive_path(package_name),
+			'/',
+			context.temp_allocator,
+		)
 		if forward == "" {
 			document.package_name = package_name
 		} else {
@@ -498,5 +502,9 @@ get_import_range :: proc(imp: ^ast.Import_Decl, src: string) -> common.Range {
 }
 
 is_ols_builtin_file :: proc(path: string) -> bool {
-	return strings.has_suffix(path, "/builtin/builtin.odin") || strings.has_suffix(path, "/builtin/intrinsics.odin")
+	return(
+		strings.has_suffix(path, "/builtin/builtin.odin") ||
+		strings.has_suffix(path, "/builtin/intrinsics.odin") ||
+		strings.has_suffix(path, "/intrinsics/intrinsics.odin") \
+	)
 }

--- a/src/server/log.odin
+++ b/src/server/log.odin
@@ -2,9 +2,6 @@ package server
 
 import "core:fmt"
 import "core:log"
-import "core:os"
-import "core:strings"
-import "core:time"
 
 Default_Console_Logger_Opts ::
 	log.Options{.Level, .Terminal_Color, .Short_File_Path, .Line, .Procedure} | log.Full_Timestamp_Opts


### PR DESCRIPTION
Now that we're running `odin check` on a lot more packages, it can be a little slow if we're waiting it to run one at a time. This parallelises it using the new `os` package. Should help with https://github.com/DanielGavin/ols/issues/1334