### PR TITLE
remove an extra trailing newline caused by `fmt.println` in odinfmt

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -90,7 +90,7 @@ main :: proc() {
 		)
 
 		if ok {
-			fmt.println(source)
+			fmt.print(source)
 		}
 
 		write_failure = !ok
@@ -111,7 +111,7 @@ main :: proc() {
 			}
 		} else {
 			if data, ok := format_file(args.path, config, arena_allocator); ok {
-				fmt.println(data)
+				fmt.print(data)
 			}
 		}
 	} else if os.is_dir(args.path) {


### PR DESCRIPTION
I noticed that neovim and helix always make sure there are two `\n`s at end of file on saving, because `odinfmt -stdin` is used in a typical configuration. If using lsp as the formatter (`vim.lsp.buf.format()` in neovim), then there would be only one newline at end of file. The extra newline is caused by `fmt.println` in odinfmt. (I am not sure if it is intended for odinfmt)