### PR TITLE
scoped const semantic token fix

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2186,9 +2186,84 @@ internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 	return Symbol{}, false
 }
 
-resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, local: ^DocumentLocal) -> (Symbol, bool) {
-	is_distinct := false
+// Shared logic for resolving identifier expressions in both local and global scope.
+// expr      - the expression to switch on
+// orig_expr - the original unsimplified expression
+resolve_identifier_expr :: proc(
+	ast_context: ^AstContext,
+	expr:         ^ast.Expr,
+	orig_expr:    ^ast.Expr,
+	node:         ast.Ident,
+	name:         string,
+	attributes:   []^ast.Attribute,
+	is_mutable:   bool,
+) -> (symbol: Symbol, ok: bool) {
 
+	#partial switch v in expr.derived {
+	case ^ast.Distinct_Type:
+		symbol, ok = resolve_identifier_expr(ast_context, v.type, orig_expr, node, name, attributes, is_mutable)
+		symbol.name = name
+		symbol.flags |= {.Distinct}
+	case ^ast.Ident:
+		symbol, ok = internal_resolve_type_identifier(ast_context, v^)
+	case ^ast.Call_Expr:
+		old_call := ast_context.call
+		ast_context.call = cast(^ast.Call_Expr)orig_expr
+		defer ast_context.call = old_call
+
+		if _, ok = v.expr.derived.(^ast.Basic_Directive); ok {
+			symbol, ok = resolve_call_directive(ast_context, v)
+		} else if ok = internal_resolve_type_expression(ast_context, v.expr, &symbol); ok {
+			return_types := get_proc_return_types(ast_context, symbol, v, is_mutable)
+			if len(return_types) > 0 {
+				ok = internal_resolve_type_expression(ast_context, return_types[0], &symbol)
+			}
+		}
+	case ^ast.Struct_Type:
+		symbol, ok = make_symbol_struct_from_ast(ast_context, v, name, attributes), true
+		symbol.name = name
+	case ^ast.Union_Type:
+		symbol, ok = make_symbol_union_from_ast(ast_context, v^, name), true
+		symbol.name = name
+	case ^ast.Enum_Type:
+		symbol, ok = make_symbol_enum_from_ast(ast_context, v^, name), true
+		symbol.name = name
+	case ^ast.Bit_Set_Type:
+		symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
+		symbol.name = name
+	case ^ast.Bit_Field_Type:
+		symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, name), true
+		symbol.name = name
+	case ^ast.Proc_Lit:
+		symbol, ok = resolve_proc_lit(ast_context, orig_expr, v, name, attributes, false)
+	case ^ast.Proc_Group:
+		symbol, ok = resolve_function_overload(ast_context, v)
+	case ^ast.Array_Type:
+		symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
+	case ^ast.Multi_Pointer_Type:
+		symbol, ok = make_symbol_multi_pointer_from_ast(ast_context, v^, node), true
+	case ^ast.Dynamic_Array_Type:
+		symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
+	case ^ast.Fixed_Capacity_Dynamic_Array_Type:
+		symbol, ok = make_symbol_fixed_cap_dynamic_array_from_ast(ast_context, v^, node), true
+	case ^ast.Matrix_Type:
+		symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
+	case ^ast.Map_Type:
+		symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
+	case ^ast.Basic_Lit:
+		symbol, ok = resolve_basic_lit(ast_context, v^)
+		symbol.name = name
+		symbol.type = is_mutable ? .Variable : .Constant
+	case ^ast.Binary_Expr:
+		symbol, ok = resolve_binary_expression(ast_context, v)
+	case:
+		ok = internal_resolve_type_expression(ast_context, orig_expr, &symbol)
+	}
+
+	return symbol, ok
+}
+
+resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, local: ^DocumentLocal) -> (symbol: Symbol, ok: bool) {
 	if local.pkg != "" {
 		ast_context.current_package = local.pkg
 	}
@@ -2198,184 +2273,74 @@ resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, loca
 		ast_context.use_locals = false
 	}
 
