### PR TITLE
Updated configuration loading during initialization

### DIFF
--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -722,22 +722,15 @@ request_initialize :: proc(
 	config.enable_checker_workspace_diagnostics = false
 	config.enable_auto_import = true
 
-	read_ols_config :: proc(file: string, config: ^common.Config, uri: common.Uri) -> (ok: bool) {
-		data, err := os.read_entire_file(file, context.temp_allocator)
-		if err != nil {
-			log.warnf("Failed to read/find %v: %v", file, err)
-			return
-		}
+	load_ols_config :: proc(data: []byte, config: ^common.Config, uri: common.Uri) -> (err: json.Unmarshal_Error) {
 		ols_config: OlsConfig
 
 		json_err := json.unmarshal(data, &ols_config, allocator = context.temp_allocator)
-		if json_err == nil {
-			read_ols_initialize_options(config, ols_config, uri)
-			ok = true
-		} else {
-			log.errorf("Failed to unmarshal %v: %v", file, json_err)
+		if json_err != nil {
+			return json_err
 		}
-		return
+		read_ols_initialize_options(config, ols_config, uri)
+		return nil
 	}
 
 	project_uri := ""
@@ -753,7 +746,16 @@ request_initialize :: proc(
 	if uri_ok {
 		// Apply ols.json config.
 		ols_config_path := path.join(elems = {uri.path, "ols.json"}, allocator = context.temp_allocator)
-		read_ols_config(ols_config_path, config, uri)
+		data, err := os.read_entire_file(ols_config_path, context.temp_allocator)
+		if err != nil {
+			log.warnf("Failed to read/find %v: %v", ols_config_path, err)
+		} else {
+			json_err := load_ols_config(data, config, uri)
+			if json_err != nil{
+				log.errorf("Failed to unmarshal %v: %v",ols_config_path, json_err)
+				return .ParseError
+			}
+		}
 	}
 
 	for format in initialize_params.capabilities.textDocument.hover.contentFormat {

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -748,15 +748,7 @@ request_initialize :: proc(
 		project_uri = initialize_params.rootUri
 	}
 
-	// Get the global ols config path.
-	global_ols_config_path := path.join(
-		elems = {filepath.dir(os.args[0]), "ols.json"},
-		allocator = context.temp_allocator,
-	)
-
 	uri, uri_ok := common.parse_uri(project_uri, context.temp_allocator)
-
-	global_config_loaded := read_ols_config(global_ols_config_path, config, uri)
 	read_ols_initialize_options(config, initialize_params.initializationOptions, uri)
 	if uri_ok {
 		// Apply ols.json config.


### PR DESCRIPTION
I removed the code that attempted to load a global ols.json. The value returned from that code path was never used, and I couldn't find a global ols.json in the repository or any mention of one in the documentation. I assumed this was an artifact of an older config loading approach, but I'm happy to restore it if that isn't the case.

I also updated the ols.json parsing logic. The two main changes were: (1) Separating file I/O from parsing so the config-loading helper only has a single failure path. (2) Returning an error when a user-provided ols.json cannot be parsed.

This means OLS now fails to initialize if the project contains an invalid ols.json. That seemed like an expected behavior to me, if the user explicitly provides configuration that can't be parsed, fail fast and loud so they're aware of the issue. However, if that isn't in line with the project's goals, I'm happy to change it.

I also looked for a way to report the parsing error without failing initialization. It appeared that send_error is the intended way to respond with LSP errors, but I only found it being called from the request dispatch function. I didn't want to just starting calling it from other places if it's not intended to be used that way.