### PR TITLE
Support fake methods with proc aliases

### DIFF
--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -504,6 +504,45 @@ get_or_create_package :: proc(collection: ^SymbolCollection, pkg_name: string) -
 }
 
 /*
+	Collects a fake method from an alias if references a proc.
+*/
+collect_alias_method :: proc(collection: ^SymbolCollection, symbol: Symbol, visited: ^map[^Symbol]struct {}) {
+
+	pkg := &collection.packages[symbol.pkg]
+	value := symbol.value.(SymbolGenericValue)
+
+	resolved: ^Symbol
+	#partial switch v in value.expr.derived {
+	case ^ast.Ident:
+		resolved = (&pkg.symbols[v.name]) or_break
+	case ^ast.Selector_Expr:
+		pkg_ident := v.expr.derived.(^ast.Ident) or_break
+		field_ident := v.field.derived.(^ast.Ident) or_break
+		alias_pkg := (&collection.packages[pkg_ident.name]) or_break
+		resolved = (&alias_pkg.symbols[field_ident.name]) or_break
+	}
+
+	if resolved == nil do return
+
+	// symbols can point to each other in a cycle
+	if resolved in visited do return
+	visited[resolved] = {}
+
+	alias_symbol := resolved^
+	alias_symbol.name = symbol.name
+	alias_symbol.pkg  = symbol.pkg
+
+	#partial switch _ in resolved.value {
+	case SymbolProcedureValue:
+		collect_method(collection, alias_symbol)
+	case SymbolProcedureGroupValue:
+		collect_proc_group_method(collection, alias_symbol)
+	case SymbolGenericValue:
+		collect_alias_method(collection, alias_symbol, visited)
+	}
+}
+
+/*
 	Collects a procedure as a fake method if it's not part of a proc group.
 */
 collect_method :: proc(collection: ^SymbolCollection, symbol: Symbol) {
@@ -989,21 +1028,17 @@ collect_fake_methods :: proc(collection: ^SymbolCollection, exprs: []GlobalExpr,
 		// Determine the package name (same logic as in collect_symbols)
 		pkg_name := get_symbol_package_name(collection, directory, uri, expr.builtin)
 
-		pkg, ok := &collection.packages[pkg_name]
-		if !ok {
-			continue
-		}
-
-		symbol, found := pkg.symbols[expr.name]
-		if !found {
-			continue
-		}
+		pkg := (&collection.packages[pkg_name]) or_continue
+		symbol := pkg.symbols[expr.name] or_continue
 
 		#partial switch _ in symbol.value {
 		case SymbolProcedureValue:
 			collect_method(collection, symbol)
 		case SymbolProcedureGroupValue:
 			collect_proc_group_method(collection, symbol)
+		case SymbolGenericValue:
+			visited := make(map[^Symbol]struct {}, context.temp_allocator)
+			collect_alias_method(collection, symbol, &visited)
 		}
 	}
 }

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -209,31 +209,52 @@ expect_completion_labels :: proc(
 		log.error("Failed get_completion_list")
 	}
 
-	if len(expect_labels) == 0 && len(completion_list.items) > 0 {
-		log.errorf("Expected empty completion label, but received %v", completion_list.items)
-	}
-
-	flags := make([]int, len(expect_labels), context.temp_allocator)
-
-	for expect_label, i in expect_labels {
+	missing_expected := make([dynamic]string, context.temp_allocator)
+	loop_expected: for label, i in expect_labels {
 		for completion, j in completion_list.items {
-			if expect_label == completion.label {
-				flags[i] += 1
+			if label == completion.label {
+				continue loop_expected
+			}
+		}
+		append(&missing_expected, label)
+	}
+
+	present_excluded := make([dynamic]string, context.temp_allocator)
+	loop_excluded: for label, i in expect_excluded {
+		for completion, j in completion_list.items {
+			if label == completion.label {
+				append(&present_excluded, label)
+				continue loop_excluded
 			}
 		}
 	}
 
-	for flag, i in flags {
-		if flag != 1 {
-			log.errorf("Expected completion detail %v, but received %v", expect_labels[i], completion_list.items)
-		}
-	}
+	if len(missing_expected) > 0 ||
+	   len(present_excluded) > 0 ||
+	   (len(expect_labels) == 0 && len(completion_list.items) > 0)
+	{
+		sb := strings.builder_make(context.temp_allocator)
+		defer log.error(strings.to_string(sb))
 
-	for expect_exclude in expect_excluded {
-		for completion in completion_list.items {
-			if expect_exclude == completion.label {
-				log.errorf("Expected completion label %v to not be included", expect_exclude)
+		fmt.sbprintln(&sb, "Completion label mismatch.")
+
+		strings.write_string(&sb, "Actual:   [")
+		for completion, i in completion_list.items {
+			if i > 0 {
+				strings.write_string(&sb, ", ")
 			}
+			fmt.sbprintf(&sb, "\"%s\"", completion.label)
+		}
+		strings.write_string(&sb, "]\n")
+
+		if len(missing_expected) > 0 {
+			fmt.sbprintfln(&sb, "Expected: %v", expect_labels)
+			fmt.sbprintfln(&sb, "Missing:  %v", missing_expected[:])
+		}
+
+		if len(present_excluded) > 0 {
+			fmt.sbprintfln(&sb, "Excluded: %v", expect_excluded)
+			fmt.sbprintfln(&sb, "Present:  %v", present_excluded[:])
 		}
 	}
 }

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -5502,6 +5502,66 @@ ast_completion_fake_method_proc_group_single_arg_cursor_position :: proc(t: ^tes
 }
 
 @(test)
+ast_completion_fake_method_proc_alias :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		import "methods"
+		main :: proc() {
+			thing: methods.Thing
+			thing.{*}
+		}
+		`,
+		packages = {
+			{
+				pkg = "methods",
+				source = `package methods
+				Thing :: struct {a, b: int}
+				thing_foo :: proc(t: ^Thing) {}
+				thing_bar :: thing_foo
+				thing_baz :: thing_bar
+				`,
+			},
+		},
+		config = {enable_fake_method = true},
+	}
+	// Both thing_foo, thing_bar and thing_baz should appear as fake methods for Thing
+	test.expect_completion_labels(t, &source, ".", {"thing_foo", "thing_bar", "thing_baz", "a", "b"})
+}
+
+@(test)
+ast_completion_fake_method_proc_alias_cross_package :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		import "core"
+		main :: proc() {
+			r: core.Rect
+			r.{*}
+		}
+		`,
+		packages = {
+			{
+				pkg = "math",
+				source = `package math
+				Rect :: struct {width, height: f32}
+				rect_area :: proc(r: Rect) -> f32 { return r.width * r.height }
+				`,
+			},
+			{
+				pkg = "core",
+				source = `package core
+				import "math"
+				Rect :: math.Rect
+				rect_area :: math.rect_area
+				`,
+			},
+		},
+		config = {enable_fake_method = true},
+	}
+	// rect_area alias from core package should show as fake method for Rect
+	test.expect_completion_labels(t, &source, ".", {"rect_area", "width", "height"})
+}
+
+@(test)
 ast_completion_package_docs :: proc(t: ^testing.T) {
 	packages := make([dynamic]test.Package, context.temp_allocator)
 


### PR DESCRIPTION
closes #1018
closes #1486

\+ made the `expect_completion_labels` error output nicer to read.