### PR TITLE
Put loading workspace diagnostics behind a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Options:
 
 - `enable_procedure_snippet`: Use snippets when completing procedures—adds parenthesis after the name. _(Enabled by default)_
 
-- `enable_checker_only_saved`: Turns on only calling the checker on the package being saved.
+- `enable_checker_only_saved`: Turns on only calling the checker on the package being saved. _(Enabled by default)_
+
+- `enable_checker_diagnostics_on_start`: Turns on running all workspace diagnostics using odin check when starting ols (experimental).
 
 - `enable_auto_import`: Automatically import packages that aren't in your import on completion.
 

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -17,7 +17,11 @@
 		"thread_pool_count": { "type": "integer" },
 		"enable_checker_only_saved": {
 			"type": "boolean",
-			"description": "Turns on only calling the checker on the package being saved"
+			"description": "Turns on only calling the checker on the package being saved."
+		},
+		"enable_checker_diagnostics_on_start": {
+			"type": "boolean",
+			"description": "Turns on running all workspace diagnostics using odin check when starting ols (experimental)."
 		},
 		"enable_semantic_tokens": {
 			"type": "boolean",

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -36,6 +36,7 @@ Config :: struct {
 	enable_overload_resolution:              bool,
 	enable_procedure_snippet:                bool,
 	enable_checker_only_saved:               bool,
+	enable_checker_diagnostics_on_start:     bool,
 	enable_auto_import:                      bool,
 	enable_completion_matching:              bool,
 	enable_document_links:                   bool,

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -388,6 +388,9 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 	config.enable_checker_only_saved =
 		ols_config.enable_checker_only_saved.(bool) or_else config.enable_checker_only_saved
 
+	config.enable_checker_diagnostics_on_start =
+		ols_config.enable_checker_diagnostics_on_start.(bool) or_else config.enable_checker_diagnostics_on_start
+
 	if ols_config.odin_command != "" {
 		config.odin_command = strings.clone(ols_config.odin_command, context.temp_allocator)
 
@@ -672,6 +675,7 @@ request_initialize :: proc(
 	config.enable_fake_method = false
 	config.enable_procedure_snippet = true
 	config.enable_checker_only_saved = true
+	config.enable_checker_diagnostics_on_start = false
 	config.enable_auto_import = true
 
 	read_ols_config :: proc(file: string, config: ^common.Config, uri: common.Uri) -> (ok: bool) {
@@ -881,7 +885,9 @@ request_initialized :: proc(
 	config: ^common.Config,
 	writer: ^Writer,
 ) -> common.Error {
-	queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_diagnostics_on_start {
+		queue_check_request(.Workspace, {}, config, writer)
+	}
 	return .None
 }
 
@@ -1703,7 +1709,9 @@ notification_did_change_watched_files :: proc(
 		}
 	}
 
-	queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_diagnostics_on_start {
+		queue_check_request(.Workspace, {}, config, writer)
+	}
 
 	return .None
 }
@@ -1731,7 +1739,9 @@ notification_workspace_did_change_configuration :: proc(
 	if uri, ok := common.parse_uri(config.workspace_folders[0].uri, context.temp_allocator); ok {
 		read_ols_initialize_options(config, ols_config, uri)
 	}
-	queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_diagnostics_on_start {
+		queue_check_request(.Workspace, {}, config, writer)
+	}
 
 	return .None
 }

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -435,6 +435,7 @@ OlsConfig :: struct {
 	enable_snippets:                         Maybe(bool),
 	enable_procedure_snippet:                Maybe(bool),
 	enable_checker_only_saved:               Maybe(bool),
+	enable_checker_diagnostics_on_start:     Maybe(bool),
 	enable_auto_import:                      Maybe(bool),
 	enable_code_action_invert_if:            Maybe(bool),
 	disable_parser_errors:                   Maybe(bool),


### PR DESCRIPTION
Due to some issues people are encountering with this running with too many packages, it seems best to put this behind a flag for now whilst I iron out the implementation.