### PR TITLE
Always clear checker diagnostics and only run on saved packages unless explicitly enabled to run on workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Options:
 
 - `enable_checker_only_saved`: Turns on only calling the checker on the package being saved. _(Enabled by default)_
 
-- `enable_checker_diagnostics_on_start`: Turns on running all workspace diagnostics using odin check when starting ols (experimental).
+- `enable_checker_workspace_diagnostics`: Turns on running all workspace diagnostics using odin check. This is currently experimental and may cause problems. A better option is using the `checker_path` feature to explicity tell `ols` the projects that it should check. (experimental).
 
 - `enable_auto_import`: Automatically import packages that aren't in your import on completion.
 
@@ -119,7 +119,7 @@ Options:
 
 - `checker_args`: Pass custom arguments to `odin check`.
 
-- `checker_skip_packages`: Paths to packages that should not be checked by `odin check`.
+- `checker_skip_packages`: Paths to packages that should not be checked by `odin check` when using `enable_checker_workspace_diagnostics`.
 
 - `verbose`: Logs warnings instead of just errors.
 

--- a/misc/ols.schema.json
+++ b/misc/ols.schema.json
@@ -19,9 +19,9 @@
 			"type": "boolean",
 			"description": "Turns on only calling the checker on the package being saved."
 		},
