### PR TITLE
Include workspace root in package list for workspace symbol search

### DIFF
--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -27,6 +27,7 @@ get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceS
 		for workspace in common.config.workspace_folders {
 			uri := common.parse_uri(workspace.uri, context.temp_allocator) or_return
 			pkgs := make([dynamic]string, 0, context.temp_allocator)
+			append(&pkgs, uri.path)
 
 			w := os.walker_create(uri.path)
 			defer os.walker_destroy(&w)


### PR DESCRIPTION
Fixes #1517.

Odin files in the workspace root directory were not included in workspace/symbol results because only subdirectories were collected when building the package list. The root path is now added explicitly.