### PR TITLE
Re-clone package paths after filepath changes

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -140,7 +140,7 @@ append_packages :: proc(path: string, pkgs: ^[dynamic]string, skip: map[string]s
 				continue
 			}
 			if !slice.contains(pkgs[:], dir) {
-				append(pkgs, dir)
+				append(pkgs, strings.clone(dir, allocator))
 			}
 		}
 	}


### PR DESCRIPTION
After https://github.com/DanielGavin/ols/pull/1429 I noticed some issues with the checker due to the filepaths no longer being cloned when accessing the directory.