### PR TITLE
fix issue resolving  overload with polymorphic arguments when passed …

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -251,7 +251,7 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 			}
 			document = cons(document, text("}"))
 		} else if len(v.fullpaths) == 1 {
-			if _, ok := v.fullpaths[0].derived_expr.(^ast.Basic_Lit); ok {
+			if _, ok := v.fullpaths[0].derived.(^ast.Basic_Lit); ok {
 				document = cons_with_nopl(document, visit_expr(p, v.fullpaths[0]))
 			} else {
 				document = cons_with_nopl(document, text("{"))

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -3759,18 +3759,16 @@ get_package_from_filepath :: proc(file_path: string) -> string {
 	return ret
 }
 
-wrap_pointer :: proc(expr: ^ast.Expr, times: int) -> ^ast.Expr {
-	n := 0
+wrap_pointer :: proc(expr: ^ast.Expr, times: int, allocator := context.temp_allocator) -> ^ast.Expr {
 	expr := expr
 
 	for i in 0 ..< times {
-		new_pointer := new_type(ast.Pointer_Type, expr.pos, expr.end, context.temp_allocator)
+		new_pointer := new_type(ast.Pointer_Type, expr.pos, expr.end, allocator)
 
 		new_pointer.elem = expr
 
 		expr = new_pointer
 	}
-
 
 	return expr
 }

--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -53,6 +53,11 @@ resolve_poly :: proc(
 				} else {
 					save_poly_map(ident, symbol_to_expr(call_symbol, call_node.pos.file), poly_map)
 				}
+				if call_symbol.pointers > 0 {
+					if expr, expr_ok := get_poly_map(ident, poly_map); expr_ok {
+						save_poly_map(ident, wrap_pointer(expr, call_symbol.pointers), poly_map)
+					}
+				}
 			}
 		}
 		return true
@@ -300,6 +305,15 @@ resolve_poly_expression :: proc(
 			return true
 		}
 	}
+
+	call_node := call_node
+	poly_node := poly_node
+	
+	// The expression for the specialization already contains the pointers
+	// so we don't need to represent it in the next poly
+	// Note: this function is only ever called by `resolve_poly_specialization`
+	call_node, _, _ = unwrap_pointer_expr(call_node)
+	poly_node, _, _ = unwrap_pointer_expr(poly_node)
 
 	call_symbol := Symbol{}
 	internal_resolve_type_expression(ast_context, call_node, &call_symbol)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -6917,3 +6917,29 @@ ast_hover_overload_resolve_aliased_arguments :: proc(t: ^testing.T) {
 
 	test.expect_hover(t, &source, "pkg1.Bar :: proc(table: Foo)")
 }
+
+@(test)
+ast_hover_overload_pointer_arg_from_return :: proc(t: ^testing.T) {
+	source: = test.Source {
+		main = `package test
+
+		foo :: proc() -> ^int {
+			return {}
+		}
+
+		bar :: proc {
+			bar_pass,
+		}
+
+		bar_pass :: proc(value: $T) -> T {
+			return T{}
+		}
+
+		main :: proc() {
+			bar{*}(foo())
+		}
+		`
+	}
+
+	test.expect_hover(t, &source, "test.bar :: proc(value: $T) -> T")
+}


### PR DESCRIPTION
…a pointer to a generic from another function

Attempts to fix #1495 

The problem seems to be that during `resolve_generic_function_symbol` the parameter resolves to the type without the pointer, as `symbol_to_expr` doesn't retain that information. I am not certain if that is intended. The changes in this pull request change that, but it breaks several other tests, and causes the server to crash. 

Is there another mechanism by which this information should normally be retained, or is it an oversight of `symbol_to_expr`?