### PR TITLE
Correct some quriks parsing runtime files

### DIFF
--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -216,7 +216,7 @@ try_build_package :: proc(pkg_name: string) {
 			pkg.fullpath = fullpath
 			pkg.name = dir
 
-			if dir == "runtime" {
+			if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
 				pkg.kind = .Runtime
 			}
 
@@ -308,7 +308,7 @@ index_file :: proc(uri: common.Uri, text: string) -> common.Error {
 	pkg.fullpath = fullpath
 	pkg.name = dir
 
-	if dir == "runtime" {
+	if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
 		pkg.kind = .Runtime
 	}
 

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -386,11 +386,13 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 
 	context.allocator = virtual.arena_allocator(document.allocator)
 
+	dir := filepath.base(filepath.dir(document.fullpath))
 	pkg := new(ast.Package)
 	pkg.kind = .Normal
 	pkg.fullpath = document.fullpath
+	pkg.name = dir
 
-	if strings.contains(document.fullpath, "base/runtime") {
+	if dir == "runtime" || strings.contains(document.fullpath, "base/runtime") {
 		pkg.kind = .Runtime
 	}
 

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -95,7 +95,7 @@ setup :: proc(src: ^Source) {
 		pkg.fullpath = fullpath
 		pkg.name = dir
 
-		if dir == "runtime" {
+		if dir == "runtime" || strings.contains(fullpath, "base/runtime") {
 			pkg.kind = .Runtime
 		}
 


### PR DESCRIPTION
Occasionally I'll hit issues where the  odin parser refuses to parse a runtime file. I'm not 100% sure why, and I can't reliably reproduce it, but with this it seems to go away.