### PR TITLE
Update to new core:path/filepath API

### DIFF
--- a/src/common/uri.odin
+++ b/src/common/uri.odin
@@ -31,7 +31,7 @@ parse_uri :: proc(value: string, allocator: mem.Allocator) -> (Uri, bool) {
 
 //Note(Daniel, Again some really incomplete and scuffed uri writer)
 create_uri :: proc(path: string, allocator: mem.Allocator) -> Uri {
-	path_forward, _ := filepath.replace_path_separators(path, '/', context.temp_allocator)
+	path_forward, _ := filepath.replace_separators(path, '/', context.temp_allocator)
 
 	builder := strings.builder_make(allocator)
 

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3719,7 +3719,7 @@ get_package_from_node :: proc(node: ast.Node) -> string {
 }
 
 get_package_from_filepath :: proc(file_path: string) -> string {
-	slashed, _ := filepath.replace_path_separators(file_path, '/', context.temp_allocator)
+	slashed, _ := filepath.replace_separators(file_path, '/', context.temp_allocator)
 	ret := path.dir(slashed, context.temp_allocator)
 	return ret
 }

--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -134,7 +134,7 @@ append_packages :: proc(path: string, pkgs: ^[dynamic]string, skip: map[string]s
 	defer os.walker_destroy(&w)
 	for info in os.walker_walk(&w) {
 		if info.type != .Directory && filepath.ext(info.name) == ".odin" {
-			dir := filepath.dir(info.fullpath, allocator)
+			dir := filepath.dir(info.fullpath)
 			if dir in skip {
 				os.walker_skip_dir(&w)
 				continue
@@ -217,7 +217,7 @@ try_build_package :: proc(pkg_name: string) {
 				p.warn = log_warning_handler
 			}
 
-			dir := filepath.base(filepath.dir(fullpath, context.allocator))
+			dir := filepath.base(filepath.dir(fullpath))
 
 			pkg := new(ast.Package)
 			pkg.kind = .Normal
@@ -263,7 +263,7 @@ remove_index_file :: proc(uri: common.Uri) -> common.Error {
 	fullpath := uri.path
 
 	when ODIN_OS == .Windows {
-		fullpath, _ = filepath.replace_path_separators(fullpath, '/', context.temp_allocator)
+		fullpath, _ = filepath.replace_separators(fullpath, '/', context.temp_allocator)
 	}
 
 	corrected_uri := common.create_uri(fullpath, context.temp_allocator)
@@ -306,10 +306,10 @@ index_file :: proc(uri: common.Uri, text: string) -> common.Error {
 
 	when ODIN_OS == .Windows {
 		correct := common.get_case_sensitive_path(fullpath, context.temp_allocator)
-		fullpath, _ = filepath.replace_path_separators(correct, '/', context.temp_allocator)
+		fullpath, _ = filepath.replace_separators(correct, '/', context.temp_allocator)
 	}
 
-	dir := filepath.base(filepath.dir(fullpath, context.temp_allocator))
+	dir := filepath.base(filepath.dir(fullpath))
 
 	pkg := new(ast.Package)
 	pkg.kind = .Normal

--- a/src/server/caches.odin
+++ b/src/server/caches.odin
@@ -82,7 +82,7 @@ find_all_package_aliases :: proc() {
 
 		for pkg in pkgs {
 			if pkg, err := filepath.rel(v, pkg, context.temp_allocator); err == .None {
-				forward_pkg, _ := filepath.replace_path_separators(pkg, '/', context.temp_allocator)
+				forward_pkg, _ := filepath.replace_separators(pkg, '/', context.temp_allocator)
 				if k not_in build_cache.pkg_aliases {
 					build_cache.pkg_aliases[k] = make([dynamic]string)
 				}

--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -320,7 +320,7 @@ check :: proc(mode: Check_Mode, check_paths: []string, config: ^common.Config) {
 
 			when ODIN_OS == .Windows {
 				path = common.get_case_sensitive_path(path, context.temp_allocator)
-				path, _ = filepath.replace_path_separators(path, '/', context.temp_allocator)
+				path, _ = filepath.replace_separators(path, '/', context.temp_allocator)
 			}
 
 			key := DiagnosticKey {

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -695,7 +695,7 @@ get_symbol_package_name :: proc(
 			elems = {common.config.collections["base"], "/intrinsics"},
 			allocator = context.temp_allocator,
 		)
-		intrinsics_path, _ = filepath.replace_path_separators(intrinsics_path, '/', context.temp_allocator)
+		intrinsics_path, _ = filepath.replace_separators(intrinsics_path, '/', context.temp_allocator)
 		return get_index_unique_string(collection, intrinsics_path)
 	}
 
@@ -713,7 +713,7 @@ get_package_decl_doc_comment :: proc(file: ast.File, allocator := context.temp_a
 }
 
 collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: string) -> common.Error {
-	forward, _ := filepath.replace_path_separators(file.fullpath, '/', context.temp_allocator)
+	forward, _ := filepath.replace_separators(file.fullpath, '/', context.temp_allocator)
 	directory := path.dir(forward, context.temp_allocator)
 	package_map := get_package_mapping(file, collection.config, directory)
 	exprs := collect_globals(file)

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1832,7 +1832,7 @@ get_package_completion :: proc(
 			absolute_path, _ = filepath.join(
 				elems = {
 					config.collections[c],
-					filepath.dir(without_quotes[colon_index + 1:], context.temp_allocator),
+					filepath.dir(without_quotes[colon_index + 1:]),
 				},
 				allocator = context.temp_allocator,
 			)
@@ -1840,8 +1840,8 @@ get_package_completion :: proc(
 			absolute_path = config.collections[c]
 		}
 	} else {
-		import_file_dir := filepath.dir(position_context.import_stmt.pos.file, context.temp_allocator)
-		import_dir := filepath.dir(without_quotes, context.temp_allocator)
+		import_file_dir := filepath.dir(position_context.import_stmt.pos.file)
+		import_dir := filepath.dir(without_quotes)
 		absolute_path, _ = filepath.join(elems = {import_file_dir, import_dir}, allocator = context.temp_allocator)
 	}
 

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -165,7 +165,7 @@ document_setup :: proc(document: ^Document) {
 	//Right now not all clients return the case correct windows path, and that causes issues with indexing, so we ensure that it's case correct.
 	when ODIN_OS == .Windows {
 		package_name := path.dir(document.uri.path, context.temp_allocator)
-		forward, _ := filepath.replace_path_separators(
+		forward, _ := filepath.replace_separators(
 			common.get_case_sensitive_path(package_name),
 			'/',
 			context.temp_allocator,
@@ -184,9 +184,9 @@ document_setup :: proc(document: ^Document) {
 		fullpath: string
 		if correct == "" {
 			//This is basically here to handle the tests where the physical file doesn't actual exist.
-			document.fullpath, _ = filepath.replace_path_separators(document.uri.path, '/', context.allocator)
+			document.fullpath, _ = filepath.replace_separators(document.uri.path, '/', context.allocator)
 		} else {
-			document.fullpath, _ = filepath.replace_path_separators(correct, '/', context.allocator)
+			document.fullpath, _ = filepath.replace_separators(correct, '/', context.allocator)
 		}
 	} else {
 		document.fullpath = document.uri.path
@@ -404,7 +404,7 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 
 	parse_imports(document, config)
 
-	folder := filepath.dir(document.fullpath, context.temp_allocator)
+	folder := filepath.dir(document.fullpath)
 	if strings.equal_fold(folder, config.builtin_path) {
 		return nil, true
 	}

--- a/src/server/format.odin
+++ b/src/server/format.odin
@@ -27,7 +27,7 @@ get_complete_format :: proc(document: ^Document, config: ^common.Config) -> ([]T
 		return {}, true
 	}
 
-	style := format.find_config_file_or_default(filepath.dir(document.fullpath, context.temp_allocator))
+	style := format.find_config_file_or_default(filepath.dir(document.fullpath))
 	prnt := printer.make_printer(style, context.temp_allocator)
 
 	src := printer.print(&prnt, &document.ast)

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -294,7 +294,7 @@ resolve_references :: proc(
 				}
 
 				if strings.has_suffix(info.name, ".odin") {
-					slash_path, _ := filepath.replace_path_separators(info.fullpath, '/', context.temp_allocator)
+					slash_path, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
 					if !strings.equal_fold(slash_path, document.fullpath) {
 						append(&fullpaths, strings.clone(info.fullpath, context.temp_allocator))
 					}
@@ -322,7 +322,7 @@ resolve_references :: proc(
 		fullpath := fullpath
 		when ODIN_OS == .Windows {
 			path := common.get_case_sensitive_path(fullpath, context.temp_allocator)
-			fullpath, _ = filepath.replace_path_separators(path, '/', context.allocator)
+			fullpath, _ = filepath.replace_separators(path, '/', context.allocator)
 		}
 		dir := filepath.dir(fullpath)
 		base := filepath.base(dir)

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -494,7 +494,7 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 
 	// Apply custom collections.
 	for it in ols_config.collections {
-		forward_path, _ := filepath.replace_path_separators(it.path, '/', context.temp_allocator)
+		forward_path, _ := filepath.replace_separators(it.path, '/', context.temp_allocator)
 
 		forward_path = common.resolve_home_dir(forward_path, context.temp_allocator)
 
@@ -502,13 +502,13 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 
 		when ODIN_OS == .Windows {
 			if filepath.is_abs(it.path) {
-				final_path, _ = filepath.replace_path_separators(
+				final_path, _ = filepath.replace_separators(
 					common.get_case_sensitive_path(forward_path, context.temp_allocator),
 					'/',
 					context.temp_allocator,
 				)
 			} else {
-				final_path, _ = filepath.replace_path_separators(
+				final_path, _ = filepath.replace_separators(
 					common.get_case_sensitive_path(
 						path.join(elems = {uri.path, forward_path}, allocator = context.temp_allocator),
 						context.temp_allocator,
@@ -532,7 +532,7 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 			log.errorf("Failed to find absolute address of collection: %v", final_path, err)
 			config.collections[strings.clone(it.name)] = strings.clone(final_path)
 		} else {
-			slashed_path, _ := filepath.replace_path_separators(abs_final_path, '/', context.temp_allocator)
+			slashed_path, _ := filepath.replace_separators(abs_final_path, '/', context.temp_allocator)
 
 			config.collections[strings.clone(it.name)] = strings.clone(slashed_path)
 		}
@@ -574,9 +574,9 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 			odin_core_env = os.get_env("ODIN_ROOT", context.temp_allocator)
 			if odin_core_env == "" {
 				if os.exists(odin_bin) {
-					odin_core_env = filepath.dir(odin_bin, context.temp_allocator)
+					odin_core_env = filepath.dir(odin_bin)
 				} else if exe_path, ok := common.lookup_in_path(odin_bin); ok {
-					odin_core_env = filepath.dir(exe_path, context.temp_allocator)
+					odin_core_env = filepath.dir(exe_path)
 				}
 			}
 
@@ -592,7 +592,7 @@ read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfi
 
 	// Insert the default collections if they are not specified in the config.
 	if odin_core_env != "" {
-		forward_path, _ := filepath.replace_path_separators(odin_core_env, '/', context.temp_allocator)
+		forward_path, _ := filepath.replace_separators(odin_core_env, '/', context.temp_allocator)
 
 		// base
 		if "base" not_in config.collections {
@@ -718,7 +718,7 @@ request_initialize :: proc(
 
 	// Get the global ols config path.
 	global_ols_config_path := path.join(
-		elems = {filepath.dir(os.args[0], context.temp_allocator), "ols.json"},
+		elems = {filepath.dir(os.args[0]), "ols.json"},
 		allocator = context.temp_allocator,
 	)
 
@@ -1238,7 +1238,7 @@ notification_did_save :: proc(
 
 	when ODIN_OS == .Windows {
 		correct := common.get_case_sensitive_path(fullpath, context.temp_allocator)
-		fullpath, _ = filepath.replace_path_separators(correct, '/', context.temp_allocator)
+		fullpath, _ = filepath.replace_separators(correct, '/', context.temp_allocator)
 	}
 
 	corrected_uri := common.create_uri(fullpath, context.temp_allocator)

--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -32,7 +32,7 @@ get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceS
 			defer os.walker_destroy(&w)
 			for info in os.walker_walk(&w) {
 				if info.type == .Directory {
-					dir, _ := filepath.replace_path_separators(info.fullpath, '/', context.temp_allocator)
+					dir, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
 					dir_name := filepath.base(dir)
 					found := false
 					for blacklist in dir_blacklist {
@@ -56,7 +56,7 @@ get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceS
 				}
 
 				for exclude_path in common.config.profile.exclude_path {
-					exclude_forward, _ := filepath.replace_path_separators(exclude_path, '/', context.temp_allocator)
+					exclude_forward, _ := filepath.replace_separators(exclude_path, '/', context.temp_allocator)
 
 					if exclude_forward[len(exclude_forward) - 2:] == "**" {
 						lower_pkg := strings.to_lower(pkg)

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -88,7 +88,7 @@ setup :: proc(src: ^Source) {
 			flags = {.Optional_Semicolons},
 		}
 
-		dir := filepath.base(filepath.dir(fullpath, context.temp_allocator))
+		dir := filepath.base(filepath.dir(fullpath))
 
 		pkg := new(ast.Package, context.temp_allocator)
 		pkg.kind = .Normal

--- a/tools/odinfmt/snapshot/snapshot.odin
+++ b/tools/odinfmt/snapshot/snapshot.odin
@@ -24,7 +24,7 @@ read_config_file_or_default :: proc(fullpath: string, allocator := context.alloc
 	default_style.character_width = 80
 	default_style.newline_style = .LF //We want to make sure it works on linux and windows.
 
-	dirpath := filepath.dir(fullpath, allocator)
+	dirpath := filepath.dir(fullpath)
 	configpath := fmt.tprintf("%v/odinfmt.json", dirpath)
 
 	if (os.exists(configpath)) {
@@ -69,7 +69,7 @@ snapshot_file :: proc(path: string) -> bool {
 
 
 	snapshot_path, _ := filepath.join(
-		elems = {filepath.dir(path, context.temp_allocator), "/.snapshots", filepath.base(path)},
+		elems = {filepath.dir(path), "/.snapshots", filepath.base(path)},
 		allocator = context.temp_allocator,
 	)
 
@@ -116,7 +116,7 @@ snapshot_file :: proc(path: string) -> bool {
 			return false
 		}
 	} else {
-		os.make_directory(filepath.dir(snapshot_path, context.temp_allocator))
+		os.make_directory(filepath.dir(snapshot_path))
 		if err := os.write_entire_file(snapshot_path, transmute([]byte)formatted); err != nil {
 			fmt.eprintf("Failed to write snapshot file %v: %v", snapshot_path, err)
 			return false


### PR DESCRIPTION
Following https://github.com/odin-lang/Odin/pull/6575/changes

<details>
<summary>Build fail log using Odin dev-2026-04:320f0f0fb</summary>

```
/Users/yeongju/.local/ols2/src/server/format.odin(30:46) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... default(filepath.dir(document.fullpath, context.temp_allocator) ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/common/uri.odin(34:2) Error: Assignment count mismatch '2' = '1' 
        path_forward, _ := filepath.replace_path_separators(pat ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/common/uri.odin(34:21) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... d, _ := filepath.replace_path_separators(path, '/', context.tem ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/workspace_symbols.odin(35:6) Error: Assignment count mismatch '2' = '1' 
        dir, _ := filepath.replace_path_separators(info.fullpat ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/workspace_symbols.odin(35:16) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... r, _ := filepath.replace_path_separators(info.fullpath, '/', co ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/workspace_symbols.odin(46:7) Error: No procedures or ambiguous call for procedure group 'append' that match with the given arguments 
        append(&pkgs, dir) 
        ^~~~~^ 
        Given argument types: 
         • ^[dynamic]string 
         • invalid type 
Did you mean one of the following overloads? 
        runtime.append_elem                  :: proc(array: ^$T/[dynamic]$E, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error)        at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(736:1) 
        runtime.append_elems                 :: proc(array: ^$T/[dynamic]$E, #no_broadcast args: ..E, loc := #caller_location) -> (n: int, err: Allocator_Error)     at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(791:1) 
        runtime.append_elem_string           :: proc(array: ^$T/[dynamic]$E/u8, arg: $A/string, loc := #caller_location) -> (n: int, err: Allocator_Error)           at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(824:1) 
        runtime.append_fixed_capacity_elem   :: proc(array: ^$T/(BadExpr), #no_broadcast arg: E) -> (n: int)                                                         at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(864:1) 
        runtime.append_fixed_capacity_elems  :: proc(array: ^$T/(BadExpr), #no_broadcast args: ..E) -> (n: int)                                                      at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(881:1) 
        runtime.append_fixed_capacity_string :: proc(array: ^$T/(BadExpr), args: ..string) -> (n: int)                                                               at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(899:1) 
        runtime.append_soa_elem              :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error)    at /Users/yeongju/.local/Odin/base/runtime/core_builtin_soa.odin(375:1) 
        runtime.append_soa_elems             :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast args: ..E, loc := #caller_location) -> (n: int, err: Allocator_Error) at /Users/yeongju/.local/Odin/base/runtime/core_builtin_soa.odin(432:1) 
/Users/yeongju/.local/ols2/src/server/workspace_symbols.odin(59:6) Error: Assignment count mismatch '2' = '1' 
        exclude_forward, _ := filepath.replace_path_separators( ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/workspace_symbols.odin(59:28) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... d, _ := filepath.replace_path_separators(exclude_path, '/', con ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/caches.odin(85:5) Error: Assignment count mismatch '2' = '1' 
        forward_pkg, _ := filepath.replace_path_separators(pkg, ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/caches.odin(85:23) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... g, _ := filepath.replace_path_separators(pkg, '/', context.temp ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/build.odin(137:11) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        dir := filepath.dir(info.fullpath, allocator) 
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/build.odin(143:5) Error: No procedures or ambiguous call for procedure group 'append' that match with the given arguments 
        append(pkgs, dir) 
        ^~~~~^ 
        Given argument types: 
         • ^[dynamic]string 
         • invalid type 
Did you mean one of the following overloads? 
        runtime.append_elem                  :: proc(array: ^$T/[dynamic]$E, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error)        at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(736:1) 
        runtime.append_elems                 :: proc(array: ^$T/[dynamic]$E, #no_broadcast args: ..E, loc := #caller_location) -> (n: int, err: Allocator_Error)     at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(791:1) 
        runtime.append_elem_string           :: proc(array: ^$T/[dynamic]$E/u8, arg: $A/string, loc := #caller_location) -> (n: int, err: Allocator_Error)           at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(824:1) 
        runtime.append_fixed_capacity_elem   :: proc(array: ^$T/(BadExpr), #no_broadcast arg: E) -> (n: int)                                                         at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(864:1) 
        runtime.append_fixed_capacity_elems  :: proc(array: ^$T/(BadExpr), #no_broadcast args: ..E) -> (n: int)                                                      at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(881:1) 
        runtime.append_fixed_capacity_string :: proc(array: ^$T/(BadExpr), args: ..string) -> (n: int)                                                               at /Users/yeongju/.local/Odin/base/runtime/core_builtin.odin(899:1) 
        runtime.append_soa_elem              :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error)    at /Users/yeongju/.local/Odin/base/runtime/core_builtin_soa.odin(375:1) 
        runtime.append_soa_elems             :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast args: ..E, loc := #caller_location) -> (n: int, err: Allocator_Error) at /Users/yeongju/.local/Odin/base/runtime/core_builtin_soa.odin(432:1) 
/Users/yeongju/.local/ols2/src/server/build.odin(220:25) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        dir := filepath.base(filepath.dir(fullpath, context.allocator)) 
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/build.odin(312:23) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... := filepath.base(filepath.dir(fullpath, context.temp_allocator)) 
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/references.odin(297:6) Error: Assignment count mismatch '2' = '1' 
        slash_path, _ := filepath.replace_path_separators(info. ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/references.odin(297:23) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... h, _ := filepath.replace_path_separators(info.fullpath, '/', co ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/documents.odin(407:12) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... older := filepath.dir(document.fullpath, context.temp_allocator) 
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(497:3) Error: Assignment count mismatch '2' = '1' 
        forward_path, _ := filepath.replace_path_separators(it. ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(497:22) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... h, _ := filepath.replace_path_separators(it.path, '/', context. ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(535:4) Error: Assignment count mismatch '2' = '1' 
        slashed_path, _ := filepath.replace_path_separators(abs ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(535:23) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... h, _ := filepath.replace_path_separators(abs_final_path, '/', c ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(577:22) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        odin_core_env = filepath.dir(odin_bin, context.temp_allocator) 
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(579:22) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        odin_core_env = filepath.dir(exe_path, context.temp_allocator) 
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(595:3) Error: Assignment count mismatch '2' = '1' 
        forward_path, _ := filepath.replace_path_separators(odi ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(595:22) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... h, _ := filepath.replace_path_separators(odin_core_env, '/', co ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/requests.odin(721:12) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... lems = {filepath.dir(os.args[0], context.temp_allocator), "ols. ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/collector.odin(698:3) Error: Assignment count mismatch '2' = '1' 
        intrinsics_path, _ = filepath.replace_path_separators(i ... 
        ^~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/collector.odin(698:24) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... th, _ = filepath.replace_path_separators(intrinsics_path, '/',  ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/collector.odin(716:2) Error: Assignment count mismatch '2' = '1' 
        forward, _ := filepath.replace_path_separators(file.ful ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/collector.odin(716:16) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... d, _ := filepath.replace_path_separators(file.fullpath, '/', co ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/completion.odin(1835:6) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        filepath.dir(without_quotes[colon_index + 1:], context. ... 
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ... 
 
/Users/yeongju/.local/ols2/src/server/completion.odin(1843:22) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... _dir := filepath.dir(position_context.import_stmt.pos.file, con ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ... 
 
/Users/yeongju/.local/ols2/src/server/completion.odin(1844:17) Error: Too many arguments for 'filepath.dir', expected 1 arguments, got 2 
        ... port_dir := filepath.dir(without_quotes, context.temp_allocator) 
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 
/Users/yeongju/.local/ols2/src/server/analysis.odin(3722:2) Error: Assignment count mismatch '2' = '1' 
        slashed, _ := filepath.replace_path_separators(file_pat ... 
        ^ 
 
/Users/yeongju/.local/ols2/src/server/analysis.odin(3722:16) Error: 'replace_path_separators' is not declared by 'filepath' 
        ... d, _ := filepath.replace_path_separators(file_path, '/', contex ... 
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
```
</details>