-		"enable_checker_diagnostics_on_start": {
+		"enable_checker_workspace_diagnostics": {
 			"type": "boolean",
-			"description": "Turns on running all workspace diagnostics using odin check when starting ols (experimental)."
+			"description": "Turns on running all workspace diagnostics using odin check. This is currently experimental and may cause problems. A better option is using the `checker_path` feature to explicity tell `ols` the projects that it should check. (experimental)."
 		},
 		"enable_semantic_tokens": {
 			"type": "boolean",
@@ -139,7 +139,7 @@
 			"items": {
 				"type": "string"
 			},
-			"description": "Paths to packages that should not be checked by `odin check`"
+			"description": "Paths to packages that should not be checked by `odin check` when using `enable_checker_workspace_diagnostics`."
 		},
 		"profile": {
 			"type": "string",

--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -36,7 +36,7 @@ Config :: struct {
 	enable_overload_resolution:              bool,
 	enable_procedure_snippet:                bool,
 	enable_checker_only_saved:               bool,
-	enable_checker_diagnostics_on_start:     bool,
+	enable_checker_workspace_diagnostics:    bool,
 	enable_auto_import:                      bool,
 	enable_completion_matching:              bool,
 	enable_document_links:                   bool,

--- a/src/main.odin
+++ b/src/main.odin
@@ -63,7 +63,7 @@ run :: proc(reader: ^server.Reader, writer: ^server.Writer) {
 	}
 
 	context.logger = logger^
-	server.create_and_start_check_worker()
+	server.create_and_start_check_worker(writer)
 	defer server.stop_check_worker()
 
 

--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -41,35 +41,49 @@ Check_Mode :: enum {
 
 Check_Request :: struct {
 	check_mode: Check_Mode,
-	uri:        common.Uri,
+	path:       string,
 	config:     ^common.Config,
-	writer:     ^Writer,
+}
+
+Checker :: struct {
+	allocator: mem.Allocator,
+	send:      chan.Chan(Check_Request, .Send),
 }
 
 @(private = "file")
-check_send: chan.Chan(Check_Request, .Send)
+checker: Checker
 
-queue_check_request :: proc(mode: Check_Mode, uri: common.Uri, config: ^common.Config, writer: ^Writer) {
-	ok := chan.send(check_send, Check_Request{check_mode = mode, uri = uri, config = config, writer = writer})
+queue_check_request :: proc(mode: Check_Mode, path: string, config: ^common.Config) {
+	path := strings.clone(path, checker.allocator)
+	ok := chan.send(checker.send, Check_Request{check_mode = mode, path = path, config = config})
 	if !ok {
-		log.errorf("Failed to queue check request for uri %q", uri.uri)
+		log.errorf("Failed to queue check request for path %q", path)
 	}
 }
 
 stop_check_worker :: proc() {
-	chan.close(check_send)
+	chan.close(checker.send)
 }
 
-create_and_start_check_worker :: proc() {
+create_and_start_check_worker :: proc(writer: ^Writer) {
+	allocator := runtime.heap_allocator()
 	check_chan, _ := chan.create(chan.Chan(Check_Request), 8, context.allocator)
-	check_send = chan.as_send(check_chan)
+	check_send := chan.as_send(check_chan)
+	checker = Checker {
+		allocator = runtime.heap_allocator(),
+		send      = check_send,
+	}
 	check_recv := chan.as_recv(check_chan)
-	thread.create_and_start_with_poly_data(Consumer{logger = context.logger, ch = check_recv}, run_check_consumer)
+	thread.create_and_start_with_poly_data(
+		Consumer{logger = context.logger, ch = check_recv, w = writer},
+		run_check_consumer,
+	)
 }
 
 Consumer :: struct {
 	logger: log.Logger,
 	ch:     chan.Chan(Check_Request, .Recv),
+	w:      ^Writer,
 }
 
 run_check_consumer :: proc(c: Consumer) {
@@ -79,10 +93,19 @@ run_check_consumer :: proc(c: Consumer) {
 		if !ok {
 			break
 		}
-		check(request.check_mode, request.uri, request.config)
-		push_diagnostics(request.writer)
+		paths := make([dynamic]string, allocator = context.temp_allocator)
+		append(&paths, request.path)
+		for request in chan.try_recv(c.ch) {
+			append(&paths, request.path)
+		}
+		check(request.check_mode, paths[:], request.config)
+		push_diagnostics(c.w)
 		free_all(context.temp_allocator)
+		for path in paths {
+			delete(path, checker.allocator)
+		}
 	}
+	free_all(context.temp_allocator)
 }
 
 //If the user does not specify where to call odin check, it'll just find all directory with odin, and call them seperately.
@@ -96,30 +119,6 @@ fallback_find_odin_directories :: proc(config: ^common.Config) -> []string {
 	}
 
 	return data[:]
-}
-
-path_has_prefix :: proc(path: string, prefix: string) -> bool {
-	if len(prefix) == 0 || len(path) < len(prefix) {
-		return false
-	}
-
-	if !strings.equal_fold(path[:len(prefix)], prefix) {
-		return false
-	}
-
-	if len(path) == len(prefix) {
-		return true
-	}
-
-	return path[len(prefix)] == '/' || prefix[len(prefix) - 1] == '/'
-}
-
-path_matches_checker_scope :: proc(file_path: string, checker_path: string) -> bool {
-	if filepath.ext(checker_path) == ".odin" {
-		return strings.equal_fold(file_path, checker_path)
-	}
-
-	return path_has_prefix(file_path, checker_path)
 }
 
 check_unused_imports :: proc(document: ^Document, config: ^common.Config) {
@@ -154,21 +153,30 @@ check_unused_imports :: proc(document: ^Document, config: ^common.Config) {
 	}
 }
 
-resolve_check_paths :: proc(mode: Check_Mode, uri: common.Uri, config: ^common.Config) -> ([]string, bool) {
+resolve_check_paths :: proc(mode: Check_Mode, paths: []string, config: ^common.Config) -> []string {
 	if len(config.profile.checker_path) > 0 {
-		return config.profile.checker_path[:], true
+		return config.profile.checker_path[:]
 	}
 
-	if mode == .Saved && config.enable_checker_only_saved && uri.path != "" {
-		paths := make([dynamic]string, context.temp_allocator)
-		dir := path.dir(uri.path, context.temp_allocator)
-		if dir not_in config.checker_skip_packages {
-			append(&paths, dir)
+	if mode == .Saved || config.enable_checker_only_saved {
+		results := make([dynamic]string, context.temp_allocator)
+		for p in paths {
+			if p == "" {
+				continue
+			}
+			dir := path.dir(p, context.temp_allocator)
+			if dir not_in config.checker_skip_packages {
+				append(&results, dir)
+			}
 		}
-		return paths[:], false
+		return results[:]
 	}
 
-	return fallback_find_odin_directories(config), true
+	if mode == .Workspace && config.enable_checker_workspace_diagnostics {
+		return fallback_find_odin_directories(config)
+	}
+
+	return {}
 }
 
 CheckProcess :: struct {
@@ -177,18 +185,14 @@ CheckProcess :: struct {
 	finished: bool,
 }
 
-check :: proc(mode: Check_Mode, uri: common.Uri, config: ^common.Config) {
-	paths, clear_all := resolve_check_paths(mode, uri, config)
-
-	if clear_all {
-		clear_diagnostics(.Check)
-	} else {
-		clear_check_diagnostics_for_paths(paths)
-	}
+check :: proc(mode: Check_Mode, check_paths: []string, config: ^common.Config) {
+	paths := resolve_check_paths(mode, check_paths, config)
 
 	if len(paths) == 0 {
 		return
 	}
+
+	clear_diagnostics(.Check)
 
 	collections := make([dynamic]string, context.temp_allocator)
 

--- a/src/server/diagnostics.odin
+++ b/src/server/diagnostics.odin
@@ -91,25 +91,6 @@ clear_diagnostics :: proc(type: DiagnosticType) {
 	}
 }
 
-clear_check_diagnostics_for_paths :: proc(paths: []string) {
-	sync.lock(&diagnostic_mutex)
-	defer sync.unlock(&diagnostic_mutex)
-
-	for uri, _ in diagnostics[.Check] {
-		parsed_uri, ok := common.parse_uri(uri, context.temp_allocator)
-		if !ok {
-			continue
-		}
-
-		for checker_path in paths {
-			if path_matches_checker_scope(parsed_uri.path, checker_path) {
-				remove_diagnostics_locked(.Check, uri)
-				break
-			}
-		}
-	}
-}
-
 get_merged_diagnostics :: proc() -> map[string][dynamic]Diagnostic {
 	sync.lock(&diagnostic_mutex)
 	defer sync.unlock(&diagnostic_mutex)

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -388,8 +388,8 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 	config.enable_checker_only_saved =
 		ols_config.enable_checker_only_saved.(bool) or_else config.enable_checker_only_saved
 
-	config.enable_checker_diagnostics_on_start =
-		ols_config.enable_checker_diagnostics_on_start.(bool) or_else config.enable_checker_diagnostics_on_start
+	config.enable_checker_workspace_diagnostics =
+		ols_config.enable_checker_workspace_diagnostics.(bool) or_else config.enable_checker_workspace_diagnostics
 
 	if ols_config.odin_command != "" {
 		config.odin_command = strings.clone(ols_config.odin_command, context.temp_allocator)
@@ -675,7 +675,7 @@ request_initialize :: proc(
 	config.enable_fake_method = false
 	config.enable_procedure_snippet = true
 	config.enable_checker_only_saved = true
-	config.enable_checker_diagnostics_on_start = false
+	config.enable_checker_workspace_diagnostics = false
 	config.enable_auto_import = true
 
 	read_ols_config :: proc(file: string, config: ^common.Config, uri: common.Uri) -> (ok: bool) {
@@ -885,8 +885,8 @@ request_initialized :: proc(
 	config: ^common.Config,
 	writer: ^Writer,
 ) -> common.Error {
-	if config.enable_checker_diagnostics_on_start {
-		queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_workspace_diagnostics {
+		queue_check_request(.Workspace, {}, config)
 	}
 	return .None
 }
@@ -1238,7 +1238,7 @@ notification_did_save :: proc(
 
 	push_diagnostics(writer)
 
-	queue_check_request(.Saved, corrected_uri, config, writer)
+	queue_check_request(.Saved, corrected_uri.path, config)
 
 	return .None
 }
@@ -1709,8 +1709,8 @@ notification_did_change_watched_files :: proc(
 		}
 	}
 
-	if config.enable_checker_diagnostics_on_start {
-		queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_workspace_diagnostics {
+		queue_check_request(.Workspace, {}, config)
 	}
 
 	return .None
@@ -1739,8 +1739,8 @@ notification_workspace_did_change_configuration :: proc(
 	if uri, ok := common.parse_uri(config.workspace_folders[0].uri, context.temp_allocator); ok {
 		read_ols_initialize_options(config, ols_config, uri)
 	}
-	if config.enable_checker_diagnostics_on_start {
-		queue_check_request(.Workspace, {}, config, writer)
+	if config.enable_checker_workspace_diagnostics {
+		queue_check_request(.Workspace, {}, config)
 	}
 
 	return .None

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -435,7 +435,7 @@ OlsConfig :: struct {
 	enable_snippets:                         Maybe(bool),
 	enable_procedure_snippet:                Maybe(bool),
 	enable_checker_only_saved:               Maybe(bool),
-	enable_checker_diagnostics_on_start:     Maybe(bool),
+	enable_checker_workspace_diagnostics:    Maybe(bool),
 	enable_auto_import:                      Maybe(bool),
 	enable_code_action_invert_if:            Maybe(bool),
 	disable_parser_errors:                   Maybe(bool),


### PR DESCRIPTION
After the recent changes to the checker there have been a lot of reports of problems. This should hopefully fix the majority of them by doing the following:

1. Drain all messages in the channel before making any odin check request. This should reduce the amount of requests that are fun.
2. Only go to the fallback for finding odin packages if it is explicitly enabled via `enable_checker_workspace_diagnostics`. 
3. Always clear all checker diagnostics when running the checker rather than trying to find the ones that no longer apply.
4. Ensure the paths provided to the checker thread are heap allocated so they don't get cleaned up before the checker has had time to use them. 

This will bring back https://github.com/DanielGavin/ols/issues/1329 but that can be bypassed by either using the aforementioned `enable_checker_workspace_diagnostics` which will likely still have issues, or by explicitly passing packages/entrypoints using the `checker_path` configuration option in the profile.

In the future I'll look at how we can make `ols` parse all the files on start and use that information to determine which paths need to be odin checked by looking for things like tests and `main` procs. The issue is that `odin check` requires an "entrypoint" of some kind to properly check everything, so if you have multiple entrypoints like we do with the tests, ols and odinfmt, in order for everything to be checked you have to explicitly do multiple `odin check` calls, one for each entrypoint. Currently the user can also simply do this themselves by explicitly mentioning all the `odin check` paths in `checker_path`, but it would be nice if we could dynamically find all of these as some projects can have many, many entrypoints (eg via something like an `examples` folder).
