### PR TITLE
Add support for new for init; x in y {} syntax

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1197,6 +1197,10 @@ visit_stmt :: proc(
 			document = cons(document, visit_expr(p, v.label), text(":"), break_with_space())
 		}
 
+		if v.init != nil {
+        	document = cons(document, visit_stmt(p, v.init), text(";"), break_with_space())
+    	}
+
 		if v.reverse {
 			document = cons(document, text("#reverse"), break_with_no_newline())
 		}

--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -780,6 +780,7 @@ free_ast_node :: proc(node: ^ast.Node, allocator: mem.Allocator) {
 		free_ast(n.body, allocator)
 	case ^Range_Stmt:
 		free_ast(n.label, allocator)
+		free_ast(n.init, allocator)
 		free_ast(n.vals, allocator)
 		free_ast(n.expr, allocator)
 		free_ast(n.body, allocator)

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -294,6 +294,7 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	case ^Range_Stmt:
 		local_scope(data, n)
 		resolve_node(n.label, data)
+		resolve_node(n.init, data)
 		resolve_nodes(n.vals, data)
 		resolve_node(n.expr, data)
 		resolve_node(n.body, data)

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -652,6 +652,10 @@ get_locals_for_range_stmt :: proc(
 		return
 	}
 
+	if stmt.init != nil {
+        get_locals_stmt(file, stmt.init, ast_context, document_position)
+    }
+
 	results := make([dynamic]^Expr, context.temp_allocator)
 
 	if stmt.expr == nil {

--- a/src/server/position_context.odin
+++ b/src/server/position_context.odin
@@ -760,6 +760,7 @@ get_document_position_node :: proc(node: ^ast.Node, position_context: ^DocumentP
 		get_document_position(n.body, position_context)
 	case ^Range_Stmt:
 		get_document_position_label(n.label, position_context)
+		get_document_position(n.init, position_context)
 		get_document_position(n.vals, position_context)
 		get_document_position(n.expr, position_context)
 		get_document_position(n.body, position_context)

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -5643,3 +5643,89 @@ ast_completion_enum_parapoly_value :: proc(t: ^testing.T) {
 	}
 	test.expect_completion_docs(t, &source, "", {".A\n---\na doc", ".B", ".C\n---\nc comment"})
 }
+
+@(test)
+ast_for_range_init_var_decl_visible_in_body :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		My_Struct :: struct {
+			one: int,
+		}
+
+		make_iter :: proc() -> int { return 0 }
+
+		main :: proc() {
+			my_array: []My_Struct
+
+			for i := make_iter(); value in my_array {
+				i{*}
+			}
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_completion_docs(t, &source, "", {"test.i: int"})
+}
+
+@(test)
+ast_for_range_init_not_visible_outside_loop :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		make_iter :: proc() -> int { return 0 }
+
+		main :: proc() {
+			my_array: []int
+
+			for i := make_iter(); value in my_array {
+			}
+
+			{*}
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_completion_labels(t, &source, "", {"make_iter", "my_array"}, {"i"})
+}
+
+@(test)
+ast_for_range_init_custom_iterator :: proc(t: ^testing.T) {
+    source := test.Source {
+        main = `package test
+
+        My_Item :: struct {
+            value: int,
+        }
+
+        Iterator :: struct {
+            items: []My_Item,
+            index: int,
+        }
+
+        make_iterator :: proc(items: []My_Item) -> Iterator {
+            return Iterator{items = items}
+        }
+
+        iterate :: proc(iter: ^Iterator) -> (item: My_Item, ok: bool) {
+            if iter.index >= len(iter.items) { return {}, false }
+            item = iter.items[iter.index]
+            iter.index += 1
+            return item, true
+        }
+
+        main :: proc() {
+            items: []My_Item
+
+            for iter := make_iterator(items); item in iterate(&iter) {
+                item.{*}
+            }
+        }
+        `,
+        packages = {},
+    }
+
+    test.expect_completion_docs(t, &source, ".", {"My_Item.value: int"})
+}


### PR DESCRIPTION
# Add support for `for init; x in y {} syntax`
Odin dev-2026-03 introduced an optional initializer statement in for-in loops:
```odin
for x := make_iterator(); v in x {
    // ...
}
```
This patch updates OLS to correctly handle the new init field on Range_Stmt across five files:

- `src/server/locals.odin` walk stmt.init so variables declared in the initializer are visible inside the loop body
- `src/server/position_context.odin` include stmt.init when resolving document position, so completions and hover work inside loops that have an init
- `src/server/file_resolve.odin` resolve stmt.init so symbols declared there are correctly indexed
- `src/server/ast.odin` free stmt.init to avoid a memory leak
- `src/odin/printer/visit.odin` emit the init statement and trailing ; when formatting a Range_Stmt that has an init

Tests covering the new behavior are added in tests/completions_test.odin.