### PR TITLE
Remove \r on `.sh` files, and prevent git from readding them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Currently all of the shell scripts are a little broken, running them produces errors like `‘bash\r’: No such file or directory`, because the shell doesn't consider \r to be whitespace I guess? This PR removes the \r's, and adds a .gitattributes file to prevent git from readding them, specifically for shell files