### PR TITLE
Fix incorrect newline in parapoly structs

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1660,7 +1660,7 @@ visit_expr :: proc(
 				document = cons(document, visit_struct_field_list(p, v.fields, {.Add_Comma}), text("}"))
 			}
 		} else if v.fields != nil {
-			document = cons(document, break_with_space(), visit_begin_brace(p, v.pos, .Generic))
+			document = cons(document, break_with_no_newline(), visit_begin_brace(p, v.pos, .Generic))
 
 			set_source_position(p, v.fields.pos)
 			document = cons(


### PR DESCRIPTION
Currently, when a non-empty parapoly struct is formatted with odinfmt and has parameters of sufficient length such that it takes multiple lines, the corresponding `{` is always placed on a new line irrespective of the used brace style. This behavior does not adhere to the 1TBS brace style which causes an error when compiling with `-strict-style`.

I've tested this change for 1TBS and Allman and it works correctly (inserts a newline for Allman and no newline for 1TBS), but I'm not too familiar with ols' Codebase yet so I may have missed something.

Fixes #1412