### PR TITLE
Avoid changing the ast when handle comp_lits with generics

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -752,6 +752,7 @@ CallArg :: struct {
 	is_poly_type:      bool,
 }
 
+// Returns false if any of the arguments fail to resolve
 expand_call_args :: proc(ast_context: ^AstContext, call: ^ast.Call_Expr) -> ([]CallArg, bool) {
 	results := make([dynamic]CallArg, context.temp_allocator)
 	if call == nil {
@@ -840,15 +841,17 @@ expand_call_args :: proc(ast_context: ^AstContext, call: ^ast.Call_Expr) -> ([]C
 		return true
 	}
 
+	all_valid := true
 	for arg in call.args {
 		reset_ast_context(ast_context)
 		ast_context.current_package = ast_context.document_package
 		if !append_arg(ast_context, arg, &results, &used_named) {
-			return {}, false
+			all_valid = false
+			append(&results, CallArg{})
 		}
 	}
 
-	return results[:], true
+	return results[:], all_valid
 }
 
 /*

--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -533,21 +533,7 @@ resolve_generic_function_symbol :: proc(
 	poly_map := make(map[string]^ast.Expr, 0, context.temp_allocator)
 	i := 0
 
-	for param in params {
-		for name in param.names {
-			defer i += 1
-			if i >= len(call_expr.args) {
-				break
-			}
-			if comp_lit, ok := call_expr.args[i].derived.(^ast.Comp_Lit); ok && comp_lit.type == nil {
-				comp_lit.type = param.type
-			}
-		}
-	}
-	call_args, ok := expand_call_args(ast_context, call_expr)
-	if !ok {
-		return {}, false
-	}
+	call_args, _ := expand_call_args(ast_context, call_expr)
 
 	i = 0
 	count_required_params := 0
@@ -563,7 +549,7 @@ resolve_generic_function_symbol :: proc(
 				break
 			}
 
-			if param.type == nil {
+			if param.type == nil || !call_args[i].has_symbol {
 				continue
 			}
 


### PR DESCRIPTION
This was causing issues when running the formatter as it would append things like `<path><type>{}` instead of just `{}` when running the format within the LSP.

As an example, it would format
```odin
				base := new_type(ast.Ident, {}, {}, context.temp_allocator)
```
into
```odin
				base := new_type(
					ast.Ident,
					/Users/bradlewis/repos/Odin/core/odin/tokenizer Pos{},
					/Users/bradlewis/repos/Odin/core/odin/tokenizer Pos{},
					context.temp_allocator,
				)
```
in the `symbols file.