### PR TITLE
fix: odinfmt keep a leading #! shebang on line 1 when formatting

### DIFF
--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -222,6 +222,14 @@ print_file :: proc(p: ^Printer, file: ^ast.File) -> string {
 
 	p.document = empty()
 
+	// A leading `#!` shebang is parsed as a comment on line 1, but the file tags
+	// below are printed at the very top of the file. Print any comments that sit
+	// before the first tag (like a shebang) first, so the shebang stays on line
+	// 1 and the file is still runnable as a script.
+	if len(file.tags) > 0 {
+		p.document = cons(p.document, move_line(p, file.tags[0].pos))
+	}
+
 	for tag in file.tags {
 		p.document = cons(p.document, text(strings.trim(tag.text, "\r\n")), newline(1))
 		pos := tag.pos

--- a/tools/odinfmt/tests/.snapshots/shebang.odin
+++ b/tools/odinfmt/tests/.snapshots/shebang.odin
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S odin-run
+#+feature dynamic-literals
+package main
+
+import "core:fmt"
+
+main :: proc() {
+	fmt.println("hello")
+}

--- a/tools/odinfmt/tests/shebang.odin
+++ b/tools/odinfmt/tests/shebang.odin
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S odin-run
+#+feature dynamic-literals
+package main
+
+import "core:fmt"
+
+main :: proc() {
+	fmt.println("hello")
+}


### PR DESCRIPTION
odinfmt prints a file's #+ tags at the very top, before any leading comment. A #! shebang is parsed as a comment on line 1, so it ended up below the tags and off line 1, which breaks running the file as a script.

Print the comments that come before the first tag (the shebang) before the tags, so a shebang stays on line 1. Files without a shebang are unchanged. Adds a snapshot test.