### PR TITLE
Consistently encode file uris

### DIFF
--- a/src/common/uri.odin
+++ b/src/common/uri.odin
@@ -9,25 +9,16 @@ import "core:unicode/utf8"
 
 Uri :: struct {
 	uri:         string,
-	decode_full: string,
 	path:        string,
 }
 
 //Note(Daniel, This is an extremely incomplete uri parser and for now ignores fragment and query and only handles file schema)
 parse_uri :: proc(value: string, allocator: mem.Allocator) -> (Uri, bool) {
 	uri: Uri
-
-	decoded, ok := decode_percent(value, allocator)
-
-	if !ok {
-		return uri, false
-	}
-
 	starts := "file:///"
 
 	start_index := len(starts)
-
-	if !starts_with(decoded, starts) {
+	if !starts_with(value, starts) {
 		return uri, false
 	}
 
@@ -35,12 +26,7 @@ parse_uri :: proc(value: string, allocator: mem.Allocator) -> (Uri, bool) {
 		start_index -= 1
 	}
 
-	uri.uri = strings.clone(value, allocator)
-
-	uri.decode_full = decoded
-	uri.path = decoded[start_index:]
-
-	return uri, true
+	return create_uri(value[start_index:], allocator), true
 }
 
 //Note(Daniel, Again some really incomplete and scuffed uri writer)
@@ -61,8 +47,8 @@ create_uri :: proc(path: string, allocator: mem.Allocator) -> Uri {
 	uri: Uri
 
 	uri.uri = strings.to_string(builder)
-	uri.decode_full = strings.clone(path_forward, allocator)
-	uri.path = uri.decode_full
+	// this seems kind of stupid but it's to ensure all there's no '%' encoded characters in the path
+	uri.path = uri_to_path(uri.uri, allocator)
 
 	return uri
 }
@@ -84,10 +70,6 @@ delete_uri :: proc(uri: Uri) {
 	if uri.uri != "" {
 		delete(uri.uri)
 	}
-
-	if uri.decode_full != "" {
-		delete(uri.decode_full)
-	}
 }
 
 encode_percent :: proc(value: string, allocator: mem.Allocator) -> string {
@@ -99,7 +81,7 @@ encode_percent :: proc(value: string, allocator: mem.Allocator) -> string {
 	for index < len(value) {
 		r, w := utf8.decode_rune(data[index:])
 
-		if r > 127 || r == ':' {
+		if r > 127 || r == ':' || r == ' ' {
 			for i := 0; i < w; i += 1 {
 				strings.write_string(
 					&builder,

--- a/src/main.odin
+++ b/src/main.odin
@@ -70,7 +70,7 @@ run :: proc(reader: ^server.Reader, writer: ^server.Writer) {
 	for common.config.running {
 		if common.config.verbose {
 			//Currently letting verbose use error, since some ast prints causes crashes - most likely a bug in core:fmt.
-			logger^ = server.create_lsp_logger(writer, log.Level.Error)
+			logger^ = server.create_lsp_logger(writer, log.Level.Info)
 		} else {
 			logger^ = server.create_lsp_logger(writer, log.Level.Error)
 		}

--- a/tests/common_test.odin
+++ b/tests/common_test.odin
@@ -1,8 +1,8 @@
 package tests
 
 import "core:log"
-import "src:common"
 import "core:testing"
+import "src:common"
 
 @(test)
 common_get_absolute_range_starting_newline :: proc(t: ^testing.T) {
@@ -14,15 +14,9 @@ common_get_absolute_range_starting_newline :: proc(t: ^testing.T) {
 	}
 	`
 
-	range := common.Range{
-		start = {
-			line = 0,
-			character = 0,
-		},
-		end = {
-			line = 1,
-			character = 0,
-		}
+	range := common.Range {
+		start = {line = 0, character = 0},
+		end = {line = 1, character = 0},
 	}
 
 	absolute_range, ok := common.get_absolute_range(range, transmute([]u8)(src))
@@ -32,5 +26,57 @@ common_get_absolute_range_starting_newline :: proc(t: ^testing.T) {
 
 	if absolute_range != {0, 1} {
 		log.error(t, "incorrect absolute_range", absolute_range, ok)
+	}
+}
+
+@(test)
+common_create_uri :: proc(t: ^testing.T) {
+	when ODIN_OS == .Windows {
+		result := common.create_uri("C:\\Hello\\my folder\\main.odin", context.temp_allocator)
+
+		// NOTE: `create_uri` has a guard for testing, and removing it breaks all the other tests.
+		// So here we just assume it should only have 2 '/' after the 'file://'. It still tests the important parts.
+		expected := "file://C%3A/Hello/my%20folder/main.odin"
+
+		testing.expect_value(t, result.uri, expected)
+	} else {
+		result := common.create_uri("/User/Hello/my folder/main.odin", context.temp_allocator)
+		expected := "file:///User/Hello/my%20folder/main.odin"
+
+		testing.expect_value(t, result.uri, expected)
+	}
+}
+
+@(test)
+common_parse_uri :: proc(t: ^testing.T) {
+	when ODIN_OS == .Windows {
+		to_test := []string{"file:///C:\\Hello\\my folder\\main.odin", "file:///C%3A\\Hello\\my%20folder\\main.odin"}
+
+		// NOTE: `create_uri` has a guard for testing, and removing it breaks all the other tests.
+		// So here we just assume it should only have 2 '/' after the 'file://'. It still tests the important parts.
+		expected := "file://C%3A/Hello/my%20folder/main.odin"
+		for s, i in to_test {
+			result, ok := common.parse_uri(s, context.temp_allocator)
+			if !ok {
+				log.errorf("index %d: failed to parse uri %v", i, s)
+			}
+
+			if result.uri != expected {
+				log.errorf("index %d: expected uri %v, got %v", i, expected, result.uri)
+			}
+		}
+	} else {
+		expected := "file:///User/Hello/my%20folder/main.odin"
+		to_test := []string{"file:///User/Hello/my folder/main.odin", "file:///User/Hello/my%20folder/main.odin"}
+		for s, i in to_test {
+			result, ok := common.parse_uri(s, context.temp_allocator)
+			if !ok {
+				log.errorf("index %d: failed to parse uri %v", i, s)
+			}
+
+			if result.uri != expected {
+				log.errorf("index %d: expected uri %v, got %v", i, expected, result.uri)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Resolves inconsistency we have with the way the file uris are parsed especially on windows where some editors will pass a uri encoding characters where as others won't. This just ensure that we're always encoding the characters so things like references are resolved correctly.