### PR TITLE
build: fix build error on recent Odin nightly (Essence OS target)

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -34,7 +34,7 @@ platform_os: map[string]struct{} = {
 }
 
 
-os_enum_to_string: [runtime.Odin_OS_Type]string = {
+os_enum_to_string := #partial [runtime.Odin_OS_Type]string {
 	.Windows      = "windows",
 	.Darwin       = "darwin",
 	.Linux        = "linux",


### PR DESCRIPTION
This PR fixes a build error encountered when using recent Odin nightly 
versions (e.g., dev-2026-04)

The compiler now requires #partial or an explicit case for the new 
'Essence' OS target in enumerated arrays. Added #partial to 
os_enum_to_string in src/server/build.odin to restore compatibility.

Error fixed:
Unhandled enumerated array case: Essence
