### PR TITLE
Find Odin files faster in Windows

### DIFF
--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -8,6 +8,7 @@ import "core:os"
 import "core:path/filepath"
 import "core:strings"
 import "core:time"
+import "core:slice"
 
 foreign import libc "system:c"
 

--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -115,6 +115,32 @@ when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .Linux || ODIN_OS =
 		return 0, true, stdout[0:index]
 	}
 
+	search_for_odin_files :: proc(base_path: string, exclude_file: string, dir_blacklist: []string, odin_files_out: ^[dynamic]string) {
+		w := os.walker_create(base_path)
+		defer os.walker_destroy(&w)
+		for info in os.walker_walk(&w) {
+			if info.type == .Directory {
+				dir, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
+				dir_name := filepath.base(dir)
+				if slice.contains(dir_blacklist, dir_name) {
+					os.walker_skip_dir(&w)
+				}
+				continue
+			}
+
+			if info.fullpath == "" {
+				continue
+			}
+
+			if strings.has_suffix(info.name, ".odin") {
+				slash_path, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
+				if !strings.equal_fold(slash_path, exclude_file) {
+					append(odin_files_out, strings.clone(info.fullpath, context.temp_allocator))
+				}
+			}
+		}
+	}
+
 	foreign libc
 	{
 		popen :: proc(command: cstring, type: cstring) -> ^FILE ---

--- a/src/common/util_windows.odin
+++ b/src/common/util_windows.odin
@@ -1,8 +1,13 @@
 package common
 
+import "core:strings"
+import "core:odin"
+import "core:slice"
 import "core:log"
 import "core:mem"
 import "core:time"
+import "core:path/filepath"
+import "core:fmt"
 
 import win32 "core:sys/windows"
 
@@ -166,4 +171,51 @@ run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) 
 	win32.CloseHandle(stdout_read)
 
 	return exit_code, true, stdout[0:index]
+}
+
+
+search_for_odin_files :: proc(base_path: string, exclude_file: string, dir_blacklist: []string, odin_files_out: ^[dynamic]string) {
+    search_pattern := fmt.tprintf("%s\\*", base_path)
+    wide_pattern := win32.utf8_to_wstring(search_pattern)
+
+    find_data: win32.WIN32_FIND_DATAW
+    hfind := win32.FindFirstFileW(wide_pattern, &find_data)
+
+    if hfind == win32.INVALID_HANDLE_VALUE {
+        return
+    }
+    defer win32.FindClose(hfind)
+
+    for {
+        file_wstring : win32.wstring = win32.wstring(raw_data(find_data.cFileName[:]))
+        file_name, _ := win32.wstring_to_utf8_alloc(file_wstring, -1, context.temp_allocator)
+
+        if file_name != "." && file_name != ".." {
+            full_path := fmt.tprintf("%s\\%s", base_path, file_name)
+            if (find_data.dwFileAttributes & win32.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+				// apply directory blacklist
+
+				dir, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
+				dir_name := filepath.base(dir)
+
+				if slice.contains(dir_blacklist, dir_name) {
+					log.errorf("skipped %v", dir)
+				} else {
+					search_for_odin_files(full_path, exclude_file, dir_blacklist, odin_files_out)
+				}
+            } else {
+                if strings.has_suffix(file_name, ".odin") {
+					// doing the thing the other branch does
+					slash_path, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
+					if !strings.equal_fold(slash_path, exclude_file) {
+						append(odin_files_out, strings.clone(full_path, context.temp_allocator))
+					}
+                }
+            }
+        }
+
+        if !win32.FindNextFileW(hfind, &find_data) {
+            break
+        }
+    }
 }

--- a/src/common/util_windows.odin
+++ b/src/common/util_windows.odin
@@ -173,7 +173,6 @@ run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) 
 	return exit_code, true, stdout[0:index]
 }
 
