### PR TITLE
adds type inference support for compress and expand values

### DIFF
--- a/src/server/builtins.odin
+++ b/src/server/builtins.odin
@@ -424,8 +424,9 @@ get_expr_return_value :: proc(
 		return get_expr_return_value(ast_context, i.expr, true, allocator)
 
 	case ^ast.Basic_Lit:
-		i.tok.text = token_kind_to_str(i.tok)
-		return i, fmt.tprintf("u %v", i.tok.text), 0, true
+		ident := new_type(ast.Ident, n.pos, n.end, allocator)
+		ident.name = token_kind_to_str(i.tok)
+		return ident, fmt.tprintf("u %v", ident.name), 0, true
 
 	case:
 		if v, v_ok := resolve_type_expression(ast_context, n); v_ok {
@@ -449,6 +450,7 @@ get_symbol_return_value :: proc(
 	return_len: int,
 	ok: bool,
 ) {
+	untyped := false
 	ast_context.use_locals = true
 
 	#partial switch sym_val in symbol.value {
@@ -458,17 +460,21 @@ get_symbol_return_value :: proc(
 
 	case SymbolUntypedValue:
 		if sym_val.type == .Bool {
+			untyped = .Mutable in symbol.flags == false ? false : true
 			ident := new_type(ast.Ident, n.pos, n.end, allocator)
 			ident.name = "bool"
 			expr = wrap_pointer(ident, symbol.pointers)
-			return expr, node_to_string(&expr.expr_base), 0, true
+			name := untyped ? fmt.tprintf("u %v", node_to_string(&expr.expr_base)) : node_to_string(&expr.expr_base)
+			return expr, name, 0, true
 		}
 
+		untyped = .Variable in symbol.flags && .Mutable in symbol.flags == false ? true : false
 		expr = symbol_to_expr(symbol, ast_context.fullpath)
 		bl := expr.derived.(^ast.Basic_Lit) or_return
 		bl.tok.text = token_kind_to_str(bl.tok)
 		expr = wrap_pointer(bl, symbol.pointers)
-		return expr, node_to_string(&expr.expr_base), 0, true
+		name := untyped ? fmt.tprintf("u %v", node_to_string(&expr.expr_base)) : node_to_string(&expr.expr_base)
+		return expr, name, 0, true
 
 
 	case SymbolProcedureValue:

--- a/src/server/builtins.odin
+++ b/src/server/builtins.odin
@@ -2,6 +2,7 @@ package server
 
 import "core:fmt"
 import "core:odin/ast"
+import "core:odin/tokenizer"
 import "core:strconv"
 
 // Attempts to resolve the type of the builtin proc by following the rules of the odin type checker
@@ -129,6 +130,100 @@ check_builtin_proc_return_type :: proc(
 			if candidate != nil {
 				return convert_quaternion_candidate(candidate, is_mutable), true
 			}
+		case "expand_values":
+			if len(call.args) != 1 {
+				return nil, false
+			}
+
+			return expand_values(ast_context, call.args[0])
+		case "compress_values":
+			args_len := len(call.args)
+			flattened_len := args_len
+			contains_proc_return := false
+
+			if args_len == 0 {
+				return nil, false
+			}
+
+			exprs := make([]^ast.Expr, args_len, context.temp_allocator)
+			types := make([]string, args_len, context.temp_allocator)
+
+			for i in 0 ..< args_len {
+				if expr, typ, r_amt, ok := get_expr_return_value(ast_context, call.args[i], false); ok {
+					if r_amt >= 1 {
+						contains_proc_return = true
+					}
+					if r_amt >= 2 {
+						flattened_len += r_amt
+					}
+					exprs[i] = expr
+					types[i] = typ
+				} else {
+					return nil, false
+				}
+			}
+
+			// single expr
+			if flattened_len == 1 {
+				return exprs[0], true
+			}
+
+			all_same := true
+			for i in 1 ..< args_len {
+				if types[i] != types[0] {
+					all_same = false
+					break
+				}
+			}
+
+			// if return type is an array
+			if all_same && !contains_proc_return {
+				arr := new_type(ast.Array_Type, call.pos, call.end, context.temp_allocator)
+				arr.elem = exprs[0]
+
+				len_lit := new_type(ast.Basic_Lit, call.pos, call.end, context.temp_allocator)
+				len_lit.tok.kind = .Integer
+				len_lit.tok.text = fmt.tprintf("%d", args_len)
+				arr.len = len_lit
+
+				return arr, true
+			}
+
+			st := new_type(ast.Struct_Type, call.pos, call.end, context.temp_allocator)
+			fl := new_type(ast.Field_List, call.pos, call.end, context.temp_allocator)
+			fl.list = make([]^ast.Field, flattened_len, context.temp_allocator)
+			flattened_exprs: []^ast.Expr
+
+			if flattened_len == args_len {
+				flattened_exprs = exprs
+			} else {
+				flattened_exprs = make([]^ast.Expr, flattened_len, context.temp_allocator)
+				ind := 0
+				for &i in exprs {
+					if v, v_ok := i.derived.(^ast.Comp_Lit); v_ok {
+						for &elem in v.elems {
+							flattened_exprs[ind] = elem
+							ind += 1
+						}
+					} else {
+						flattened_exprs[ind] = i
+						ind += 1
+					}
+				}
+			}
+
+			for i in 0 ..< flattened_len {
+				f := new_type(ast.Field, call.pos, call.end, context.temp_allocator)
+				name_ident := new_type(ast.Ident, call.pos, call.end, context.temp_allocator)
+				name_ident.name = fmt.tprintf("v%v", i)
+				f.names = make([]^ast.Expr, 1, context.temp_allocator)
+				f.names[0] = name_ident
+				f.type = flattened_exprs[i]
+				fl.list[i] = f
+			}
+
+			st.fields = fl
+			return st, true
 		}
 	}
 
@@ -271,4 +366,230 @@ compare_basic_lit_value :: proc(a, b: f64, name: string) -> bool {
 		return a < b
 	}
 	return a > b
+}
+
+@(private = "file")
+token_kind_to_str :: proc(tok: tokenizer.Token) -> string {
+	#partial switch tok.kind {
+	case .Imag:
+		if v, ok := strconv.parse_complex64(tok.text); ok {
+			return "complex64"
+		} else {
+			return "quaternion64"
+		}
+	case .Integer:
+		return "int"
+	case .Float:
+		return "f64"
+	case .String:
+		return "string"
+	case .Rune:
+		return "rune"
+	case .Invalid:
+		return "bool"
+	}
+
+	return ""
+}
+
+@(private = "file")
+get_expr_return_value :: proc(
+	ast_context: ^AstContext,
+	n: ^ast.Expr,
+	is_proc_return: bool,
+	allocator := context.temp_allocator,
+) -> (
+	^ast.Expr,
+	string,
+	int,
+	bool,
+) {
+	#partial switch i in n.derived {
+	case ^ast.Call_Expr:
+		if s, s_ok := resolve_call_expr(ast_context, i); s_ok {
+			if v, v_ok := s.value.(SymbolProcedureValue); v_ok {
+				ast_context.call = i
+				if g, g_ok := resolve_generic_function_symbol(
+					ast_context,
+					v.orig_arg_types,
+					v.orig_return_types,
+					v.inlining,
+					s,
+				); g_ok {
+					return get_symbol_return_value(ast_context, i, g, true, allocator)
+				}
+			}
+		}
+
+		return get_expr_return_value(ast_context, i.expr, true, allocator)
+
+	case ^ast.Basic_Lit:
+		i.tok.text = token_kind_to_str(i.tok)
+		return i, fmt.tprintf("u %v", i.tok.text), 0, true
+
+	case:
+		if v, v_ok := resolve_type_expression(ast_context, n); v_ok {
+			return get_symbol_return_value(ast_context, n, v, is_proc_return, allocator)
+		}
+	}
+
+	return nil, "", 0, false
+}
+
+@(private = "file")
+get_symbol_return_value :: proc(
+	ast_context: ^AstContext,
+	n: ^ast.Expr,
+	symbol: Symbol,
+	is_proc_return: bool,
+	allocator := context.temp_allocator,
+) -> (
+	expr: ^ast.Expr,
+	str: string,
+	return_len: int,
+	ok: bool,
+) {
+	ast_context.use_locals = true
+
+	#partial switch sym_val in symbol.value {
+	case SymbolBasicValue:
+		expr = wrap_pointer(sym_val.ident, symbol.pointers)
+		return expr, node_to_string(expr), 0, true
+
+	case SymbolUntypedValue:
+		if sym_val.type == .Bool {
+			ident := new_type(ast.Ident, n.pos, n.end, allocator)
+			ident.name = "bool"
+			expr = wrap_pointer(ident, symbol.pointers)
+			return expr, node_to_string(&expr.expr_base), 0, true
+		}
+
+		expr = symbol_to_expr(symbol, ast_context.fullpath)
+		bl := expr.derived.(^ast.Basic_Lit) or_return
+		bl.tok.text = token_kind_to_str(bl.tok)
+		expr = wrap_pointer(bl, symbol.pointers)
+		return expr, node_to_string(&expr.expr_base), 0, true
+
+
+	case SymbolProcedureValue:
+		if symbol.name == "" {
+			ident := new_type(ast.Ident, n.pos, n.end, allocator)
+			ident.name = "nil"
+			return ident, ident.name, 0, true
+		}
+
+		if is_proc_return {
+			return_len = len(sym_val.return_types)
+
+			if return_len == 1 {
+				expr, str, _ = get_expr_return_value(
+					ast_context,
+					sym_val.return_types[0].type,
+					is_proc_return,
+					allocator,
+				) or_return
+
+				return expr, str, 1, true
+			}
+
+			cl := new_type(ast.Comp_Lit, n.pos, n.end, allocator)
+			cl.elems = make([]^ast.Expr, return_len, allocator)
+
+			for i in 0 ..< return_len {
+				val, _, _ := get_expr_return_value(
+					ast_context,
+					sym_val.return_types[i].type,
+					is_proc_return,
+					allocator,
+				) or_return
+
+				cl.elems[i] = val
+			}
+
+			return cl, node_to_string(&expr.expr_base), return_len, true
+		}
+
+		expr = symbol_to_expr(symbol, ast_context.fullpath, allocator)
+		return expr, node_to_string(expr), 0, true
+
+	case SymbolFixedArrayValue,
+	     SymbolSliceValue,
+	     SymbolMapValue,
+	     SymbolDynamicArrayValue,
+	     SymbolMatrixValue,
+	     SymbolMultiPointerValue:
+		if symbol.type_expr == nil {
+			expr = wrap_pointer(symbol_to_expr(symbol, ast_context.fullpath), symbol.pointers)
+			return expr, node_to_string(expr), 0, true
+		}
+
+		expr = wrap_pointer(symbol.type_expr, symbol.pointers)
+		return expr, node_to_string(expr), 0, true
+
+	case:
+		ident := new_type(ast.Ident, n.pos, n.end, allocator)
+		ident.name = symbol.name
+		expr = wrap_pointer(ident, symbol.pointers)
+		return expr, node_to_string(&expr.expr_base), 0, true
+	}
+
+	return nil, "", 0, false
+}
+
+expand_values :: proc(
+	ast_context: ^AstContext,
+	expr: ^ast.Expr,
+	allocator := context.temp_allocator,
+) -> (
+	ce: ^ast.Call_Expr,
+	ok: bool,
+) {
+	new_expr, _, _ := get_expr_return_value(ast_context, expr, false, allocator) or_return
+	expanded_exprs := make([dynamic]^ast.Expr, allocator)
+
+	#partial switch v in new_expr.derived {
+	case ^ast.Array_Type:
+		if v.len == nil {
+			return nil, false
+		}
+		if l, l_ok := v.len.derived.(^ast.Basic_Lit); l_ok {
+			length := strconv.parse_int(l.tok.text, 10) or_return
+			for _ in 0 ..< length {
+				append(&expanded_exprs, v.elem)
+			}
+		}
+	case ^ast.Struct_Type:
+		for &elem in v.fields.list {
+			for &_ in elem.names {
+				append(&expanded_exprs, elem.type)
+			}
+		}
+	case ^ast.Ident:
+		if s, s_ok := struct_type_from_identifier(ast_context, v^); s_ok {
+			for &elem in s.fields.list {
+				for &_ in elem.names {
+					append(&expanded_exprs, elem.type)
+				}
+			}
+		}
+	case:
+		return nil, false
+	}
+
+	ce = new_type(ast.Call_Expr, expr.pos, expr.end, allocator)
+	pt := new_type(ast.Proc_Type, expr.pos, expr.end, allocator)
+	pt.results = new_type(ast.Field_List, expr.pos, expr.end, allocator)
+	pt.results.list = make([]^ast.Field, len(expanded_exprs), allocator)
+
+	for i in 0 ..< len(expanded_exprs) {
+		f := new_type(ast.Field, expr.pos, expr.end, allocator)
+		f.type = expanded_exprs[i]
+		pt.results.list[i] = f
+	}
+
+	ce.expr = pt
+	ce.derived_expr = pt
+	ce.derived = ce
+
+	return ce, true
 }

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -293,6 +293,28 @@ get_generic_assignment :: proc(
 			append(results, b)
 		}
 	case ^ast.Unary_Expr:
