### PR TITLE
Adding feature align_struct_declarations

### DIFF
--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -83,7 +83,7 @@
 		},
 		"align_struct_declarations": {
 			"type": "boolean",
-			"default": true,
+			"default": false,
 			"description": "Align the struct declaration symbol in struct fields so they all start at the same column"
 		}
 	},

--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -80,6 +80,11 @@
 			"type": "boolean",
 			"default": true,
 			"description": "Align the values of struct fields when assigning a struct value to a variable so they all start at the same column"
+		},
+		"align_struct_declarations": {
+			"type": "boolean",
+			"default": true,
+			"description": "Align the struct declaration symbol in struct fields so they all start at the same column"
 		}
 	},
 	"required": []

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -106,7 +106,7 @@ when ODIN_OS == .Windows {
 		spaces_around_colons      = false,
 		align_struct_fields       = true,
 		align_struct_values       = true,
-		align_struct_declarations = true,
+		align_struct_declarations = false,
 	}
 } else {
 	default_style := Config {
@@ -123,7 +123,7 @@ when ODIN_OS == .Windows {
 		spaces_around_colons      = false,
 		align_struct_fields       = true,
 		align_struct_values       = true,
-		align_struct_declarations = true,
+		align_struct_declarations = false,
 	}
 }
 

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -39,21 +39,22 @@ Disabled_Info :: struct {
 }
 
 Config :: struct {
-	character_width:          int,
-	spaces:                   int, //Spaces per indentation
-	newline_limit:            int, //The limit of newlines between statements and declarations.
-	tabs:                     bool, //Enable or disable tabs
-	tabs_width:               int,
-	convert_do:               bool, //Convert all do statements to brace blocks
-	brace_style:              Brace_Style,
-	indent_cases:             bool,
-	newline_style:            Newline_Style,
-	sort_imports:             bool,
-	inline_single_stmt_case:  bool,
-	spaces_around_colons:     bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
-	space_single_line_blocks: bool,
-	align_struct_fields:      bool,
-	align_struct_values:      bool,
+	character_width:           int,
+	spaces:                    int, //Spaces per indentation
+	newline_limit:             int, //The limit of newlines between statements and declarations.
+	tabs:                      bool, //Enable or disable tabs
+	tabs_width:                int,
+	convert_do:                bool, //Convert all do statements to brace blocks
+	brace_style:               Brace_Style,
+	indent_cases:              bool,
+	newline_style:             Newline_Style,
+	sort_imports:              bool,
+	inline_single_stmt_case:   bool,
+	spaces_around_colons:      bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
+	space_single_line_blocks:  bool,
+	align_struct_fields:       bool,
+	align_struct_values:       bool,
+	align_struct_declarations: bool,
 }
 
 Brace_Style :: enum {
@@ -92,35 +93,37 @@ Line_Suffix_Option :: enum {
 
 when ODIN_OS == .Windows {
 	default_style := Config {
-		spaces               = 4,
-		newline_limit        = 2,
-		convert_do           = false,
-		tabs                 = true,
-		tabs_width           = 4,
-		brace_style          = ._1TBS,
-		indent_cases         = false,
-		newline_style        = .CRLF,
-		character_width      = 100,
-		sort_imports         = true,
-		spaces_around_colons = false,
-		align_struct_fields  = true,
-		align_struct_values  = true,
+		spaces                    = 4,
+		newline_limit             = 2,
+		convert_do                = false,
+		tabs                      = true,
+		tabs_width                = 4,
+		brace_style               = ._1TBS,
+		indent_cases              = false,
+		newline_style             = .CRLF,
+		character_width           = 100,
+		sort_imports              = true,
+		spaces_around_colons      = false,
+		align_struct_fields       = true,
+		align_struct_values       = true,
+		align_struct_declarations = true,
 	}
 } else {
 	default_style := Config {
-		spaces               = 4,
-		newline_limit        = 2,
-		convert_do           = false,
-		tabs                 = true,
-		tabs_width           = 4,
-		brace_style          = ._1TBS,
-		indent_cases         = false,
-		newline_style        = .LF,
-		character_width      = 100,
-		sort_imports         = true,
-		spaces_around_colons = false,
-		align_struct_fields  = true,
-		align_struct_values  = true,
+		spaces                    = 4,
+		newline_limit             = 2,
+		convert_do                = false,
+		tabs                      = true,
+		tabs_width                = 4,
+		brace_style               = ._1TBS,
+		indent_cases              = false,
+		newline_style             = .LF,
+		character_width           = 100,
+		sort_imports              = true,
+		spaces_around_colons      = false,
+		align_struct_fields       = true,
+		align_struct_values       = true,
+		align_struct_declarations = true,
 	}
 }
 

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -2071,8 +2071,14 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		return document
 	}
 
+	declaration_alignment := 0
+	if p.config.align_struct_declarations && .Enforce_Newline in options {
+		declaration_alignment = get_possible_field_declaration_alignment(list.list)
+	}
+
 	for field, i in list.list {
 		align := empty()
+		declaration_align := empty()
 
 		p.source_position = field.pos
 
@@ -2095,23 +2101,49 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		name_options := List_Options{.Add_Comma}
 
 		if (.Enforce_Newline in options) {
-			if p.config.align_struct_fields {
+			// When align_struct_declarations is active, it handles the visual
+			if p.config.align_struct_fields && !p.config.align_struct_declarations {
 				alignment := get_possible_field_alignment(list.list)
 
 				if alignment > 0 {
 					length := 0
 					for name in field.names {
-						length += get_node_length(name) + 2
-						if .Using in field.flags {
-							length += 6
-						}
-						if .Subtype in field.flags {
-							length += 9
-						}
+						length += get_node_length(name)
+					}
+					if len(field.names) > 1 {
+						length += 2 * (len(field.names) - 1)
+					}
+					if .Using in field.flags {
+						length += 6
+					}
+					if .Subtype in field.flags {
+						length += 9
 					}
 					align = repeat_space(alignment - length)
 				}
 			}
+
+			if p.config.align_struct_declarations && declaration_alignment > 0 {
+				name_length := 0
+				for name in field.names {
+					name_length += get_node_length(name)
+				}
+				if len(field.names) > 1 {
+					name_length += 2 * (len(field.names) - 1)
+				}
+
+				if .Using in field.flags {
+					name_length += 6
+				}
+				if .Subtype in field.flags {
+					name_length += 9
+				}
+
+				if name_length > 0 && name_length < declaration_alignment {
+					declaration_align = repeat_space(declaration_alignment - name_length)
+				}
+			}
+
 			document = cons(document, visit_exprs(p, field.names, name_options))
 		} else {
 			document = cons_with_opl(document, visit_exprs(p, field.names, name_options))
@@ -2119,11 +2151,16 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 
 		if field.type != nil {
 			if len(field.names) != 0 {
-				document = cons(document, text(" :" if p.config.spaces_around_colons else ":"), align)
+				document = cons(
+					document,
+					declaration_align,
+					text(" :" if p.config.spaces_around_colons else ":"),
+					align,
+				)
 			}
 			document = cons_with_nopl(document, visit_expr(p, field.type))
 		} else {
-			document = cons(document, text(":"), text("="))
+			document = cons(document, declaration_align, text(":"), text("="))
 			document = cons_with_opl(document, visit_expr(p, field.default_value))
 		}
 
@@ -2499,11 +2536,43 @@ get_possible_field_alignment :: proc(fields: []^ast.Field) -> int {
 	for field in fields {
 		length := 0
 		for name in field.names {
-			length += get_node_length(name) + 2
+			length += get_node_length(name)
+		}
+
+		if len(field.names) > 1 {
+			length += 2 * (len(field.names) - 1)
 		}
 
 		if .Using in field.flags {
 			length += 6
+		}
+
+		longest_name = max(longest_name, length)
+	}
+
+	return longest_name
+}
+
+@(private)
+get_possible_field_declaration_alignment :: proc(fields: []^ast.Field) -> int {
+	longest_name := 0
+
+	for field in fields {
+		length := 0
+		for name in field.names {
+			length += get_node_length(name)
+		}
+
+		if len(field.names) > 1 {
+			length += 2 * (len(field.names) - 1)
+		}
+
+		if .Using in field.flags {
+			length += 6 // "using "
+		}
+
+		if .Subtype in field.flags {
+			length += 9 // "#subtype "
 		}
 
 		longest_name = max(longest_name, length)

--- a/tools/odinfmt/tests/align_declarations/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/align_declarations/.snapshots/structs.odin
@@ -1,0 +1,49 @@
+package align_declarations
+
+Game :: struct {
+	paddle     : Paddle,
+	is_running : bool,
+}
+
+Player :: struct {
+	name    : string,
+	age     : u8,
+	health  : uint,
+	stamina : uint,
+}
+
+Entity :: struct {
+	pos   : [3]f32,
+	vel   : [3]f32,
+	rot   : [3]f32,
+	scale : [3]f32,
+}
+
+Vector3 :: struct {
+	x : f32,
+	y : f32,
+	z : f32,
+	w : f32,
+}
+
+Config :: struct {
+	timeout : int,
+	retries : int,
+}
+
+// Single field (no alignment needed)
+Single :: struct {
+	value : int,
+}
+
+State :: struct {
+	ready   : bool,
+	running : bool,
+	error   : Error_Info,
+	count   : int,
+}
+
+Multi_Names :: struct {
+	a, b, c : int,
+	x       : f32,
+}

--- a/tools/odinfmt/tests/align_declarations/odinfmt.json
+++ b/tools/odinfmt/tests/align_declarations/odinfmt.json
@@ -1,0 +1,6 @@
+{
+	"align_struct_declarations": true,
+	"spaces_around_colons": true,
+	"character_width": 80,
+	"newline_style": "LF"
+}

--- a/tools/odinfmt/tests/align_declarations/structs.odin
+++ b/tools/odinfmt/tests/align_declarations/structs.odin
@@ -1,0 +1,49 @@
+package align_declarations
+
+Game :: struct {
+	paddle :     Paddle,
+	is_running : bool,
+}
+
+Player :: struct {
+	name :    string,
+	age :     u8,
+	health :  uint,
+	stamina : uint,
+}
+
+Entity :: struct {
+	pos :   [3]f32,
+	vel :   [3]f32,
+	rot :   [3]f32,
+	scale : [3]f32,
+}
+
+Vector3 :: struct {
+	x : f32,
+	y : f32,
+	z : f32,
+	w : f32,
+}
+
+Config :: struct {
+	timeout : int,
+	retries : int,
+}
+
+// Single field (no alignment needed)
+Single :: struct {
+	value : int,
+}
+
+State :: struct {
+	ready :   bool,
+	running : bool,
+	error :   Error_Info,
+	count :   int,
+}
+
+Multi_Names :: struct {
+	a, b, c : int,
+	x :       f32,
+}

--- a/tools/odinfmt/tests/no_align_declarations/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/no_align_declarations/.snapshots/structs.odin
@@ -1,0 +1,20 @@
+package no_align_declarations
+
+Game :: struct {
+	paddle :     Paddle,
+	is_running : bool,
+}
+
+Player :: struct {
+	name :    string,
+	age :     u8,
+	health :  uint,
+	stamina : uint,
+}
+
+State :: struct {
+	ready :   bool,
+	running : bool,
+	error :   Error_Info,
+	count :   int,
+}

--- a/tools/odinfmt/tests/no_align_declarations/odinfmt.json
+++ b/tools/odinfmt/tests/no_align_declarations/odinfmt.json
@@ -1,0 +1,6 @@
+{
+	"align_struct_declarations": false,
+	"spaces_around_colons": true,
+	"character_width": 80,
+	"newline_style": "LF"
+}

--- a/tools/odinfmt/tests/no_align_declarations/structs.odin
+++ b/tools/odinfmt/tests/no_align_declarations/structs.odin
@@ -1,0 +1,20 @@
+package no_align_declarations
+
+Game :: struct {
+	paddle :     Paddle,
+	is_running : bool,
+}
+
+Player :: struct {
+	name :    string,
+	age :     u8,
+	health :  uint,
+	stamina : uint,
+}
+
+State :: struct {
+	ready :   bool,
+	running : bool,
+	error :   Error_Info,
+	count :   int,
+}

--- a/tools/odinfmt/tests/random/.snapshots/demo.odin
+++ b/tools/odinfmt/tests/random/.snapshots/demo.odin
@@ -620,22 +620,22 @@ union_type :: proc() {
 		// an example of this for a basic game Entity.
 
 		Entity :: struct {
-			id:          u64,
-			name:        string,
-			position:    Vector3,
+			id         : u64,
+			name       : string,
+			position   : Vector3,
 			orientation: Quaternion,
-			derived:     any,
+			derived    : any,
 		}
 
 		Frog :: struct {
 			using entity: Entity,
-			jump_height:  f32,
+			jump_height : f32,
 		}
 
 		Monster :: struct {
 			using entity: Entity,
-			is_robot:     bool,
-			is_zombie:    bool,
+			is_robot    : bool,
+			is_zombie   : bool,
 		}
 
 		// See `parametric_polymorphism` procedure for details
@@ -664,11 +664,11 @@ union_type :: proc() {
 		// basic game Entity but using an union.
 
 		Entity :: struct {
-			id:          u64,
-			name:        string,
-			position:    Vector3,
+			id         : u64,
+			name       : string,
+			position   : Vector3,
 			orientation: Quaternion,
-			derived:     union {
+			derived    : union {
 				Frog,
 				Monster,
 			},
@@ -676,13 +676,13 @@ union_type :: proc() {
 
 		Frog :: struct {
 			using entity: ^Entity,
-			jump_height:  f32,
+			jump_height : f32,
 		}
 
 		Monster :: struct {
 			using entity: ^Entity,
-			is_robot:     bool,
-			is_zombie:    bool,
+			is_robot    : bool,
+			is_zombie   : bool,
 		}
 
 		// See `parametric_polymorphism` procedure for details
@@ -755,7 +755,7 @@ using_statement :: proc() {
 	}
 	{
 		Entity :: struct {
-			position:    Vector3,
+			position   : Vector3,
 			orientation: quaternion128,
 		}
 
@@ -790,7 +790,7 @@ using_statement :: proc() {
 		// making all the fields of position appear as if they on Entity itself:
 		Entity :: struct {
 			using position: Vector3,
-			orientation:    quaternion128,
+			orientation   : quaternion128,
 		}
 		foo :: proc(entity: ^Entity) {
 			fmt.println(entity.x, entity.y, entity.z)
@@ -807,8 +807,8 @@ using_statement :: proc() {
 		}
 		Frog :: struct {
 			ribbit_volume: f32,
-			using entity:  Entity,
-			colour:        Colour,
+			using entity : Entity,
+			colour       : Colour,
 		}
 
 		frog: Frog
@@ -933,15 +933,15 @@ parametric_polymorphism :: proc() {
 	{ 	// Polymorphic Types and Type Specialization
 		Table_Slot :: struct($Key, $Value: typeid) {
 			occupied: bool,
-			hash:     u32,
-			key:      Key,
-			value:    Value,
+			hash    : u32,
+			key     : Key,
+			value   : Value,
 		}
 		TABLE_SIZE_MIN :: 32
 		Table :: struct($Key, $Value: typeid) {
-			count:     int,
+			count    : int,
 			allocator: mem.Allocator,
-			slots:     []Table_Slot(Key, Value),
+			slots    : []Table_Slot(Key, Value),
 		}
 
 		// Only allow types that are specializations of a (polymorphic) slice
@@ -1231,7 +1231,7 @@ threading_example :: proc() {
 
 
 		for i in 0 ..< 30 {
-			// be mindful of the allocator used for tasks. The allocator needs to be thread safe, or be owned by the task for exclusive use 
+			// be mindful of the allocator used for tasks. The allocator needs to be thread safe, or be owned by the task for exclusive use
 			thread.pool_add_task(
 				pool = &pool,
 				procedure = task_proc,
@@ -1821,7 +1821,7 @@ range_statements_with_multiple_return_values :: proc() {
 	fmt.println("\n#range statements with multiple return values")
 	My_Iterator :: struct {
 		index: int,
-		data:  []i32,
+		data : []i32,
 	}
 	make_my_iterator :: proc(data: []i32) -> My_Iterator {
 		return My_Iterator{data = data}
@@ -2001,7 +2001,7 @@ constant_literal_expressions :: proc() {
 		x, y: f32,
 	}
 	Foo :: struct {
-		a, b:    int,
+		a, b   : int,
 		using c: Bar,
 	}
 
@@ -2463,7 +2463,7 @@ matrix_type :: proc() {
 		fmt.println("r", r)
 	}
 
-	{ 	// Component-wise operations 
+	{ 	// Component-wise operations
 		// if the element type supports it
 		// Not support for '/', '%', or '%%' operations
 
@@ -2500,10 +2500,10 @@ matrix_type :: proc() {
 
 	{ 	// Submatrix casting square matrices
 		// Casting a square matrix to another square matrix with same element type
-		// is supported. 
+		// is supported.
 		// If the cast is to a smaller matrix type, the top-left submatrix is taken.
 		// If the cast is to a larger matrix type, the matrix is extended with zeros
-		// everywhere and ones in the diagonal for the unfilled elements of the 
+		// everywhere and ones in the diagonal for the unfilled elements of the
 		// extended matrix.
 
 		mat2 :: distinct matrix[2, 2]f32
@@ -2524,7 +2524,7 @@ matrix_type :: proc() {
 	}
 
 	{ 	// Casting non-square matrices
-		// Casting a matrix to another matrix is allowed as long as they share 
+		// Casting a matrix to another matrix is allowed as long as they share
 		// the same element type and the number of elements (rows*columns).
 		// Matrices in Odin are stored in column-major order, which means
 		// the casts will preserve this element order.
@@ -2542,16 +2542,16 @@ matrix_type :: proc() {
 	// TECHNICAL INFORMATION: the internal representation of a matrix in Odin is stored
 	// in column-major format
 	// e.g. matrix[2, 3]f32 is internally [3][2]f32 (with different a alignment requirement)
-	// Column-major is used in order to utilize (SIMD) vector instructions effectively on 
+	// Column-major is used in order to utilize (SIMD) vector instructions effectively on
 	// modern hardware, if possible.
 	//
 	// Unlike normal arrays, matrices try to maximize alignment to allow for the (SIMD) vectorization
 	// properties whilst keeping zero padding (either between columns or at the end of the type).
-	// 
+	//
 	// Zero padding is a compromise for use with third-party libraries, instead of optimizing for performance.
-	// Padding between columns was not taken even if that would have allowed each column to be loaded 
-	// individually into a SIMD register with the correct alignment properties. 
-	// 
+	// Padding between columns was not taken even if that would have allowed each column to be loaded
+	// individually into a SIMD register with the correct alignment properties.
+	//
 	// Currently, matrices are limited to a maximum of 16 elements (rows*columns), and a minimum of 1 element.
 	// This is because matrices are stored as values (not a reference type), and thus operations on them will
 	// be stored on the stack. Restricting the maximum element count minimizing the possibility of stack overflows.

--- a/tools/odinfmt/tests/random/.snapshots/demo.odin
+++ b/tools/odinfmt/tests/random/.snapshots/demo.odin
@@ -620,22 +620,22 @@ union_type :: proc() {
 		// an example of this for a basic game Entity.
 
 		Entity :: struct {
-			id         : u64,
-			name       : string,
-			position   : Vector3,
+			id:          u64,
+			name:        string,
+			position:    Vector3,
 			orientation: Quaternion,
-			derived    : any,
+			derived:     any,
 		}
 
 		Frog :: struct {
 			using entity: Entity,
-			jump_height : f32,
+			jump_height:  f32,
 		}
 
 		Monster :: struct {
 			using entity: Entity,
-			is_robot    : bool,
-			is_zombie   : bool,
+			is_robot:     bool,
+			is_zombie:    bool,
 		}
 
 		// See `parametric_polymorphism` procedure for details
@@ -664,11 +664,11 @@ union_type :: proc() {
 		// basic game Entity but using an union.
 
 		Entity :: struct {
-			id         : u64,
-			name       : string,
-			position   : Vector3,
+			id:          u64,
+			name:        string,
+			position:    Vector3,
 			orientation: Quaternion,
-			derived    : union {
+			derived:     union {
 				Frog,
 				Monster,
 			},
@@ -676,13 +676,13 @@ union_type :: proc() {
 
 		Frog :: struct {
 			using entity: ^Entity,
-			jump_height : f32,
+			jump_height:  f32,
 		}
 
 		Monster :: struct {
 			using entity: ^Entity,
-			is_robot    : bool,
-			is_zombie   : bool,
+			is_robot:     bool,
+			is_zombie:    bool,
 		}
 
 		// See `parametric_polymorphism` procedure for details
@@ -755,7 +755,7 @@ using_statement :: proc() {
 	}
 	{
 		Entity :: struct {
-			position   : Vector3,
+			position:    Vector3,
 			orientation: quaternion128,
 		}
 
@@ -790,7 +790,7 @@ using_statement :: proc() {
 		// making all the fields of position appear as if they on Entity itself:
 		Entity :: struct {
 			using position: Vector3,
-			orientation   : quaternion128,
+			orientation:    quaternion128,
 		}
 		foo :: proc(entity: ^Entity) {
 			fmt.println(entity.x, entity.y, entity.z)
@@ -807,8 +807,8 @@ using_statement :: proc() {
 		}
 		Frog :: struct {
 			ribbit_volume: f32,
-			using entity : Entity,
-			colour       : Colour,
+			using entity:  Entity,
+			colour:        Colour,
 		}
 
 		frog: Frog
@@ -933,15 +933,15 @@ parametric_polymorphism :: proc() {
 	{ 	// Polymorphic Types and Type Specialization
 		Table_Slot :: struct($Key, $Value: typeid) {
 			occupied: bool,
-			hash    : u32,
-			key     : Key,
-			value   : Value,
+			hash:     u32,
+			key:      Key,
+			value:    Value,
 		}
 		TABLE_SIZE_MIN :: 32
 		Table :: struct($Key, $Value: typeid) {
-			count    : int,
+			count:     int,
 			allocator: mem.Allocator,
-			slots    : []Table_Slot(Key, Value),
+			slots:     []Table_Slot(Key, Value),
 		}
 
 		// Only allow types that are specializations of a (polymorphic) slice
@@ -1821,7 +1821,7 @@ range_statements_with_multiple_return_values :: proc() {
 	fmt.println("\n#range statements with multiple return values")
 	My_Iterator :: struct {
 		index: int,
-		data : []i32,
+		data:  []i32,
 	}
 	make_my_iterator :: proc(data: []i32) -> My_Iterator {
 		return My_Iterator{data = data}
@@ -2001,7 +2001,7 @@ constant_literal_expressions :: proc() {
 		x, y: f32,
 	}
 	Foo :: struct {
-		a, b   : int,
+		a, b:    int,
 		using c: Bar,
 	}
 

--- a/tools/odinfmt/tests/random/.snapshots/document.odin
+++ b/tools/odinfmt/tests/random/.snapshots/document.odin
@@ -28,19 +28,19 @@ Document_Text :: struct {
 
 Document_Nest :: struct {
 	indentation: int,
-	alignment:   int,
-	document:    ^Document,
+	alignment  : int,
+	document   : ^Document,
 }
 
 Document_Nest_If_Break :: struct {
 	indentation: int,
-	alignment:   int,
-	document:    ^Document,
-	group_id:    string,
+	alignment  : int,
+	document   : ^Document,
+	group_id   : string,
 }
 
 Document_Break :: struct {
-	value:   string,
+	value  : string,
 	newline: bool,
 }
 
@@ -50,8 +50,8 @@ Document_If_Break :: struct {
 
 Document_Group :: struct {
 	document: ^Document,
-	mode:     Document_Group_Mode,
-	options:  Document_Group_Options,
+	mode    : Document_Group_Mode,
+	options : Document_Group_Options,
 }
 
 Document_Cons :: struct {
@@ -260,9 +260,9 @@ cons_with_nopl :: proc(
 
 Tuple :: struct {
 	indentation: int,
-	alignment:   int,
-	mode:        Document_Group_Mode,
-	document:    ^Document,
+	alignment  : int,
+	mode       : Document_Group_Mode,
+	document   : ^Document,
 }
 
 fits :: proc(width: int, list: ^[dynamic]Tuple) -> bool {

--- a/tools/odinfmt/tests/random/.snapshots/document.odin
+++ b/tools/odinfmt/tests/random/.snapshots/document.odin
@@ -28,19 +28,19 @@ Document_Text :: struct {
 
 Document_Nest :: struct {
 	indentation: int,
-	alignment  : int,
-	document   : ^Document,
+	alignment:   int,
+	document:    ^Document,
 }
 
 Document_Nest_If_Break :: struct {
 	indentation: int,
-	alignment  : int,
-	document   : ^Document,
-	group_id   : string,
+	alignment:   int,
+	document:    ^Document,
+	group_id:    string,
 }
 
 Document_Break :: struct {
-	value  : string,
+	value:   string,
 	newline: bool,
 }
 
@@ -50,8 +50,8 @@ Document_If_Break :: struct {
 
 Document_Group :: struct {
 	document: ^Document,
-	mode    : Document_Group_Mode,
-	options : Document_Group_Options,
+	mode:     Document_Group_Mode,
+	options:  Document_Group_Options,
 }
 
 Document_Cons :: struct {
@@ -260,9 +260,9 @@ cons_with_nopl :: proc(
 
 Tuple :: struct {
 	indentation: int,
-	alignment  : int,
-	mode       : Document_Group_Mode,
-	document   : ^Document,
+	alignment:   int,
+	mode:        Document_Group_Mode,
+	document:    ^Document,
 }
 
 fits :: proc(width: int, list: ^[dynamic]Tuple) -> bool {


### PR DESCRIPTION
The feature makes possible to align declarations in a struct automatically.

For instance:

```
Game :: struct {
	paddle     : Paddle,
	is_running : bool,
}

Player :: struct {
	name    : string,
	age     : u8,
	health  : uint,
	stamina : uint,
}
```

Option:

```json
{
	"align_struct_declarations": true,
	"spaces_around_colons": true
}
```