### PR TITLE
Feat/add type parameter semantic token

### DIFF
--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -153,6 +153,27 @@ local_scope :: proc(data: ^FileResolveData, stmt: ^ast.Stmt) {
 	get_locals_stmt(data.ast_context.file, stmt, data.ast_context, data.position_context)
 }
 
+@(deferred_in = local_scope_poly_deferred)
+@(private = "file")
+local_scope_poly :: proc(data: ^FileResolveData, poly_params: ^ast.Field_List) {
+	if poly_params == nil {
+		return
+	}
+
+	add_local_group(data.ast_context)
+
+	get_locals_poly(data.ast_context.file, poly_params, data.ast_context)
+}
+
+@(private = "file")
+local_scope_poly_deferred :: proc(data: ^FileResolveData, poly_params: ^ast.Field_List) {
+	if poly_params == nil {
+		return
+	}
+
+	pop_local_group(data.ast_context)
+}
+
 @(private = "file")
 resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	if node == nil {
@@ -518,6 +539,7 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 		for clause in n.where_clauses {
 			resolve_node(clause, data)
 		}
+		local_scope_poly(data, n.poly_params)
 		resolve_node(n.fields, data)
 
 		if data.flag != .None {
@@ -540,6 +562,7 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 		data.position_context.union_type = n
 		resolve_node(n.poly_params, data)
 		resolve_node(n.align, data)
+		local_scope_poly(data, n.poly_params)
 		resolve_nodes(n.variants, data)
 	case ^ast.Enum_Type:
 		data.position_context.enum_type = n

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -1160,6 +1160,29 @@ get_locals_proc_param_and_results :: proc(
 	}
 }
 
+get_locals_poly :: proc(file: ast.File, params: ^ast.Field_List, ast_context: ^AstContext) {
+	for param in params.list {
+		for name in param.names {
+			if poly, ok := name.derived.(^ast.Poly_Type); ok {
+				str := get_ast_node_string(poly.type, file.src)
+				store_local(
+					ast_context,
+					name,
+					param.type,
+					name.pos.offset,
+					str,
+					false,
+					false,
+					{.PolyType},
+					"",
+					false,
+				)
+			}
+		}
+	}
+}
+
+
 get_locals :: proc(
 	file: ast.File,
 	function: ^ast.Node,

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -561,6 +561,11 @@ visit_ident :: proc(
 		modifiers += {.ReadOnly}
 	}
 
+	if .PolyType in symbol.flags {
+		write_semantic_node(builder, ident, .TypeParameter, modifiers)
+		return
+	}
+
 	if .Variable in symbol.flags {
 		write_semantic_node(builder, ident, .Variable, modifiers)
 		return

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -179,6 +179,7 @@ semantic_tokens_type_parameter :: proc(t: ^testing.T) {
 		{1, 2,  3, .Struct,        {.ReadOnly}}, // [0]  Foo
 		{0, 15, 1, .TypeParameter, {}},          // [1]  A
 		{1, 3,  3, .Property,      {}},          // [2]  bar
+		{0, 5,  1, .TypeParameter, {.ReadOnly}}, // [3]  A
 	})
 }
 


### PR DESCRIPTION
After https://github.com/DanielGavin/ols/issues/1388 was created I realised poly types weren't being handled by semantic tokens. This just adds them as a `typeParameter`.