### PR TITLE
Test ignore file tags

### DIFF
--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -7,6 +7,7 @@ import "core:odin/ast"
 import "core:odin/parser"
 import "core:strings"
 import "core:testing"
+import "core:path/filepath"
 
 import "src:common"
 import "src:server"
@@ -14,9 +15,6 @@ import "src:server"
 File :: struct {
 	name:   string,
 	source: string,
-	// Allows you to directly specify the file path. 
-	// If it's 'test/<file>.odin', it will share the same package as the main file.
-	file:   string,
 }
 
 Package :: struct {
@@ -181,6 +179,8 @@ setup_multi_file_collect :: proc(src: ^Source) {
 			warn  = parser.default_error_handler,
 			flags = {.Optional_Semicolons},
 		}
+
+		dir := filepath.base(filepath.dir(fullpath))
 
 		pkg := new(ast.Package, context.temp_allocator)
 		pkg.kind = .Normal

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -6,7 +6,6 @@ import "core:log"
 import "core:mem/virtual"
 import "core:odin/ast"
 import "core:odin/parser"
-import "core:path/filepath"
 import "core:strings"
 import "core:testing"
 
@@ -71,19 +70,14 @@ setup :: proc(src: ^Source) {
 
 	server.document_refresh(src.document, &src.config, nil)
 
-	{
+	if len(src.files) > 1 {
 		pkg := new(ast.Package, context.temp_allocator)
 		pkg.name = "test"
 		pkg.fullpath = "test"
 		pkg.name = "test"
 
-		for f in src.files {
-			fullpath := strings.join({pkg.fullpath, f.name}, "/", context.temp_allocator)
-
-			// Skip the document file - it may have incomplete syntax after {*} stripping
-			if fullpath != src.document.uri.path {
-				process_file(fullpath, f.source, pkg)
-			}
+		for f in src.files[1:] {
+			process_file(f.name, f.source, pkg)
 		}
 	}
 
@@ -98,18 +92,16 @@ setup :: proc(src: ^Source) {
 			pkg.kind = .Runtime
 		}
 
-		if len(src_pkg.files) > 0 {
-			for f in src_pkg.files {
-				fullpath := strings.join({pkg.fullpath, f.name}, "/", context.temp_allocator)
-				process_file(fullpath, f.source, pkg)
-			}
+		if len(src_pkg.files) > 0 do for f in src_pkg.files {
+			process_file(f.name, f.source, pkg)
 		} else {
-			fullpath := strings.join({pkg.fullpath, "package.odin"}, "/", context.temp_allocator)
-			process_file(fullpath, src_pkg.source, pkg)
+			process_file("package.odin", src_pkg.source, pkg)
 		}
 	}
 
-	process_file :: proc(fullpath: string, source: string, pkg: ^ast.Package) {
+	process_file :: proc(filename: string, source: string, pkg: ^ast.Package) {
+
+		fullpath := strings.join({pkg.fullpath, filename}, "/", context.temp_allocator)
 
 		p := parser.Parser {
 			err   = parser.default_error_handler,

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -38,9 +38,9 @@ setup :: proc(src: ^Source) {
 
 	src.document = new(server.Document, context.temp_allocator)
 
-	src.document.package_name = "test"
 	src.document.client_owned = true
 	src.document.allocator = new(virtual.Arena, context.temp_allocator)
+	src.document.package_name = "test"
 
 	_ = virtual.arena_init_growing(src.document.allocator)
 
@@ -81,11 +81,9 @@ setup :: proc(src: ^Source) {
 			fullpath := strings.join({pkg.fullpath, f.name}, "/", context.temp_allocator)
 
 			// Skip the document file - it may have incomplete syntax after {*} stripping
-			if fullpath == src.document.uri.path {
-				continue
+			if fullpath != src.document.uri.path {
+				process_file(fullpath, f.source, pkg)
 			}
-
-			process_file(fullpath, f.source, pkg)
 		}
 	}
 

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -49,15 +49,18 @@ setup :: proc(src: ^Source) {
 		src.main  = ""
 	}
 
-	if len(src.files) > 0 {
-		f := &src.files[0]
-		source := transmute([]u8)f.source
-
-		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
-		src.document.text = source
-		src.document.used_text = len(source)
+	if len(src.files) <= 0 {
+		log.error("Expected at least one file")
+		return
 	}
+
+	f := &src.files[0]
+	source := transmute([]u8)f.source
+
+	fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+	src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+	src.document.text = source
+	src.document.used_text = len(source)
 
 	server.setup_index(server.get_builtin_path())
 
@@ -68,7 +71,27 @@ setup :: proc(src: ^Source) {
 
 	server.document_refresh(src.document, &src.config, nil)
 
-	setup_multi_file_collect(src)
+	for f in src.files {
+		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+
+		// Skip the document file - it may have incomplete syntax after {*} stripping
+		if fullpath == src.document.uri.path {
+			continue
+		}
+
+		dir := filepath.base(filepath.dir(fullpath))
+
+		pkg := new(ast.Package, context.temp_allocator)
+		pkg.name = "test"
+		pkg.fullpath = fullpath
+		pkg.name = dir
+
+		if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
+			pkg.kind = .Runtime
+		}
+
+		process_file(fullpath, f.source, pkg)
+	}
 
 	for src_pkg in src.packages {
 		context.allocator = virtual.arena_allocator(src.document.allocator)
@@ -76,37 +99,10 @@ setup :: proc(src: ^Source) {
 		dir := src_pkg.pkg
 
 		pkg := new(ast.Package, context.temp_allocator)
-		pkg.kind = .Normal
 		pkg.name = dir
 
 		if dir == "runtime" {
 			pkg.kind = .Runtime
-		}
-
-		process_file :: proc(fullpath: string, source: string, pkg: ^ast.Package) {
-			p := parser.Parser {
-				err   = parser.default_error_handler,
-				warn  = parser.default_error_handler,
-				flags = {.Optional_Semicolons},
-			}
-
-			file := ast.File {
-				fullpath = fullpath,
-				src      = source,
-				pkg      = pkg,
-			}
-
-			ok := parser.parse_file(&p, &file)
-
-			if !ok || file.syntax_error_count > 0 {
-				panic("Parser error in test package source")
-			}
-
-			uri := common.create_uri(fullpath, context.temp_allocator)
-
-			if ret := server.collect_symbols(&server.indexer.index.collection, file, uri.uri); ret != .None {
-				return
-			}
 		}
 
 		if len(src_pkg.files) > 0 {
@@ -121,55 +117,17 @@ setup :: proc(src: ^Source) {
 			process_file(fullpath, src_pkg.source, pkg)
 		}
 	}
-}
 
-@(private)
-setup_multi_file_prepare :: proc(src: ^Source) {
-
-	src.document.package_name = "test"
-
-	if len(src.files) < 1 do return
-
-	f := &src.files[0]
-	source := transmute([]u8)f.source
-
-	fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-	src.document.uri = common.create_uri(fullpath, context.temp_allocator)
-	src.document.text = source
-	src.document.used_text = len(source)
-}
-
-@(private)
-setup_multi_file_collect :: proc(src: ^Source) {
-	for f in src.files {
-		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-
-		// Skip the document file - it may have incomplete syntax after {*} stripping
-		if fullpath == src.document.uri.path {
-			continue
-		}
-
+	process_file :: proc(fullpath: string, source: string, pkg: ^ast.Package) {
 		p := parser.Parser {
 			err   = parser.default_error_handler,
 			warn  = parser.default_error_handler,
 			flags = {.Optional_Semicolons},
 		}
 
-		dir := filepath.base(filepath.dir(fullpath))
-
-		pkg := new(ast.Package, context.temp_allocator)
-		pkg.kind = .Normal
-		pkg.name = "test"
-		pkg.fullpath = fullpath
-		pkg.name = dir
-
-		if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
-			pkg.kind = .Runtime
-		}
-
 		file := ast.File {
 			fullpath = fullpath,
-			src      = f.source,
+			src      = source,
 			pkg      = pkg,
 		}
 
@@ -181,8 +139,9 @@ setup_multi_file_collect :: proc(src: ^Source) {
 
 		uri := common.create_uri(fullpath, context.temp_allocator)
 
-		if ret := server.collect_symbols(&server.indexer.index.collection, file, uri.uri); ret != .None {
-			return
+		err := server.collect_symbols(&server.indexer.index.collection, file, uri.uri)
+		if err != .None {
+			log.errorf("Error (%v) while collecting symbols in file (%s) \"%s\"", err, fullpath, source)
 		}
 	}
 }

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -43,11 +43,15 @@ setup :: proc(src: ^Source) {
 
 	_ = virtual.arena_init_growing(src.document.allocator)
 
-	if len(src.files) > 0 {
-		setup_multi_file_prepare(src)
-	} else {
-		setup_single_file(src)
+	if len(src.main) > 0 {
+		files := make([dynamic]File, 0, len(src.files)+1, context.temp_allocator)
+		append(&files, File{"main.odin", src.main})
+		append(&files, ..src.files)
+		src.files = files[:]
+		src.main = ""
 	}
+
+	setup_multi_file_prepare(src)
 
 	server.setup_index(server.get_builtin_path())
 
@@ -58,9 +62,7 @@ setup :: proc(src: ^Source) {
 
 	server.document_refresh(src.document, &src.config, nil)
 
-	if len(src.files) > 0 {
-		setup_multi_file_collect(src)
-	}
+	setup_multi_file_collect(src)
 
 	for src_pkg in src.packages {
 		context.allocator = virtual.arena_allocator(src.document.allocator)
@@ -103,12 +105,12 @@ setup :: proc(src: ^Source) {
 
 		if len(src_pkg.files) > 0 {
 			for f in src_pkg.files {
-				fullpath := fmt.aprintf("test/%v/%v", dir, f.name)
+				fullpath := strings.join({"test", dir, f.name}, "/", context.temp_allocator)
 				pkg.fullpath = fullpath
 				process_file(fullpath, f.source, pkg)
 			}
 		} else {
-			fullpath := fmt.aprintf("test/%v/package.odin", dir)
+			fullpath := strings.join({"test", dir, "package.odin"}, "/", context.temp_allocator)
 			pkg.fullpath = fullpath
 			process_file(fullpath, src_pkg.source, pkg)
 		}
@@ -116,85 +118,63 @@ setup :: proc(src: ^Source) {
 }
 
 @(private)
-setup_single_file :: proc(src: ^Source) {
-	src.main = strings.clone(src.main, context.temp_allocator)
-	src.document.uri = common.create_uri("test/test.odin", context.temp_allocator)
-	src.document.text = transmute([]u8)src.main
-	src.document.used_text = len(src.document.text)
-	src.document.package_name = "test"
-
-	current, last: u8
-	current_line, current_character: int
-
-	for current_index := 0; current_index < len(src.main); current_index += 1 {
-		current = src.main[current_index]
-
-		if last == '\r' {
-			current_line += 1
-			current_character = 0
-		} else if current == '\n' {
-			current_line += 1
-			current_character = 0
-		} else if len(src.main) > current_index + 3 && src.main[current_index:current_index + 3] == "{*}" {
-			dst_slice := transmute([]u8)src.main[current_index:]
-			src_slice := transmute([]u8)src.main[current_index + 3:]
-			copy(dst_slice, src_slice)
-			src.position.character = current_character
-			src.position.line = current_line
-			break
-		} else {
-			current_character += 1
-		}
-
-		last = current
-	}
-}
-
-@(private)
 setup_multi_file_prepare :: proc(src: ^Source) {
 	src.document.package_name = "test"
 
-	for i in 0 ..< len(src.files) {
-		f := &src.files[i]
-		source := strings.clone(f.source, context.temp_allocator)
-		f.source = source
+	for &f, i in src.files {
 
-		fullpath := fmt.aprintf("test/%v", f.name)
+		marker_pos := strings.index(f.source, "{*}")
+		if marker_pos < 0 do continue
 
-		if pos := strings.index(source, "{*}"); pos >= 0 {
-			last: u8
-			cursor_line, cursor_char: int
-			for j := 0; j < pos; j += 1 {
-				ch := source[j]
-				if last == '\r' {
-					cursor_line += 1
-					cursor_char = 0
-				} else if ch == '\n' {
-					cursor_line += 1
-					cursor_char = 0
-				} else {
-					cursor_char += 1
-				}
-				last = ch
+		// remove `{*}`
+		source := make([]u8, len(f.source)-3, context.temp_allocator)
+		copy(source[:marker_pos], transmute([]u8)f.source[:marker_pos])
+		copy(source[marker_pos:], transmute([]u8)f.source[marker_pos+3:])
+		f.source = string(source)
+
+		last: u8
+		cursor_line, cursor_char: int
+		for j := 0; j < marker_pos; j += 1 {
+			ch := source[j]
+			if last == '\r' {
+				cursor_line += 1
+				cursor_char = 0
+			} else if ch == '\n' {
+				cursor_line += 1
+				cursor_char = 0
+			} else {
+				cursor_char += 1
 			}
-
-			dst_slice := transmute([]u8)source[pos:]
-			src_slice := transmute([]u8)source[pos + 3:]
-			copy(dst_slice, src_slice)
-
-			src.document.uri = common.create_uri(fullpath, context.temp_allocator)
-			src.document.text = transmute([]u8)source
-			src.document.used_text = len(source)
-			src.position.line = cursor_line
-			src.position.character = cursor_char
+			last = ch
 		}
+
+		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+		src.document.text = source
+		src.document.used_text = len(source)
+		src.position.line = cursor_line
+		src.position.character = cursor_char
+	}
+
+	// If no file had {*}, default document to first file
+	if len(src.document.text) == 0 && len(src.files) > 0 {
+		f := &src.files[0]
+		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+		src.document.text = transmute([]u8)f.source
+		src.document.used_text = len(f.source)
 	}
 }
 
 @(private)
 setup_multi_file_collect :: proc(src: ^Source) {
 	for f in src.files {
-		fullpath := fmt.aprintf("test/%v", f.name)
+		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+
+		// Skip the document file - it may have incomplete syntax after {*} stripping
+		if fullpath == src.document.uri.path {
+			continue
+		}
 
 		p := parser.Parser {
 			err   = parser.default_error_handler,

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -5,23 +5,29 @@ import "core:log"
 import "core:mem/virtual"
 import "core:odin/ast"
 import "core:odin/parser"
-import "core:path/filepath"
 import "core:strings"
 import "core:testing"
 
 import "src:common"
 import "src:server"
 
-Package :: struct {
-	pkg:    string,
+File :: struct {
+	name:   string,
 	source: string,
 	// Allows you to directly specify the file path. 
 	// If it's 'test/<file>.odin', it will share the same package as the main file.
 	file:   string,
 }
 
+Package :: struct {
+	pkg:    string,
+	source: string, // backwards compatable–for single-file packages
+	files:  []File,
+}
+
 Source :: struct {
-	main:        string,
+	main:        string, // backwards compatable–for single-file packages
+	files:       []File,
 	packages:    []Package,
 	document:    ^server.Document,
 	collections: map[string]string,
@@ -31,18 +37,92 @@ Source :: struct {
 
 @(private)
 setup :: proc(src: ^Source) {
-	src.main = strings.clone(src.main, context.temp_allocator)
 	src.document = new(server.Document, context.temp_allocator)
-	src.document.uri = common.create_uri("test/test.odin", context.temp_allocator)
 	src.document.client_owned = true
-	src.document.text = transmute([]u8)src.main
-	src.document.used_text = len(src.document.text)
 	src.document.allocator = new(virtual.Arena, context.temp_allocator)
-	src.document.package_name = "test"
 
 	_ = virtual.arena_init_growing(src.document.allocator)
 
-	//no unicode in tests currently
+	if len(src.files) > 0 {
+		setup_multi_file_prepare(src)
+	} else {
+		setup_single_file(src)
+	}
+
+	server.setup_index(server.get_builtin_path())
+
+	// Set the collection's config to the test's config to enable feature flags like enable_fake_method
+	server.indexer.index.collection.config = &src.config
+
+	server.document_setup(src.document)
+
+	server.document_refresh(src.document, &src.config, nil)
+
+	if len(src.files) > 0 {
+		setup_multi_file_collect(src)
+	}
+
+	for src_pkg in src.packages {
+		context.allocator = virtual.arena_allocator(src.document.allocator)
+
+		dir := src_pkg.pkg
+
+		pkg := new(ast.Package, context.temp_allocator)
+		pkg.kind = .Normal
+		pkg.name = dir
+
+		if dir == "runtime" {
+			pkg.kind = .Runtime
+		}
+
+		process_file :: proc(fullpath: string, source: string, pkg: ^ast.Package) {
+			p := parser.Parser {
+				err   = parser.default_error_handler,
+				warn  = parser.default_error_handler,
+				flags = {.Optional_Semicolons},
+			}
+
+			file := ast.File {
+				fullpath = fullpath,
+				src      = source,
+				pkg      = pkg,
+			}
+
+			ok := parser.parse_file(&p, &file)
+
+			if !ok || file.syntax_error_count > 0 {
+				panic("Parser error in test package source")
+			}
+
+			uri := common.create_uri(fullpath, context.temp_allocator)
+
+			if ret := server.collect_symbols(&server.indexer.index.collection, file, uri.uri); ret != .None {
+				return
+			}
+		}
+
+		if len(src_pkg.files) > 0 {
+			for f in src_pkg.files {
+				fullpath := fmt.aprintf("test/%v/%v", dir, f.name)
+				pkg.fullpath = fullpath
+				process_file(fullpath, f.source, pkg)
+			}
+		} else {
+			fullpath := fmt.aprintf("test/%v/package.odin", dir)
+			pkg.fullpath = fullpath
+			process_file(fullpath, src_pkg.source, pkg)
+		}
+	}
+}
+
+@(private)
+setup_single_file :: proc(src: ^Source) {
+	src.main = strings.clone(src.main, context.temp_allocator)
+	src.document.uri = common.create_uri("test/test.odin", context.temp_allocator)
+	src.document.text = transmute([]u8)src.main
+	src.document.used_text = len(src.document.text)
+	src.document.package_name = "test"
+
 	current, last: u8
 	current_line, current_character: int
 
@@ -68,26 +148,53 @@ setup :: proc(src: ^Source) {
 
 		last = current
 	}
+}
 
-	server.setup_index(server.get_builtin_path())
+@(private)
+setup_multi_file_prepare :: proc(src: ^Source) {
+	src.document.package_name = "test"
 
-	// Set the collection's config to the test's config to enable feature flags like enable_fake_method
-	server.indexer.index.collection.config = &src.config
+	for i in 0 ..< len(src.files) {
+		f := &src.files[i]
+		source := strings.clone(f.source, context.temp_allocator)
+		f.source = source
 
-	server.document_setup(src.document)
+		fullpath := fmt.aprintf("test/%v", f.name)
 
-	server.document_refresh(src.document, &src.config, nil)
+		if pos := strings.index(source, "{*}"); pos >= 0 {
+			last: u8
+			cursor_line, cursor_char: int
+			for j := 0; j < pos; j += 1 {
+				ch := source[j]
+				if last == '\r' {
+					cursor_line += 1
+					cursor_char = 0
+				} else if ch == '\n' {
+					cursor_line += 1
+					cursor_char = 0
+				} else {
+					cursor_char += 1
+				}
+				last = ch
+			}
 
-	for src_pkg in src.packages {
-		context.allocator = virtual.arena_allocator(src.document.allocator)
+			dst_slice := transmute([]u8)source[pos:]
+			src_slice := transmute([]u8)source[pos + 3:]
+			copy(dst_slice, src_slice)
 
-		path := src_pkg.file
-		if path == "" {
-			path = fmt.aprintf("test/%v/package.odin", src_pkg.pkg)
+			src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+			src.document.text = transmute([]u8)source
+			src.document.used_text = len(source)
+			src.position.line = cursor_line
+			src.position.character = cursor_char
 		}
-		uri := common.create_uri(path, context.temp_allocator)
+	}
+}
 
-		fullpath := uri.path
+@(private)
+setup_multi_file_collect :: proc(src: ^Source) {
+	for f in src.files {
+		fullpath := fmt.aprintf("test/%v", f.name)
 
 		p := parser.Parser {
 			err   = parser.default_error_handler,
@@ -95,10 +202,9 @@ setup :: proc(src: ^Source) {
 			flags = {.Optional_Semicolons},
 		}
 
-		dir := filepath.base(filepath.dir(fullpath))
-
 		pkg := new(ast.Package, context.temp_allocator)
 		pkg.kind = .Normal
+		pkg.name = "test"
 		pkg.fullpath = fullpath
 		pkg.name = dir
 
@@ -108,16 +214,17 @@ setup :: proc(src: ^Source) {
 
 		file := ast.File {
 			fullpath = fullpath,
-			src      = src_pkg.source,
+			src      = f.source,
 			pkg      = pkg,
 		}
 
 		ok := parser.parse_file(&p, &file)
 
-
 		if !ok || file.syntax_error_count > 0 {
 			panic("Parser error in test package source")
 		}
+
+		uri := common.create_uri(fullpath, context.temp_allocator)
 
 		if ret := server.collect_symbols(&server.indexer.index.collection, file, uri.uri); ret != .None {
 			return

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -71,54 +71,48 @@ setup :: proc(src: ^Source) {
 
 	server.document_refresh(src.document, &src.config, nil)
 
-	for f in src.files {
-		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-
-		// Skip the document file - it may have incomplete syntax after {*} stripping
-		if fullpath == src.document.uri.path {
-			continue
-		}
-
-		dir := filepath.base(filepath.dir(fullpath))
-
+	{
 		pkg := new(ast.Package, context.temp_allocator)
 		pkg.name = "test"
-		pkg.fullpath = fullpath
-		pkg.name = dir
+		pkg.fullpath = "test"
+		pkg.name = "test"
 
-		if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
-			pkg.kind = .Runtime
+		for f in src.files {
+			fullpath := strings.join({pkg.fullpath, f.name}, "/", context.temp_allocator)
+
+			// Skip the document file - it may have incomplete syntax after {*} stripping
+			if fullpath == src.document.uri.path {
+				continue
+			}
+
+			process_file(fullpath, f.source, pkg)
 		}
-
-		process_file(fullpath, f.source, pkg)
 	}
 
 	for src_pkg in src.packages {
 		context.allocator = virtual.arena_allocator(src.document.allocator)
 
-		dir := src_pkg.pkg
-
 		pkg := new(ast.Package, context.temp_allocator)
-		pkg.name = dir
+		pkg.name = src_pkg.pkg
+		pkg.fullpath = strings.join({"test", pkg.name}, "/", context.temp_allocator)
 
-		if dir == "runtime" {
+		if pkg.name == "runtime" || strings.contains(pkg.fullpath, "base/runtime") {
 			pkg.kind = .Runtime
 		}
 
 		if len(src_pkg.files) > 0 {
 			for f in src_pkg.files {
-				fullpath := strings.join({"test", dir, f.name}, "/", context.temp_allocator)
-				pkg.fullpath = fullpath
+				fullpath := strings.join({pkg.fullpath, f.name}, "/", context.temp_allocator)
 				process_file(fullpath, f.source, pkg)
 			}
 		} else {
-			fullpath := strings.join({"test", dir, "package.odin"}, "/", context.temp_allocator)
-			pkg.fullpath = fullpath
+			fullpath := strings.join({pkg.fullpath, "package.odin"}, "/", context.temp_allocator)
 			process_file(fullpath, src_pkg.source, pkg)
 		}
 	}
 
 	process_file :: proc(fullpath: string, source: string, pkg: ^ast.Package) {
+
 		p := parser.Parser {
 			err   = parser.default_error_handler,
 			warn  = parser.default_error_handler,

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -6,9 +6,9 @@ import "core:log"
 import "core:mem/virtual"
 import "core:odin/ast"
 import "core:odin/parser"
+import "core:path/filepath"
 import "core:strings"
 import "core:testing"
-import "core:path/filepath"
 
 import "src:common"
 import "src:server"
@@ -31,12 +31,14 @@ Source :: struct {
 	document:    ^server.Document,
 	collections: map[string]string,
 	config:      common.Config,
-	position:    common.Position,
 }
 
 @(private)
 setup :: proc(src: ^Source) {
+
 	src.document = new(server.Document, context.temp_allocator)
+
+	src.document.package_name = "test"
 	src.document.client_owned = true
 	src.document.allocator = new(virtual.Arena, context.temp_allocator)
 
@@ -47,7 +49,15 @@ setup :: proc(src: ^Source) {
 		src.main  = ""
 	}
 
-	setup_multi_file_prepare(src)
+	if len(src.files) > 0 {
+		f := &src.files[0]
+		source := transmute([]u8)f.source
+
+		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+		src.document.text = source
+		src.document.used_text = len(source)
+	}
 
 	server.setup_index(server.get_builtin_path())
 
@@ -123,36 +133,6 @@ setup_multi_file_prepare :: proc(src: ^Source) {
 	f := &src.files[0]
 	source := transmute([]u8)f.source
 
-	if marker_pos := strings.index(f.source, "{*}"); marker_pos >= 0 {
-		// remove `{*}`
-
-		new_source := make([]u8, len(source)-3, context.temp_allocator)
-		copy(new_source[:marker_pos], source[:marker_pos])
-		copy(new_source[marker_pos:], source[marker_pos+3:])
-
-		source = new_source
-		f.source = string(source)
-
-		last: u8
-		cursor_line, cursor_char: int
-		for j := 0; j < marker_pos; j += 1 {
-			ch := source[j]
-			if last == '\r' {
-				cursor_line += 1
-				cursor_char = 0
-			} else if ch == '\n' {
-				cursor_line += 1
-				cursor_char = 0
-			} else {
-				cursor_char += 1
-			}
-			last = ch
-		}
-
-		src.position.line = cursor_line
-		src.position.character = cursor_char
-	}
-
 	fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
 	src.document.uri = common.create_uri(fullpath, context.temp_allocator)
 	src.document.text = source
@@ -214,16 +194,63 @@ teardown :: proc(src: ^Source) {
 	virtual.arena_destroy(src.document.allocator)
 }
 
+source_remove_cursor :: proc (src: ^Source) -> (cursor: common.Position) {
+
+	source: ^string
+	if src.main != "" {
+		source = &src.main
+	} else if len(src.files) > 0{
+		source = &src.files[0].source
+	}
+
+	if source == nil || len(source) == 0 {
+		log.error("Cannot get cursor from an empty file")
+		return
+	}
+
+	CURSOR :: "{*}"
+
+	marker_pos := strings.index(source^, CURSOR)
+	if marker_pos < 0 {
+		log.errorf("Didn't find %s in `%s`", CURSOR, source^)
+		return
+	}
+
+	// remove cursor mark from source
+	new_source := make([]u8, len(source)-len(CURSOR), context.temp_allocator)
+	copy(new_source[:marker_pos], source[:marker_pos])
+	copy(new_source[marker_pos:], source[marker_pos+len(CURSOR):])
+	source ^= string(new_source)
+
+	// find cursor (line,col) position
+	last: u8
+	for j := 0; j < marker_pos; j += 1 {
+		ch := source[j]
+		defer last = ch
+
+		if last == '\r' || ch == '\n' {
+			cursor.line += 1
+			cursor.character = 0
+		} else {
+			cursor.character += 1
+		}
+	}
+
+	return
+}
+
 expect_signature_labels :: proc(
 	t: ^testing.T,
 	src: ^Source,
 	expect_labels: []string,
 	expected_active_parameter := -1,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	help, ok := server.get_signature_information(src.document, src.position, &src.config)
+	help, ok := server.get_signature_information(src.document, cursor, &src.config)
 
 	if !ok {
 		log.error("Failed get_signature_information")
@@ -261,10 +288,12 @@ expect_signature_labels :: proc(
 }
 
 expect_signature_parameter_position :: proc(t: ^testing.T, src: ^Source, position: int) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	help, ok := server.get_signature_information(src.document, src.position, &src.config)
+	help, ok := server.get_signature_information(src.document, cursor, &src.config)
 
 	if help.activeParameter != position {
 		log.errorf("expected parameter position %v, but received %v", position, help.activeParameter)
@@ -278,6 +307,8 @@ expect_completion_labels :: proc(
 	expect_labels: []string,
 	expect_excluded: []string = nil,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
@@ -285,7 +316,7 @@ expect_completion_labels :: proc(
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
+	completion_list, ok := server.get_completion_list(src.document, cursor, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -348,6 +379,8 @@ expect_completion_docs :: proc(
 	expect_details: []string,
 	expect_excluded: []string = nil,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
@@ -367,7 +400,7 @@ expect_completion_docs :: proc(
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
+	completion_list, ok := server.get_completion_list(src.document, cursor, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -408,6 +441,8 @@ expect_completion_insert_text :: proc(
 	trigger_character: string,
 	expect_inserts: []string,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
@@ -415,7 +450,7 @@ expect_completion_insert_text :: proc(
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
+	completion_list, ok := server.get_completion_list(src.document, cursor, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -452,6 +487,8 @@ expect_completion_edit_text :: proc(
 	label: string,
 	expected_text: string,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
@@ -459,7 +496,7 @@ expect_completion_edit_text :: proc(
 		triggerCharacter = trigger_character,
 	}
 
-	completion_list, ok := server.get_completion_list(src.document, src.position, completion_context, &src.config)
+	completion_list, ok := server.get_completion_list(src.document, cursor, completion_context, &src.config)
 
 	if !ok {
 		log.error("Failed get_completion_list")
@@ -490,10 +527,12 @@ expect_completion_edit_text :: proc(
 }
 
 expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	hover, valid, ok := server.get_hover_information(src.document, src.position)
+	hover, valid, ok := server.get_hover_information(src.document, cursor)
 
 	if !ok {
 		log.error(t, "Failed get_hover_information")
@@ -514,10 +553,12 @@ expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {
 }
 
 expect_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_locations: []common.Location) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	locations, ok := server.get_definition_location(src.document, src.position, &src.config)
+	locations, ok := server.get_definition_location(src.document, cursor, &src.config)
 
 	if !ok {
 		log.error("Failed get_definition_location")
@@ -545,10 +586,12 @@ expect_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_location
 }
 
 expect_type_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_locations: []common.Location) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	locations, ok := server.get_type_definition_locations(src.document, src.position)
+	locations, ok := server.get_type_definition_locations(src.document, cursor)
 
 	if !ok {
 		log.error("Failed get_definition_location")
@@ -590,10 +633,12 @@ expect_reference_locations :: proc(
 	expect_excluded: []common.Location = nil,
 	include_declaration := true,
 ) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	locations, ok := server.get_references(src.document, src.position, include_declaration = include_declaration)
+	locations, ok := server.get_references(src.document, cursor, include_declaration = include_declaration)
 
 	for expect_location in expect_locations {
 		match := false
@@ -625,10 +670,12 @@ expect_reference_locations :: proc(
 }
 
 expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: common.Range) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	range, ok := server.get_prepare_rename(src.document, src.position)
+	range, ok := server.get_prepare_rename(src.document, cursor)
 	if !ok {
 		log.error("Failed to find range")
 	}
@@ -645,13 +692,12 @@ expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: c
 
 
 expect_action :: proc(t: ^testing.T, src: ^Source, expect_action_names: []string) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	input_range := common.Range {
-		start = src.position,
-		end   = src.position,
-	}
+	input_range := common.Range{cursor, cursor}
 	actions, ok := server.get_code_actions(src.document, input_range, &src.config)
 	if !ok {
 		log.error("Failed to find actions")
@@ -679,13 +725,12 @@ expect_action :: proc(t: ^testing.T, src: ^Source, expect_action_names: []string
 }
 
 expect_action_with_edit :: proc(t: ^testing.T, src: ^Source, action_name: string, expected_new_text: string) {
+	cursor := source_remove_cursor(src)
+
 	setup(src)
 	defer teardown(src)
 
-	input_range := common.Range {
-		start = src.position,
-		end   = src.position,
-	}
+	input_range := common.Range{cursor, cursor}
 	actions, ok := server.get_code_actions(src.document, input_range, &src.config)
 	if !ok {
 		log.error("Failed to find actions")

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -1,5 +1,6 @@
 package ols_testing
 
+import "core:slice"
 import "core:fmt"
 import "core:log"
 import "core:mem/virtual"
@@ -42,11 +43,8 @@ setup :: proc(src: ^Source) {
 	_ = virtual.arena_init_growing(src.document.allocator)
 
 	if len(src.main) > 0 {
-		files := make([dynamic]File, 0, len(src.files)+1, context.temp_allocator)
-		append(&files, File{"main.odin", src.main})
-		append(&files, ..src.files)
-		src.files = files[:]
-		src.main = ""
+		src.files = slice.concatenate([][]File{{{"main.odin", src.main}}, src.files}, context.temp_allocator)
+		src.main  = ""
 	}
 
 	setup_multi_file_prepare(src)
@@ -117,17 +115,22 @@ setup :: proc(src: ^Source) {
 
 @(private)
 setup_multi_file_prepare :: proc(src: ^Source) {
+
 	src.document.package_name = "test"
 
-	for &f, i in src.files {
+	if len(src.files) < 1 do return
 
-		marker_pos := strings.index(f.source, "{*}")
-		if marker_pos < 0 do continue
+	f := &src.files[0]
+	source := transmute([]u8)f.source
 
+	if marker_pos := strings.index(f.source, "{*}"); marker_pos >= 0 {
 		// remove `{*}`
-		source := make([]u8, len(f.source)-3, context.temp_allocator)
-		copy(source[:marker_pos], transmute([]u8)f.source[:marker_pos])
-		copy(source[marker_pos:], transmute([]u8)f.source[marker_pos+3:])
+
+		new_source := make([]u8, len(source)-3, context.temp_allocator)
+		copy(new_source[:marker_pos], source[:marker_pos])
+		copy(new_source[marker_pos:], source[marker_pos+3:])
+
+		source = new_source
 		f.source = string(source)
 
 		last: u8
@@ -146,22 +149,14 @@ setup_multi_file_prepare :: proc(src: ^Source) {
 			last = ch
 		}
 
-		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
-		src.document.text = source
-		src.document.used_text = len(source)
 		src.position.line = cursor_line
 		src.position.character = cursor_char
 	}
 
-	// If no file had {*}, default document to first file
-	if len(src.document.text) == 0 && len(src.files) > 0 {
-		f := &src.files[0]
-		fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
-		src.document.uri = common.create_uri(fullpath, context.temp_allocator)
-		src.document.text = transmute([]u8)f.source
-		src.document.used_text = len(f.source)
-	}
+	fullpath := strings.join({"test", f.name}, "/", context.temp_allocator)
+	src.document.uri = common.create_uri(fullpath, context.temp_allocator)
+	src.document.text = source
+	src.document.used_text = len(source)
 }
 
 @(private)

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -1084,8 +1084,17 @@ ast_file_private_completion :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_file_tag_private_completion :: proc(t: ^testing.T) {
-	comments := []string{"// +private", "//+private file", "// +build  ignore"}
+ast_file_tag_private_package_completion :: proc(t: ^testing.T) {
+
+	comments := []string{
+		"//+private",
+		"//+private file",
+		"//+build ignore",
+		"//+ignore",
+		// "#+ ignore",
+		// "#+ private",
+		// "#+ private file",
+	}
 
 	for comment in comments {
 
@@ -1094,9 +1103,18 @@ ast_file_tag_private_completion :: proc(t: ^testing.T) {
 		strings.write_string(&b, comment)
 		strings.write_string(&b, `
 			package my_package
-
-			my_proc :: proc() -> bool {}
+			ignored_proc :: proc() {}
 		`)
+
+		pkg := test.Package{
+			pkg = "my_package",
+			files = {
+				{"ignored.odin", strings.to_string(b)},
+				{"normal.odin", `package my_package
+					normal_proc :: proc() {}
+				`},
+			},
+		}
 
 		source := test.Source {
 			main     = `package main
@@ -1105,10 +1123,52 @@ ast_file_tag_private_completion :: proc(t: ^testing.T) {
 				my_package.{*}
 			}
 			`,
-			packages = {{pkg = "my_package", source = strings.to_string(b)}},
+			packages = {pkg},
 		}
 
-		test.expect_completion_docs(t, &source, ".", {})
+		test.expect_completion_docs(t, &source, ".",
+			{"my_package.normal_proc :: proc()"},
+			{"my_package.ignored_proc :: proc()"},
+		)
+	}
+}
+
+@(test)
+ast_file_tag_private_files_completion :: proc(t: ^testing.T) {
+
+	comments := []string{
+		"//+private file",
+		"//+build ignore",
+		"//+ignore",
+		// "#+ ignore",
+		// "#+ private file",
+	}
+
+	for comment in comments {
+
+		b := strings.builder_make(context.temp_allocator)
+
+		strings.write_string(&b, comment)
+		strings.write_string(&b, `
+			package main
+			ignored_proc :: proc() {}
+		`)
+
+		source := test.Source {
+			files = {
+				{"main.odin", `package main
+					main :: proc() {
+						ignored_{*}
+					}
+				`},
+				{"ignored.odin", strings.to_string(b)},
+			}
+		}
+
+		test.expect_completion_docs(t, &source, ".",
+			{},
+			{"my_package.ignored_proc :: proc()"},
+		)
 	}
 }
 

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -1171,7 +1171,7 @@ ast_file_tag_private_files_completion :: proc(t: ^testing.T) {
 			files = {
 				{"ignored.odin", pkg_src_ignored},
 				{"noraml.odin", pkg_src_normal},
-			}
+			},
 		}
 
 		test.expect_completion_docs(t, &source, ".",

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -1099,14 +1099,14 @@ ast_file_tag_private_package_completion :: proc(t: ^testing.T) {
 
 	for comment in comments {
 
-		pkg_name :: "my_package"
-		pkg_decl :: "package "+pkg_name
-		symbol_ignored :: "symbol_ignored :: proc()"
-		symbol_normal :: "symbol_normal :: proc()"
-		symbol_ignored_decl :: symbol_ignored + " {}"
-		symbol_normal_decl :: symbol_normal + " {}"
+		pkg_name                  :: "my_package"
+		pkg_decl                  :: "package "+pkg_name
+		symbol_ignored            :: "symbol_ignored :: proc()"
+		symbol_normal             :: "symbol_normal :: proc()"
+		symbol_ignored_decl       :: symbol_ignored + " {}"
+		symbol_normal_decl        :: symbol_normal + " {}"
 		symbol_ignored_completion :: pkg_name+"."+symbol_ignored
-		symbol_normal_completion :: pkg_name+"."+symbol_normal
+		symbol_normal_completion  :: pkg_name+"."+symbol_normal
 
 		pkg_src_ignored := strings.join({comment, pkg_decl, symbol_ignored_decl}, "\n", context.temp_allocator)
 		pkg_src_normal  := strings.join({pkg_decl, symbol_normal_decl}, "\n", context.temp_allocator)
@@ -1150,14 +1150,14 @@ ast_file_tag_private_files_completion :: proc(t: ^testing.T) {
 
 	for comment in comments {
 
-		pkg_name :: "test"
-		pkg_decl :: "package "+pkg_name
-		symbol_ignored :: "symbol_ignored :: proc()"
-		symbol_normal :: "symbol_normal :: proc()"
-		symbol_ignored_decl :: symbol_ignored + " {}"
-		symbol_normal_decl :: symbol_normal + " {}"
+		pkg_name                  :: "test"
+		pkg_decl                  :: "package "+pkg_name
+		symbol_ignored            :: "symbol_ignored :: proc()"
+		symbol_normal             :: "symbol_normal :: proc()"
+		symbol_ignored_decl       :: symbol_ignored + " {}"
+		symbol_normal_decl        :: symbol_normal  + " {}"
 		symbol_ignored_completion :: pkg_name+"."+symbol_ignored
-		symbol_normal_completion :: pkg_name+"."+symbol_normal
+		symbol_normal_completion  :: pkg_name+"."+symbol_normal
 
 		pkg_src_ignored := strings.join({comment, pkg_decl, symbol_ignored_decl}, "\n", context.temp_allocator)
 		pkg_src_normal  := strings.join({pkg_decl, symbol_normal_decl}, "\n", context.temp_allocator)

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -1098,21 +1098,23 @@ ast_file_tag_private_package_completion :: proc(t: ^testing.T) {
 
 	for comment in comments {
 
-		b := strings.builder_make(context.temp_allocator)
+		pkg_name :: "my_package"
+		pkg_decl :: "package "+pkg_name
+		symbol_ignored :: "symbol_ignored :: proc()"
+		symbol_normal :: "symbol_normal :: proc()"
+		symbol_ignored_decl :: symbol_ignored + " {}"
+		symbol_normal_decl :: symbol_normal + " {}"
+		symbol_ignored_completion :: pkg_name+"."+symbol_ignored
+		symbol_normal_completion :: pkg_name+"."+symbol_normal
 
-		strings.write_string(&b, comment)
-		strings.write_string(&b, `
-			package my_package
-			ignored_proc :: proc() {}
-		`)
+		pkg_src_ignored := strings.join({comment, pkg_decl, symbol_ignored_decl}, "\n", context.temp_allocator)
+		pkg_src_normal  := strings.join({pkg_decl, symbol_normal_decl}, "\n", context.temp_allocator)
 
 		pkg := test.Package{
-			pkg = "my_package",
+			pkg = pkg_name,
 			files = {
-				{"ignored.odin", strings.to_string(b)},
-				{"normal.odin", `package my_package
-					normal_proc :: proc() {}
-				`},
+				{"ignored.odin", pkg_src_ignored},
+				{"normal.odin", pkg_src_normal},
 			},
 		}
 
@@ -1127,8 +1129,8 @@ ast_file_tag_private_package_completion :: proc(t: ^testing.T) {
 		}
 
 		test.expect_completion_docs(t, &source, ".",
-			{"my_package.normal_proc :: proc()"},
-			{"my_package.ignored_proc :: proc()"},
+			{symbol_normal_completion},
+			{symbol_ignored_completion},
 		)
 	}
 }
@@ -1146,28 +1148,33 @@ ast_file_tag_private_files_completion :: proc(t: ^testing.T) {
 
 	for comment in comments {
 
-		b := strings.builder_make(context.temp_allocator)
+		pkg_name :: "test"
+		pkg_decl :: "package "+pkg_name
+		symbol_ignored :: "symbol_ignored :: proc()"
+		symbol_normal :: "symbol_normal :: proc()"
+		symbol_ignored_decl :: symbol_ignored + " {}"
+		symbol_normal_decl :: symbol_normal + " {}"
+		symbol_ignored_completion :: pkg_name+"."+symbol_ignored
+		symbol_normal_completion :: pkg_name+"."+symbol_normal
 
-		strings.write_string(&b, comment)
-		strings.write_string(&b, `
-			package main
-			ignored_proc :: proc() {}
-		`)
+		pkg_src_ignored := strings.join({comment, pkg_decl, symbol_ignored_decl}, "\n", context.temp_allocator)
+		pkg_src_normal  := strings.join({pkg_decl, symbol_normal_decl}, "\n", context.temp_allocator)
 
 		source := test.Source {
+			main = pkg_decl+`
+				main :: proc() {
+					symbol_{*}
+				}
+			`,
 			files = {
-				{"main.odin", `package main
-					main :: proc() {
-						ignored_{*}
-					}
-				`},
-				{"ignored.odin", strings.to_string(b)},
+				{"ignored.odin", pkg_src_ignored},
+				{"noraml.odin", pkg_src_normal},
 			}
 		}
 
 		test.expect_completion_docs(t, &source, ".",
-			{},
-			{"my_package.ignored_proc :: proc()"},
+			{symbol_normal_completion},
+			{symbol_ignored_completion},
 		)
 	}
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -1091,9 +1091,10 @@ ast_file_tag_private_package_completion :: proc(t: ^testing.T) {
 		"//+private file",
 		"//+build ignore",
 		"//+ignore",
-		// "#+ ignore",
-		// "#+ private",
-		// "#+ private file",
+		"#+ignore",
+		"#+build ignore",
+		"#+private",
+		"#+private file",
 	}
 
 	for comment in comments {
@@ -1142,8 +1143,9 @@ ast_file_tag_private_files_completion :: proc(t: ^testing.T) {
 		"//+private file",
 		"//+build ignore",
 		"//+ignore",
-		// "#+ ignore",
-		// "#+ private file",
+		"#+ignore",
+		"#+build ignore",
+		"#+private file",
 	}
 
 	for comment in comments {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -6878,26 +6878,22 @@ ast_hover_enum_case_with_range :: proc(t: ^testing.T) {
 
 @(test)
 ast_hover_test_with_mulitple_files :: proc(t: ^testing.T) {
-	packages := make([dynamic]test.Package, context.temp_allocator)
 
-	append(
-		&packages,
-		test.Package {
-			pkg = "test",
-			file = "test/test2.odin",
-			source = `package test
-			Bar :: struct{}
-			`,
-		}
-	)
-	source := test.Source {
-		main     = `package test
-		main :: proc() {
-			bar: B{*}ar
-		}
-		`,
-		packages = packages[:],
+	source := test.Source{
+		files = {
+			{"main.odin",
+				`package test
+				main :: proc() {
+					bar: B{*}ar
+				}
+			`},
+			{"bar.odin",
+				`package test
+				Bar :: struct {}
+			`},
+		},
 	}
+
 	test.expect_hover(t, &source, "test.Bar :: struct{}")
 }
 


### PR DESCRIPTION
- Adds support for multiple files in tests for both main package and imported packages.
- Improves ignore file tags tests by testing both between file and between packages behaviors.

In the meantime while this was a draft @BradLewis already added a support for multiple files in #1490 (which was very confusing when rebasing), so this just offers a different interface (maybe slightly more intuitive) to the same thing.