-
 search_for_odin_files :: proc(base_path: string, exclude_file: string, dir_blacklist: []string, odin_files_out: ^[dynamic]string) {
     search_pattern := fmt.tprintf("%s\\*", base_path)
     wide_pattern := win32.utf8_to_wstring(search_pattern)
@@ -193,14 +192,12 @@ search_for_odin_files :: proc(base_path: string, exclude_file: string, dir_black
         if file_name != "." && file_name != ".." {
             full_path := fmt.tprintf("%s\\%s", base_path, file_name)
             if (find_data.dwFileAttributes & win32.FILE_ATTRIBUTE_DIRECTORY) != 0 {
-				// apply directory blacklist
 
+				// apply directory blacklist
 				dir, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
 				dir_name := filepath.base(dir)
 
-				if slice.contains(dir_blacklist, dir_name) {
-					log.errorf("skipped %v", dir)
-				} else {
+				if !slice.contains(dir_blacklist, dir_name) {
 					search_for_odin_files(full_path, exclude_file, dir_blacklist, odin_files_out)
 				}
             } else {

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -13,6 +13,10 @@ import "core:strings"
 
 import "src:common"
 
+import win "core:sys/windows"
+import "core:fmt"
+import "core:time"
+
 prepare_references :: proc(
 	document: ^Document,
 	ast_context: ^AstContext,
@@ -278,9 +282,17 @@ resolve_references :: proc(
 		return locations[:], true
 	}
 
+	last_time := time.now()
+
 	when !ODIN_TEST {
+
 		for workspace in common.config.workspace_folders {
+
+
 			uri, _ := common.parse_uri(workspace.uri, context.temp_allocator)
+			when ODIN_OS != .Windows {
+
+
 			w := os.walker_create(uri.path)
 			defer os.walker_destroy(&w)
 			for info in os.walker_walk(&w) {
@@ -304,8 +316,14 @@ resolve_references :: proc(
 					}
 				}
 			}
-		}
-	}
+			} else { // if it's windows..
+				search_recursively_windows(uri.path, &fullpaths, document)
+			}
+		}}
+
+    dur := time.diff(last_time, time.now())
+    dur_ms := time.duration_milliseconds(dur)
+	log.errorf("time to find odin files: %vms", dur_ms)
 
 	reset_ast_context(ast_context)
 
@@ -476,4 +494,44 @@ get_references :: proc(
 	}
 
 	return temp_locations[:], ok2
+}
+
+search_recursively_windows :: proc(base_path: string, odin_files: ^[dynamic]string, document: ^Document) {
+    search_pattern := fmt.tprintf("%s\\*", base_path)
+    wide_pattern := win.utf8_to_wstring(search_pattern)
+
+    find_data: win.WIN32_FIND_DATAW
+    hfind := win.FindFirstFileW(wide_pattern, &find_data)
+
+    if hfind == win.INVALID_HANDLE_VALUE {
+        return
+    }
+    defer win.FindClose(hfind)
+
+    for {
+        file_wstring : win.wstring = win.wstring(raw_data(find_data.cFileName[:]))
+        file_name, err := win.wstring_to_utf8_alloc(file_wstring, -1)
+        if err != .None {
+            panic("error to utf8")
+        }
+        
+        if file_name != "." && file_name != ".." {
+            full_path := fmt.tprintf("%s\\%s", base_path, file_name)
+            if (find_data.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+                search_recursively_windows(full_path, odin_files, document)
+            } else {
+                if strings.has_suffix(file_name, ".odin") {
+					// doing the thing the other branch does
+					slash_path, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
+					if !strings.equal_fold(slash_path, document.fullpath) {
+						append(odin_files, strings.clone(full_path, context.temp_allocator))
+					}
+                }
+            }
+        }
+
+        if !win.FindNextFileW(hfind, &find_data) {
+            break
+        }
+    }
 }

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -12,12 +12,7 @@ import "core:slice"
 import "core:strings"
 
 import "src:common"
-
-when ODIN_OS == .Windows {
-import win "core:sys/windows"
-import "core:fmt"
 import "core:time"
-}
 
 prepare_references :: proc(
 	document: ^Document,
@@ -287,41 +282,11 @@ resolve_references :: proc(
 	last_time := time.now()
 
 	when !ODIN_TEST {
-
-		for workspace in common.config.workspace_folders {
-
-
-			uri, _ := common.parse_uri(workspace.uri, context.temp_allocator)
-			when ODIN_OS != .Windows {
-
-
-			w := os.walker_create(uri.path)
-			defer os.walker_destroy(&w)
-			for info in os.walker_walk(&w) {
-				if info.type == .Directory {
-					dir, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
-					dir_name := filepath.base(dir)
-					if slice.contains(dir_blacklist, dir_name) {
-						os.walker_skip_dir(&w)
-					}
-					continue
-				}
-
-				if info.fullpath == "" {
-					continue
-				}
-
-				if strings.has_suffix(info.name, ".odin") {
-					slash_path, _ := filepath.replace_separators(info.fullpath, '/', context.temp_allocator)
-					if !strings.equal_fold(slash_path, document.fullpath) {
-						append(&fullpaths, strings.clone(info.fullpath, context.temp_allocator))
-					}
-				}
-			}
-			} else { // if it's windows..
-				search_recursively_windows(uri.path, &fullpaths, document)
-			}
-		}}
+	for workspace in common.config.workspace_folders {
+		uri, _ := common.parse_uri(workspace.uri, context.temp_allocator)
+		common.search_for_odin_files(uri.path, document.fullpath, dir_blacklist, &fullpaths)
+	}
+	}
 
     dur := time.diff(last_time, time.now())
     dur_ms := time.duration_milliseconds(dur)
@@ -496,50 +461,4 @@ get_references :: proc(
 	}
 
 	return temp_locations[:], ok2
-}
-
-search_recursively_windows :: proc(base_path: string, odin_files: ^[dynamic]string, document: ^Document) {
-    search_pattern := fmt.tprintf("%s\\*", base_path)
-    wide_pattern := win.utf8_to_wstring(search_pattern)
-
-    find_data: win.WIN32_FIND_DATAW
-    hfind := win.FindFirstFileW(wide_pattern, &find_data)
-
-    if hfind == win.INVALID_HANDLE_VALUE {
-        return
-    }
-    defer win.FindClose(hfind)
-
-    for {
-        file_wstring : win.wstring = win.wstring(raw_data(find_data.cFileName[:]))
-        file_name, _ := win.wstring_to_utf8_alloc(file_wstring, -1, context.temp_allocator)
-
-        if file_name != "." && file_name != ".." {
-            full_path := fmt.tprintf("%s\\%s", base_path, file_name)
-            if (find_data.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0 {
-				// apply directory blacklist
-
-				dir, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
-				dir_name := filepath.base(dir)
-
-				if slice.contains(dir_blacklist, dir_name) {
-					log.errorf("skipped %v", dir)
-				} else {
-					search_recursively_windows(full_path, odin_files, document)
-				}
-            } else {
-                if strings.has_suffix(file_name, ".odin") {
-					// doing the thing the other branch does
-					slash_path, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
-					if !strings.equal_fold(slash_path, document.fullpath) {
-						append(odin_files, strings.clone(full_path, context.temp_allocator))
-					}
-                }
-            }
-        }
-
-        if !win.FindNextFileW(hfind, &find_data) {
-            break
-        }
-    }
 }

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -12,7 +12,6 @@ import "core:slice"
 import "core:strings"
 
 import "src:common"
-import "core:time"
 
 prepare_references :: proc(
 	document: ^Document,
@@ -279,18 +278,12 @@ resolve_references :: proc(
 		return locations[:], true
 	}
 
-	last_time := time.now()
-
 	when !ODIN_TEST {
 	for workspace in common.config.workspace_folders {
 		uri, _ := common.parse_uri(workspace.uri, context.temp_allocator)
 		common.search_for_odin_files(uri.path, document.fullpath, dir_blacklist, &fullpaths)
 	}
 	}
-
-    dur := time.diff(last_time, time.now())
-    dur_ms := time.duration_milliseconds(dur)
-	log.errorf("time to find odin files: %vms", dur_ms)
 
 	reset_ast_context(ast_context)
 

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -13,9 +13,11 @@ import "core:strings"
 
 import "src:common"
 
+when ODIN_OS == .Windows {
 import win "core:sys/windows"
 import "core:fmt"
 import "core:time"
+}
 
 prepare_references :: proc(
 	document: ^Document,
@@ -510,15 +512,21 @@ search_recursively_windows :: proc(base_path: string, odin_files: ^[dynamic]stri
 
     for {
         file_wstring : win.wstring = win.wstring(raw_data(find_data.cFileName[:]))
-        file_name, err := win.wstring_to_utf8_alloc(file_wstring, -1)
-        if err != .None {
-            panic("error to utf8")
-        }
-        
+        file_name, _ := win.wstring_to_utf8_alloc(file_wstring, -1, context.temp_allocator)
+
         if file_name != "." && file_name != ".." {
             full_path := fmt.tprintf("%s\\%s", base_path, file_name)
             if (find_data.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0 {
-                search_recursively_windows(full_path, odin_files, document)
+				// apply directory blacklist
+
+				dir, _ := filepath.replace_separators(full_path, '/', context.temp_allocator)
+				dir_name := filepath.base(dir)
+
+				if slice.contains(dir_blacklist, dir_name) {
+					log.errorf("skipped %v", dir)
+				} else {
+					search_recursively_windows(full_path, odin_files, document)
+				}
             } else {
                 if strings.has_suffix(file_name, ".odin") {
 					// doing the thing the other branch does


### PR DESCRIPTION
Makes odin file search much faster in windows. This search is done when renaming symbols or finding references.

My testing on https://github.com/lucypero/lucydx12:

Before PR: `295ms`
After PR: `42ms`

Revert f0c5301feed55823e541155349fe1b8ec28c3a92 to log timings.

