### PR TITLE
Update README.md code snippets to use jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Install the package https://github.com/sublimelsp/LSP
 
 Configuration of the LSP:
 
-```json
+```jsonc
 {
 	"clients": {
 		"odin": {
@@ -405,7 +405,7 @@ Configure the plugin in micro's settings.json:
 First, make sure you have the LSP plugin enabled. Then, you can find LSP settings for Kate in Settings -> Configure Kate -> LSP Client -> User Server Settings.
 
 You may have to set the folders for your Odin home path directly, like in the following example:
-```json
+```jsonc
 {
     "servers": {
         "odin": {


### PR DESCRIPTION
There are two JSON code snippets that use comments which are not allowed in standard JSON. Thus the syntax highlighter marks these sections in red. JSONC functions exactly the same way but allows comments and is probably better suited for these two snippets.

It's a little pedantic I admit, but they do look nicer now.