### PR TITLE
make `checker` thread_local

### DIFF
--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -50,7 +50,7 @@ Checker :: struct {
 	send:      chan.Chan(Check_Request, .Send),
 }
 
-@(private = "file")
+@(thread_local, private = "file")
 checker: Checker
 
 queue_check_request :: proc(mode: Check_Mode, path: string, config: ^common.Config) {


### PR DESCRIPTION
Should the global variable  `checker` in check.odin be thread_local?