### PR TITLE
Fix skipping private fields by using new consistent uri format

### DIFF
--- a/src/server/indexer.odin
+++ b/src/server/indexer.odin
@@ -1,7 +1,8 @@
 package server
 
-import "core:log"
 import "core:strings"
+
+import "src:common"
 
 Indexer :: struct {
 	builtin_packages: [dynamic]string,
@@ -21,18 +22,16 @@ clear_index_cache :: proc() {
 	memory_index_clear_cache(&indexer.index)
 }
 
-should_skip_private_symbol :: proc(symbol: Symbol, current_pkg, current_file: string) -> bool {
+should_skip_private_symbol :: proc(symbol: Symbol, current_pkg, current_file_uri: string) -> bool {
 	if .PrivateFile not_in symbol.flags && .PrivatePackage not_in symbol.flags {
 		return false
 	}
 
-	if current_file == "" {
+	if current_file_uri == "" {
 		return false
 	}
 
-	symbol_file := strings.trim_prefix(symbol.uri, "file://")
-	current_file := strings.trim_prefix(current_file, "file://")
-	if .PrivateFile in symbol.flags && symbol_file != current_file {
+	if .PrivateFile in symbol.flags && symbol.uri != current_file_uri {
 		return true
 	}
 
@@ -46,13 +45,13 @@ is_builtin_pkg :: proc(pkg: string) -> bool {
 	return strings.equal_fold(pkg, "$builtin") || strings.has_suffix(pkg, "/builtin")
 }
 
-lookup_builtin_symbol :: proc(name: string, current_file: string) -> (Symbol, bool) {
-	if symbol, ok := lookup_symbol(name, "$builtin", current_file); ok {
+lookup_builtin_symbol :: proc(name: string, current_pkg: string, current_file_uri: string) -> (Symbol, bool) {
+	if symbol, ok := lookup_symbol(name, "$builtin", current_pkg, current_file_uri); ok {
 		return symbol, true
 	}
 
 	for built in indexer.builtin_packages {
-		if symbol, ok := lookup_symbol(name, built, current_file); ok {
+		if symbol, ok := lookup_symbol(name, built, current_pkg, current_file_uri); ok {
 			return symbol, true
 		}
 	}
@@ -65,18 +64,20 @@ lookup :: proc(name: string, pkg: string, current_file: string, loc := #caller_l
 		return {}, false
 	}
 
+	current_pkg := get_package_from_filepath(current_file)
+	current_file_uri := common.create_uri(current_file, context.temp_allocator).uri
+
 	if is_builtin_pkg(pkg) {
-		return lookup_builtin_symbol(name, current_file)
+		return lookup_builtin_symbol(name, current_pkg, current_file_uri)
 	}
 
-	return lookup_symbol(name, pkg, current_file)
+	return lookup_symbol(name, pkg, current_pkg, current_file_uri)
 }
 
 @(private = "file")
-lookup_symbol ::proc(name: string, pkg: string, current_file: string) -> (Symbol, bool) {
+lookup_symbol :: proc(name: string, pkg: string, current_pkg: string, current_file_uri: string) -> (Symbol, bool) {
 	if symbol, ok := memory_index_lookup(&indexer.index, name, pkg); ok {
-		current_pkg := get_package_from_filepath(current_file)
-		if should_skip_private_symbol(symbol, current_pkg, current_file) {
+		if should_skip_private_symbol(symbol, current_pkg, current_file_uri) {
 			return {}, false
 		}
 		return symbol, true

--- a/src/server/memory_index.odin
+++ b/src/server/memory_index.odin
@@ -69,14 +69,15 @@ memory_index_fuzzy_search :: proc(
 	for field in fields {
 		append(&matchers, common.make_fuzzy_matcher(field))
 	}
+	current_pkg := get_package_from_filepath(current_file)
+	current_file_uri := common.create_uri(current_file, context.temp_allocator).uri
 
 	top := 100
-	current_pkg := get_package_from_filepath(current_file)
 
 	for pkg in pkgs {
 		if pkg, ok := index.collection.packages[pkg]; ok {
 			for _, symbol in pkg.symbols {
-				if should_skip_private_symbol(symbol, current_pkg, current_file) {
+				if should_skip_private_symbol(symbol, current_pkg, current_file_uri) {
 					continue
 				}
 				if resolve_fields {

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -125,7 +125,7 @@ collect_methods :: proc(
 		}
 
 		for &symbol in symbols {
-			if should_skip_private_symbol(symbol, ast_context.current_package, ast_context.fullpath) {
+			if should_skip_private_symbol(symbol, ast_context.current_package, ast_context.uri) {
 				continue
 			}
 			resolve_unresolved_symbol(ast_context, &symbol)


### PR DESCRIPTION
Same issues with uris again on windows, this time with private elements. Was flagged via

```odin
// file A
package main

foo :: proc {
    foo1,
}
@(private="file")
foo1 :: proc() -> int {}

// file B
package main

main :: proc() {
    a := foo() // fails to be resolved as it's private and the aforementioned uri comparison issues.
}
```