-	if dist, ok := local.rhs.derived.(^ast.Distinct_Type); ok {
-		if dist.type != nil {
-			local.rhs = dist.type
-			is_distinct = true
-		}
-	}
-
-	return_symbol: Symbol
-	ok: bool
-
-	#partial switch v in local.rhs.derived {
-	case ^ast.Ident:
-		return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
-	case ^ast.Union_Type:
-		return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Enum_Type:
-		return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Struct_Type:
-		return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node.name, {}), true
-		return_symbol.name = node.name
-	case ^ast.Bit_Set_Type:
-		return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
-		return_symbol.name = node.name
-	case ^ast.Bit_Field_Type:
-		return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Proc_Lit:
-		return_symbol, ok = resolve_proc_lit(ast_context, local.rhs, v, node.name, {}, false)
-	case ^ast.Proc_Group:
-		return_symbol, ok = resolve_function_overload(ast_context, v)
-	case ^ast.Array_Type:
-		return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
-	case ^ast.Multi_Pointer_Type:
-		return_symbol, ok = make_symbol_multi_pointer_from_ast(ast_context, v^, node), true
-	case ^ast.Dynamic_Array_Type:
-		return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
-	case ^ast.Fixed_Capacity_Dynamic_Array_Type:
-		return_symbol, ok = make_symbol_fixed_cap_dynamic_array_from_ast(ast_context, v^, node), true
-	case ^ast.Matrix_Type:
-		return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
-	case ^ast.Map_Type:
-		return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
-	case ^ast.Basic_Lit:
-		return_symbol, ok = resolve_basic_lit(ast_context, v^)
-		return_symbol.name = node.name
-		return_symbol.type = .Mutable in local.flags ? .Variable : .Constant
-	case ^ast.Binary_Expr:
-		return_symbol, ok = resolve_binary_expression(ast_context, v)
-	case:
-		ok = internal_resolve_type_expression(ast_context, local.rhs, &return_symbol)
-	}
-
-	if is_distinct {
-		return_symbol.name = node.name
-		return_symbol.flags |= {.Distinct}
-	}
+	symbol, ok = resolve_identifier_expr(
+		ast_context,
+		local.rhs,
+		local.rhs,
+		node,
+		node.name,
+		{}, // locals don't have attributes
+		.Mutable in local.flags,
+	)
 
 	if local.parameter {
-		return_symbol.flags |= {.Parameter}
+		symbol.flags |= {.Parameter}
 	}
 
 	if .Mutable in local.flags {
-		return_symbol.type = .Variable
-		return_symbol.flags |= {.Mutable}
+		symbol.type = .Variable
+		symbol.flags |= {.Mutable}
 	}
 	if .Variable in local.flags {
-		return_symbol.flags |= {.Variable}
+		symbol.flags |= {.Variable}
 	}
 	if .PolyType in local.flags {
-		return_symbol.flags |= {.PolyType}
+		symbol.flags |= {.PolyType}
 	}
 
-	return_symbol.flags |= {.Local}
-	return_symbol.value_expr = local.value_expr
-	return_symbol.type_expr = local.type_expr
-	return_symbol.doc = get_comment(local.docs, ast_context.allocator)
-	return_symbol.comment = get_comment(local.comment, ast_context.allocator)
+	symbol.flags |= {.Local}
+	symbol.value_expr = local.value_expr
+	symbol.type_expr = local.type_expr
+	symbol.doc = get_comment(local.docs, ast_context.allocator)
+	symbol.comment = get_comment(local.comment, ast_context.allocator)
 
-	return return_symbol, ok
+	return symbol, ok
 }
 
