### PR TITLE
Fix stray trailing comma in ols.schema.json

### DIFF
--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -133,7 +133,7 @@
 		"checker_skip_packages": {
 			"type": "array",
 			"items": {
-				"type": "string",
+				"type": "string"
 			},
 			"description": "Paths to packages that should not be checked by `odin check`"
 		},


### PR DESCRIPTION
Hi team,

I noticed that the commit (c8842e3), introduced three (3) days ago, added a new section "checker_skip_packages" which added a trailing comma. I have introduced a pull request to amend it since I noticed that the schema was no longer being parsed without error in my text editor. 

Thank you for your time in advance.