+		if v.op.kind == .Mul_Mul {
+			if ce, ok := expand_values(ast_context, v.expr, ast_context.allocator); ok {
+				if symbol, s_ok := resolve_type_expression(ast_context, ce.expr); s_ok {
+					if proc_val, p_ok := symbol.value.(SymbolProcedureValue); p_ok {
+						returns := get_proc_return_types(ast_context, symbol, ce, is_mutable)
+						if len(returns) == 0 {
+							append(results, cast(^ast.Expr)&ce.node)
+						} else {
+							for ret in returns {
+								calls[len(results)] = {}
+								append(results, ret)
+							}
+						}
+						break
+					}
+				}
+			}
+
+			append(results, value)
+			break
+		}
+		
 		append(results, value)
 
 		#partial switch n in v.expr.derived {

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3089,60 +3089,210 @@ ast_hover_builtin_clamp_from_proc :: proc(t: ^testing.T) {
 }
 
 @(test)
-ast_hover_builtin_compress_values_to_array :: proc(t: ^testing.T) {
+ast_hover_builtin_compress_untyped_ints_to_array :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		main :: proc() {
-			m{*}: [3]int = compress_values(1, 2, 3)
+			m{*} := compress_values(1, 2)
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.m: [3]int")
+	test.expect_hover(t, &source, "test.m: [2]int")
 }
 
 @(test)
-ast_hover_builtin_compress_values_to_struct :: proc(t: ^testing.T) {
+ast_hover_builtin_compress_values_typed_ints_to_array :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		main :: proc() {
-			Foo :: struct {
-				a, b: int,
-			}
-
-			m{*}: Foo = compress_values(1, 2)
+			x := 10
+			y := 20
+			
+			m{*} := compress_values(x, y)
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.m: test.Foo")
+	test.expect_hover(t, &source, "test.m: [2]int")
 }
 
 @(test)
-ast_hover_builtin_expand_values_to_array :: proc(t: ^testing.T) {
+ast_hover_builtin_compress_values_structs_to_array :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
+		St :: struct {
+			x: bool,
+		}
+		
 		main :: proc() {
-			arr := [2]int{1, 2}
-			m{*} := [3]int{expand_values(arr), 3}
+			x := St{}
+			
+			m{*} := compress_values(x, St{})
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.m: [3]int")
+	test.expect_hover(t, &source, "test.m: [2]St")
 }
 
 @(test)
-ast_hover_builtin_expand_values_to_struct :: proc(t: ^testing.T) {
+ast_hover_builtin_compress_values_untyped_typed_floats_to_struct :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		main :: proc() {
-			Foo :: struct {
-				a, b: int,
-			}
-
-			m{*} := Foo{expand_values(arr)}
+			x := 31.1
+			
+			m{*} := compress_values(x, 5.1)
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.m: test.Foo")
+	test.expect_hover(t, &source, "test.m: struct {\n\tv0: f64,\n\tv1: f64,\n}")
+}
+
+@(test)
+ast_hover_builtin_compress_values_typed_floats_to_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			f_16: f16 = 20
+			f_32: f32 = 20
+			f_64 := 20.1
+			
+			m{*} := compress_values(f_16, f_32, f_64)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: struct {\n\tv0: f16,\n\tv1: f32,\n\tv2: f64,\n}")
+}
+
+@(test)
+ast_hover_builtin_compress_values_typed_ints_to_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			i_8: i8 = 20
+			i_16: i16 = 20
+			i_32: i32 = 20
+			i_64 := 20
+			
+			m{*} := compress_values(i_8, i_16, i_32, i_64)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: struct {\n\tv0: i8,\n\tv1: i16,\n\tv2: i32,\n\tv3: int,\n}")
+}
+
+@(test)
+ast_hover_builtin_compress_values_proc_to_single_value :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		proc_1 :: proc(i: int) -> int {
+			return i
+		}
+
+		main :: proc() {
+			m{*} := compress_values(proc_1(10))
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: int")
+}
+
+@(test)
+ast_hover_builtin_compress_values_generic_proc_to_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		proc_1 :: proc(x: $T, y: $N) -> (T, N) {
+			return x, y
+		}
+
+		main :: proc() {
+			m{*} := compress_values(proc_1(false, 35.1))
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: struct {\n\tv0: bool,\n\tv1: f64,\n}")
+}
+
+@(test)
+ast_hover_builtin_compress_values_arrays_to_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			arr := [2]int{10, 20}
+			slice := []int{10, 20}
+			dyn: [dynamic]int
+			dyn_fixed: [dynamic; 2]int
+
+			m{*} := compress_values(arr, slice, dyn, dyn_fixed)
+		}
+	`,
+	}
+	test.expect_hover(
+		t,
+		&source,
+		"test.m: struct {\n\tv0: [2]int,\n\tv1: []int,\n\tv2: [dynamic]int,\n\tv3: [dynamic; 2]int,\n}",
+	)
+}
+
+@(test)
+ast_hover_builtin_compress_values_ptrs_to_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			arr := [2]int{10, 20}
+			m_ptr: [^]int
+
+			m{*} := compress_values(&arr, m_ptr)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: struct {\n\tv0: ^[2]int,\n\tv1: [^]int,\n}")
+}
+
+@(test)
+ast_hover_builtin_expand_values_from_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		St :: struct {
+			x: int,
+			y: bool,
+		}
+
+		
+		main :: proc() {
+			a, b{*} := expand_values(St{3, true})
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.b: bool")
+}
+
+@(test)
+ast_hover_builtin_expand_values_from_array :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			a, b{*} := expand_values([2]f32{21.1, 23.3})
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.b: f32")
+}
+
+@(test)
+ast_hover_builtin_expand_values_operator_from_struct :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		St :: struct {
+			x: int,
+			y: bool,
+		}
+
+		main :: proc() {
+			a, b{*} := **St{3, true}
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.b: bool")
 }
 
 @(test)

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -3093,11 +3093,25 @@ ast_hover_builtin_compress_untyped_ints_to_array :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test
 		main :: proc() {
-			m{*} := compress_values(1, 2)
+			C_INT :: 3
+			m{*} := compress_values(1, 2, 3)
 		}
 	`,
 	}
-	test.expect_hover(t, &source, "test.m: [2]int")
+	test.expect_hover(t, &source, "test.m: [3]int")
+}
+
+@(test)
+ast_hover_builtin_compress_untyped_bools_to_array :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			C_BOOL :: false
+			m{*} := compress_values(false, true, C_BOOL)
+		}
+	`,
+	}
+	test.expect_hover(t, &source, "test.m: [3]bool")
 }
 
 @(test)


### PR DESCRIPTION
I've added type inference support for compress and expand values, including the "**" operator for expand values. 
I did quite a bit of testing to make sure there are no apparent bugs. One issue that I wasn't able to solve was how constants work in compress values. For compress values to work correctly it needs to be able to determine if a value is typed or untyped. Constants should be seen as untyped but I couldn't figure out an easy way of receiving this info. So in certain circumstances with literals of the same type in compress values but differing on whether or not they are untyped, the hover will be wrong.