-resolve_global_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, global: ^GlobalExpr) -> (Symbol, bool) {
-	is_distinct := false
+resolve_global_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, global: ^GlobalExpr) -> (symbol: Symbol, ok: bool) {
 	ast_context.use_locals = false
 
-	if dist, ok := global.expr.derived.(^ast.Distinct_Type); ok {
-		if dist.type != nil {
-			global.expr = dist.type
-			is_distinct = true
-		}
-	}
-
-	return_symbol: Symbol
-	ok: bool
-
-	#partial switch v in global.expr.derived {
-	case ^ast.Ident:
-		return_symbol, ok = internal_resolve_type_identifier(ast_context, v^)
-	case ^ast.Call_Expr:
-		old_call := ast_context.call
-		ast_context.call = cast(^ast.Call_Expr)global.expr
-
-		defer {
-			ast_context.call = old_call
-		}
-		if _, ok = v.expr.derived.(^ast.Basic_Directive); ok {
-			return_symbol, ok = resolve_call_directive(ast_context, v)
-		} else if ok = internal_resolve_type_expression(ast_context, v.expr, &return_symbol); ok {
-			return_types := get_proc_return_types(ast_context, return_symbol, v, .Mutable in global.flags)
-			if len(return_types) > 0 {
-				ok = internal_resolve_type_expression(ast_context, return_types[0], &return_symbol)
-			}
-			// Otherwise should be a parapoly style
-		}
-
-	case ^ast.Struct_Type:
-		return_symbol, ok = make_symbol_struct_from_ast(ast_context, v, node.name, global.attributes), true
-		return_symbol.name = node.name
-	case ^ast.Bit_Set_Type:
-		return_symbol, ok = make_symbol_bitset_from_ast(ast_context, v^, node), true
-		return_symbol.name = node.name
-	case ^ast.Union_Type:
-		return_symbol, ok = make_symbol_union_from_ast(ast_context, v^, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Enum_Type:
-		return_symbol, ok = make_symbol_enum_from_ast(ast_context, v^, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Bit_Field_Type:
-		return_symbol, ok = make_symbol_bit_field_from_ast(ast_context, v, node.name), true
-		return_symbol.name = node.name
-	case ^ast.Proc_Lit:
-		return_symbol, ok = resolve_proc_lit(ast_context, global.expr, v, node.name, global.attributes, false)
-	case ^ast.Proc_Group:
-		return_symbol, ok = resolve_function_overload(ast_context, v)
-	case ^ast.Array_Type:
-		return_symbol, ok = make_symbol_array_from_ast(ast_context, v^, node), true
-	case ^ast.Dynamic_Array_Type:
-		return_symbol, ok = make_symbol_dynamic_array_from_ast(ast_context, v^, node), true
-	case ^ast.Matrix_Type:
-		return_symbol, ok = make_symbol_matrix_from_ast(ast_context, v^, node), true
-	case ^ast.Map_Type:
-		return_symbol, ok = make_symbol_map_from_ast(ast_context, v^, node), true
-	case ^ast.Basic_Lit:
-		return_symbol, ok = resolve_basic_lit(ast_context, v^)
-		return_symbol.name = node.name
-		return_symbol.type = .Mutable in global.flags ? .Variable : .Constant
-	case:
-		ok = internal_resolve_type_expression(ast_context, global.expr, &return_symbol)
-	}
-
-	if is_distinct {
-		return_symbol.name = node.name
-		return_symbol.flags |= {.Distinct}
-	}
+	symbol, ok = resolve_identifier_expr(
+		ast_context,
+		global.expr,
+		global.expr,
+		node,
+		node.name,
+		global.attributes,
+		.Mutable in global.flags,
+	)
 
 	if .Mutable in global.flags {
-		return_symbol.type = .Variable
-		return_symbol.flags |= {.Mutable}
+		symbol.type = .Variable
+		symbol.flags |= {.Mutable}
 	}
 
 	if .Variable in global.flags {
-		return_symbol.flags |= {.Variable}
+		symbol.flags |= {.Variable}
 	}
 
 	if global.docs != nil {
-		return_symbol.doc = get_comment(global.docs, ast_context.allocator)
+		symbol.doc = get_comment(global.docs, ast_context.allocator)
 	}
 
 	if global.comment != nil {
-		return_symbol.comment = get_comment(global.comment, ast_context.allocator)
+		symbol.comment = get_comment(global.comment, ast_context.allocator)
 	}
 
-	return_symbol.type_expr = global.type_expr
-	return_symbol.value_expr = global.value_expr
+	symbol.type_expr = global.type_expr
+	symbol.value_expr = global.value_expr
 
-	return return_symbol, ok
+	return symbol, ok
 }
 
 resolve_proc_lit :: proc(

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -382,6 +382,8 @@ get_locals_value_decl :: proc(file: ast.File, value_decl: ast.Value_Decl, ast_co
 			if len(value_decl.values) > i {
 				value_expr = value_decl.values[i]
 			}
+		} else if len(value_decl.values) > i && is_variable_declaration(value_decl.values[i]) {
+			flags |= {.Variable}
 		}
 
 		if value_decl.is_mutable {

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -154,68 +154,37 @@ get_generic_assignment :: proc(
 	case ^ast.Or_Branch_Expr:
 		get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
 	case ^ast.Call_Expr:
+
 		old_call := ast_context.call
 		ast_context.call = cast(^ast.Call_Expr)value
-
-		defer {
-			ast_context.call = old_call
-		}
-
-		//Check for basic type casts
-		if len(v.args) == 1 {
-			if ident, ok := v.expr.derived.(^ast.Ident); ok {
-				//Handle the old way of type casting
-				if v, ok := keyword_map[ident.name]; ok {
-					//keywords
-					type_ident := new_type(ast.Ident, ident.pos, ident.end, ast_context.allocator)
-					type_ident.name = ident.name
-					append(results, type_ident)
-					break
-				}
-			}
-		}
+		defer ast_context.call = old_call
 
 		// If we have a call expr followed immediately by another call expr, we want to return value
 		// of the second call. Eg a := foo()()
-		if _, ok := v.expr.derived.(^ast.Call_Expr); ok {
-			symbol := Symbol{}
-			if ok := internal_resolve_type_expression(ast_context, v.expr, &symbol); ok {
-				if value, ok := symbol.value.(SymbolProcedureValue); ok {
-					if len(value.return_types) == 1 {
-						if proc_type, ok := value.return_types[0].type.derived.(^ast.Proc_Type); ok {
-							for return_item in proc_type.results.list {
-								get_generic_assignment(
-									file,
-									return_item.type,
-									ast_context,
-									results,
-									calls,
-									flags,
-									is_mutable,
-								)
-							}
-							return
-						} else if ident, ok := value.return_types[0].type.derived.(^ast.Ident); ok {
-							if ok := internal_resolve_type_expression(ast_context, ident, &symbol); ok {
-								if value, ok := symbol.value.(SymbolProcedureValue); ok {
-									for return_item in value.return_types {
-										get_generic_assignment(
-											file,
-											return_item.type,
-											ast_context,
-											results,
-											calls,
-											flags,
-											is_mutable,
-										)
-									}
-								}
-							}
-						}
-					}
+		#partial switch _ in v.expr.derived {
+		case ^ast.Call_Expr:
+			symbol: Symbol
+
+			internal_resolve_type_expression(ast_context, v.expr, &symbol) or_break
+
+			value := symbol.value.(SymbolProcedureValue) or_break
+
+			if len(value.return_types) != 1 do break
+
+			#partial switch type in value.return_types[0].type.derived {
+			case ^ast.Proc_Type:
+				for return_item in type.results.list {
+					get_generic_assignment(file, return_item.type, ast_context, results, calls, flags, is_mutable)
+				}
+				return
+			case ^ast.Ident:
+				internal_resolve_type_expression(ast_context, type, &symbol) or_break
+				value := symbol.value.(SymbolProcedureValue) or_break
+				for return_item in value.return_types {
+					get_generic_assignment(file, return_item.type, ast_context, results, calls, flags, is_mutable)
 				}
 			}
-		} else if directive, ok := v.expr.derived.(^ast.Basic_Directive); ok {
+		case ^ast.Basic_Directive:
 			append(results, v)
 		}
 
@@ -223,23 +192,40 @@ get_generic_assignment :: proc(
 		if symbol, ok := resolve_type_expression(ast_context, v.expr); ok {
 			#partial switch symbol_value in symbol.value {
 			case SymbolProcedureValue:
-				return_types := get_proc_return_types(ast_context, symbol, v, is_mutable)
-				for ret in return_types {
-					calls[len(results)] = {}
-					append(results, ret)
+				//For builtin procs (max, min, abs, etc.), preserve the original Call_Expr
+				if symbol.pkg == "$builtin" {
+					append(results, value)
+				} else {
+					for ret in get_proc_return_types(ast_context, symbol, v, is_mutable) {
+						calls[len(results)] = {}
+						append(results, ret)
+					}
 				}
 			case SymbolAggregateValue:
 				//In case we can't resolve the proc group, just save it anyway, so it won't cause any issues further down the line.
 				append(results, value)
 
 			case SymbolStructValue:
-				// Parametrized struct
-				get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				// Parametrized struct or type cast like My_Struct(123)
+				if symbol.type != .Function && symbol.type != .Type_Function && symbol.type != .Package {
+					append(results, value)
+				} else {
+					get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				}
 			case SymbolUnionValue:
-				// Parametrized union
-				get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				// Parametrized union or type cast like My_Union(123)
+				if symbol.type != .Function && symbol.type != .Type_Function && symbol.type != .Package {
+					append(results, value)
+				} else {
+					get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				}
 			case SymbolBasicValue:
-				get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				// Type alias like Bool :: bool; Bool(true)
+				if symbol.type != .Function && symbol.type != .Type_Function && symbol.type != .Package {
+					append(results, value)
+				} else {
+					get_generic_assignment(file, v.expr, ast_context, results, calls, flags, is_mutable)
+				}
 			case:
 				if ident, ok := v.expr.derived.(^ast.Ident); ok {
 					//TODO: Simple assumption that you are casting it the type.
@@ -380,21 +366,24 @@ get_locals_value_decl :: proc(file: ast.File, value_decl: ast.Value_Decl, ast_co
 	}
 
 	for name, i in value_decl.names {
+		str := get_ast_node_string(name, file.src)
+
 		result_i := min(len(results) - 1, i)
 		if .SameLhsRhsCount in flags && len(result_starts) > i {
 			result_i = min(len(results) - 1, result_starts[i])
 		}
-		str := get_ast_node_string(name, file.src)
-		flags: bit_set[LocalFlag]
-
 		expr := results[result_i]
+
+		flags: bit_set[LocalFlag]
 		value_expr: ^ast.Expr
+
 		if is_variable_declaration(expr) {
 			flags |= {.Variable}
 			if len(value_decl.values) > i {
 				value_expr = value_decl.values[i]
 			}
 		}
+
 		if value_decl.is_mutable {
 			flags |= {.Mutable}
 		}
@@ -408,7 +397,7 @@ get_locals_value_decl :: proc(file: ast.File, value_decl: ast.Value_Decl, ast_co
 			ast_context.non_mutable_only,
 			false, // calls[result_i] or_else false, // TODO: find a good way to handle this
 			flags,
-			get_package_from_node(results[result_i]^),
+			get_package_from_node(expr^),
 			false,
 			value_decl.type,
 			value_expr,

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2876,6 +2876,28 @@ ast_hover_proc_force_no_inline :: proc(t: ^testing.T) {
 }
 
 @(test)
+ast_hover_builtin_const_type_cast_local :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			fo{*}o :: u32(123)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.foo :: u32(123)")
+}
+
+@(test)
+ast_hover_builtin_const_type_cast_global :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		fo{*}o :: u32(123)
+	`,
+	}
+	test.expect_hover(t, &source, "test.foo :: u32(123)")
+}
+
+@(test)
 ast_hover_builtin_max_with_type_local :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
@@ -2884,7 +2906,7 @@ ast_hover_builtin_max_with_type_local :: proc(t: ^testing.T) {
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.max_u32 :: u32")
+	test.expect_hover(t, &source, "test.max_u32 :: max(u32)")
 }
 
 @(test)

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -307,6 +307,31 @@ semantic_tokens_const_alias_type_cast :: proc(t: ^testing.T) {
 }
 
 @(test)
+semantic_tokens_const_array :: proc(t: ^testing.T) {
+	src := test.Source {
+		main = `package test
+		Vec   :: [2]f32
+		G_VEC :: Vec{1, 2}
+		main :: proc() {
+			VEC :: Vec{1, 2}
+		}
+		`
+	}
+
+	test.expect_semantic_tokens(t, &src, {
+		// Global scope
+		{1, 2,  3, .Type,     {.ReadOnly}}, // [0]  Vec
+		{0, 12, 3, .Type,     {.ReadOnly}}, // [1]  f32
+		{1, 2,  5, .Variable, {.ReadOnly}}, // [2]  G_VEC
+		{0, 9,  3, .Type,     {.ReadOnly}}, // [3]  Vec
+		{1, 2,  4, .Function, {.ReadOnly}}, // [4]  main
+		// Local scope
+		{1, 3,  3, .Variable, {.ReadOnly}}, // [5]  VEC
+		{0, 7,  3, .Type,     {.ReadOnly}}, // [6]  Vec
+	})
+}
+
+@(test)
 semantic_tokens_global_binary_expr :: proc(t: ^testing.T) {
 	src := test.Source {
 		main = `package test

--- a/tests/semantic_tokens_test.odin
+++ b/tests/semantic_tokens_test.odin
@@ -246,3 +246,80 @@ semantic_tokens_fixed_capacity_dynamic_array :: proc(t: ^testing.T) {
 		{0, 17, 3, .Type,     {.ReadOnly}}, // [1]  int
 	})
 }
+
+@(test)
+semantic_tokens_const_type_cast :: proc(t: ^testing.T) {
+	src := test.Source {
+		main = `package test
+		GLOBAL_TRUE :: bool(true)
+		GLOBAL_A    :: int(42)
+		GLOBAL_B    :: cstring("hello")
+		main :: proc() {
+			TRUE :: bool(true)
+			A    :: int(42)
+			A    :: cstring("hello")
+		}
+		`
+	}
+
+	test.expect_semantic_tokens(t, &src, {
+		// Global scope
+		{1, 2, 11, .Variable, {.ReadOnly}}, // [0]  GLOBAL_TRUE
+		{0, 15, 4, .Type,     {.ReadOnly}}, // [1]  bool
+		{1, 2,  8, .Variable, {.ReadOnly}}, // [2]  GLOBAL_A
+		{0, 15, 3, .Type,     {.ReadOnly}}, // [3]  int
+		{1, 2,  8, .Variable, {.ReadOnly}}, // [4]  GLOBAL_B
+		{0, 15, 7, .Type,     {.ReadOnly}}, // [5]  cstring
+		{1, 2,  4, .Function, {.ReadOnly}}, // [6]  main
+		// Local scope
+		{1, 3,  4, .Variable, {.ReadOnly}}, // [7]  TRUE
+		{0, 8,  4, .Type,     {.ReadOnly}}, // [8]  bool
+		{1, 3,  1, .Variable, {.ReadOnly}}, // [9]  A
+		{0, 8,  3, .Type,     {.ReadOnly}}, // [10] int
+		{1, 3,  1, .Variable, {.ReadOnly}}, // [11] B
+		{0, 8,  7, .Type,     {.ReadOnly}}, // [12] cstring
+	})
+}
+
+@(test)
+semantic_tokens_const_alias_type_cast :: proc(t: ^testing.T) {
+	src := test.Source {
+		main = `package test
+		Bool   :: bool
+		G_TRUE :: Bool(true)
+		main :: proc() {
+			TRUE :: Bool(true)
+		}
+		`
+	}
+
+	test.expect_semantic_tokens(t, &src, {
+		// Global scope
+		{1, 2,  4, .Type,     {.ReadOnly}}, // [0]  Bool
+		{0, 10, 4, .Type,     {.ReadOnly}}, // [1]  bool
+		{1, 2,  6, .Variable, {.ReadOnly}}, // [2]  G_TRUE
+		{0, 10, 4, .Type,     {.ReadOnly}}, // [3]  Bool
+		{1, 2,  4, .Function, {.ReadOnly}}, // [4]  main
+		// Local scope
+		{1, 3,  4, .Variable, {.ReadOnly}}, // [5]  TRUE
+		{0, 8,  4, .Type,     {.ReadOnly}}, // [6]  Bool
+	})
+}
+
+@(test)
+semantic_tokens_global_binary_expr :: proc(t: ^testing.T) {
+	src := test.Source {
+		main = `package test
+		FOO :: 3 + 4
+		BAR :: int(1) + int(2)
+		`
+	}
+
+	test.expect_semantic_tokens(t, &src, {
+		{1, 2, 3, .Variable, {.ReadOnly}}, // [0]  FOO
+		{1, 2, 3, .Variable, {.ReadOnly}}, // [1]  BAR
+		{0, 7, 3, .Type,     {.ReadOnly}}, // [2]  int
+		{0, 9, 3, .Type,     {.ReadOnly}}, // [3]  int
+	})
+}
+


### PR DESCRIPTION
Fixes #1494 and the `max_u32 :: max(u32)` hover case by unifying a bit how local and global resolving works.