### PR TITLE
Fold simple package consts in when conditions

### DIFF
--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -478,6 +478,7 @@ collect_when_stmt :: proc(
 	file: ast.File,
 	file_tags: parser.File_Tags,
 	when_decl: ^ast.When_Stmt,
+	when_expr_map: ^map[string]When_Expr,
 ) {
 	if when_decl.cond == nil {
 		return
@@ -486,13 +487,19 @@ collect_when_stmt :: proc(
 	if when_decl.body == nil {
 		return
 	}
-	if stmt, ok := get_when_block_stmt(when_decl); ok {
-		collect_when_body(exprs, file, file_tags, stmt)
+	if stmt, ok := get_when_block_stmt(when_decl, when_expr_map^); ok {
+		collect_when_body(exprs, file, file_tags, stmt, when_expr_map)
 	}
 }
 
-get_when_block_stmt :: proc(when_decl: ^ast.When_Stmt) -> (^ast.Block_Stmt, bool) {
-	if resolve_when_condition(when_decl.cond) {
+get_when_block_stmt :: proc(
+	when_decl: ^ast.When_Stmt,
+	when_expr_map: map[string]When_Expr,
+) -> (
+	^ast.Block_Stmt,
+	bool,
+) {
+	if resolve_when_condition(when_decl.cond, when_expr_map) {
 		if block, ok := when_decl.body.derived.(^ast.Block_Stmt); ok {
 			return block, true
 		}
@@ -501,7 +508,7 @@ get_when_block_stmt :: proc(when_decl: ^ast.When_Stmt) -> (^ast.Block_Stmt, bool
 
 		for else_stmt != nil {
 			if else_when, ok := else_stmt.derived.(^ast.When_Stmt); ok {
-				if resolve_when_condition(else_when.cond) {
+				if resolve_when_condition(else_when.cond, when_expr_map) {
 					if block, ok := else_when.body.derived.(^ast.Block_Stmt); ok {
 						return block, true
 					}
@@ -523,20 +530,27 @@ collect_when_body :: proc(
 	file: ast.File,
 	file_tags: parser.File_Tags,
 	block: ^ast.Block_Stmt,
+	when_expr_map: ^map[string]When_Expr,
 ) {
 	for stmt in block.stmts {
 		if when_stmt, ok := stmt.derived.(^ast.When_Stmt); ok {
-			collect_when_stmt(exprs, file, file_tags, when_stmt)
+			collect_when_stmt(exprs, file, file_tags, when_stmt, when_expr_map)
 		} else if foreign_decl, ok := stmt.derived.(^ast.Foreign_Block_Decl); ok {
 			if foreign_decl.body != nil {
 				if foreign_block, ok := foreign_decl.body.derived.(^ast.Block_Stmt); ok {
 					for foreign_stmt in foreign_block.stmts {
 						collect_value_decl(exprs, file, file_tags, foreign_stmt, foreign_decl.attributes[:])
+						if value_decl, ok := foreign_stmt.derived.(^ast.Value_Decl); ok {
+							register_when_consts_from_value_decl(when_expr_map, file, value_decl)
+						}
 					}
 				}
 			}
 		} else {
 			collect_value_decl(exprs, file, file_tags, stmt, {})
+			if value_decl, ok := stmt.derived.(^ast.Value_Decl); ok {
+				register_when_consts_from_value_decl(when_expr_map, file, value_decl)
+			}
 		}
 	}
 }
@@ -549,11 +563,15 @@ collect_globals :: proc(file: ast.File) -> []GlobalExpr {
 	exprs := make([dynamic]GlobalExpr, context.temp_allocator)
 	defer shrink(&exprs)
 
+	// Declaration-order const fold for when conditions (e.g. MAP_ENABLED :: !ODIN_BEDROCK).
+	when_expr_map := make_when_expr_map()
+
 	for decl in file.decls {
 		if value_decl, ok := decl.derived.(^ast.Value_Decl); ok {
 			collect_value_decl(&exprs, file, file_tags, decl, {})
+			register_when_consts_from_value_decl(&when_expr_map, file, value_decl)
 		} else if when_decl, ok := decl.derived.(^ast.When_Stmt); ok {
-			collect_when_stmt(&exprs, file, file_tags, when_decl)
+			collect_when_stmt(&exprs, file, file_tags, when_decl, &when_expr_map)
 		} else if foreign_decl, ok := decl.derived.(^ast.Foreign_Block_Decl); ok {
 			if foreign_decl.body == nil {
 				continue
@@ -562,6 +580,9 @@ collect_globals :: proc(file: ast.File) -> []GlobalExpr {
 			if block, ok := foreign_decl.body.derived.(^ast.Block_Stmt); ok {
 				for stmt in block.stmts {
 					collect_value_decl(&exprs, file, file_tags, stmt, foreign_decl.attributes[:])
+					if value_decl, ok := stmt.derived.(^ast.Value_Decl); ok {
+						register_when_consts_from_value_decl(&when_expr_map, file, value_decl)
+					}
 				}
 			}
 		}

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -510,7 +510,9 @@ get_locals_stmt :: proc(
 	case ^ast.Using_Stmt:
 		get_locals_using_stmt(v^, ast_context)
 	case ^ast.When_Stmt:
-		if stmt, ok := get_when_block_stmt(v); ok {
+		when_expr_map := make_when_expr_map()
+		register_when_consts_from_globals(&when_expr_map, ast_context.globals)
+		if stmt, ok := get_when_block_stmt(v, when_expr_map); ok {
 			get_locals_block_stmt(file, stmt^, ast_context, document_position, true)
 		}
 	case ^ast.Case_Clause:

--- a/src/server/when.odin
+++ b/src/server/when.odin
@@ -1,7 +1,6 @@
 #+feature dynamic-literals
 package server
 
-import "base:runtime"
 import "core:fmt"
 import "core:odin/ast"
 import "core:strconv"
@@ -30,6 +29,97 @@ convert_os_string: map[string]string = {
 	"orca"         = "Orca",
 }
 
+// Profile defines seed for when-condition evaluation.
+make_when_expr_map :: proc() -> map[string]When_Expr {
+	when_expr_map := make(map[string]When_Expr, context.temp_allocator)
+
+	for key, value in common.config.profile.defines {
+		when_expr_map[key] = resolve_when_ident(when_expr_map, value) or_continue
+	}
+
+	return when_expr_map
+}
+
+/*
+Limited static fold of a package-level constant into the when map.
+Only immutable consts whose RHS resolves to bool/int/string under the
+existing when evaluator are registered (defines, literals, !, &&, ||,
+parens, string compares). Unknown idents still default to false bool.
+Profile defines win over package names.
+*/
+register_when_const :: proc(when_expr_map: ^map[string]When_Expr, name: string, value: ^ast.Expr) {
+	if name == "" || value == nil {
+		return
+	}
+	if name in when_expr_map^ {
+		return
+	}
+
+	resolved, ok := resolve_when_expr(when_expr_map^, value)
+	if !ok {
+		return
+	}
+
+	// Only scalars are useful as when-condition bindings.
+	#partial switch v in resolved {
+	case bool:
+		when_expr_map^[name] = v
+	case int:
+		when_expr_map^[name] = v
+	case string:
+		when_expr_map^[name] = v
+	}
+}
+
+// Register foldable consts from a value declaration (immutable only).
+register_when_consts_from_value_decl :: proc(
+	when_expr_map: ^map[string]When_Expr,
+	file: ast.File,
+	value_decl: ^ast.Value_Decl,
+) {
+	if value_decl == nil || value_decl.is_mutable {
+		return
+	}
+
+	for name, i in value_decl.names {
+		if len(value_decl.values) <= i {
+			continue
+		}
+		name_str := get_ast_node_string(name, file.src)
+		register_when_const(when_expr_map, name_str, value_decl.values[i])
+	}
+}
+
+// Multi-pass fold of package globals (map order is unstable).
+register_when_consts_from_globals :: proc(
+	when_expr_map: ^map[string]When_Expr,
+	globals: map[string]GlobalExpr,
+) {
+	// Enough passes for short const chains (A :: B, B :: !C).
+	for _ in 0 ..< 8 {
+		added := false
+		for name, global in globals {
+			if .Mutable in global.flags {
+				continue
+			}
+			if global.value_expr == nil {
+				continue
+			}
+			if name in when_expr_map^ {
+				continue
+			}
+			before := len(when_expr_map)
+			register_when_const(when_expr_map, name, global.value_expr)
+			if len(when_expr_map) > before {
+				added = true
+			}
+		}
+		if !added {
+			break
+		}
+	}
+}
+
 resolve_when_ident :: proc(when_expr_map: map[string]When_Expr, ident: string) -> (When_Expr, bool) {
 	switch ident {
 	case "ODIN_OS":
@@ -53,6 +143,11 @@ resolve_when_ident :: proc(when_expr_map: map[string]When_Expr, ident: string) -
 
 	if ident in when_expr_map {
 		value := when_expr_map[ident]
+		// Fully resolve stored AST fragments (if any) so conditions see scalars.
+		#partial switch v in value {
+		case ^ast.Expr:
+			return resolve_when_expr(when_expr_map, v)
+		}
 		return value, true
 	}
 
@@ -135,11 +230,9 @@ resolve_when_expr :: proc(
 }
 
 
-resolve_when_condition :: proc(condition: ^ast.Expr) -> bool {
-	when_expr_map := make(map[string]When_Expr, context.temp_allocator)
-
-	for key, value in common.config.profile.defines {
-		when_expr_map[key] = resolve_when_ident(when_expr_map, value) or_continue
+resolve_when_condition :: proc(condition: ^ast.Expr, when_expr_map: map[string]When_Expr) -> bool {
+	if condition == nil {
+		return false
 	}
 
 	if when_expr, ok := resolve_when_expr(when_expr_map, condition); ok {

--- a/tests/when_const_fold_test.odin
+++ b/tests/when_const_fold_test.odin
@@ -1,0 +1,141 @@
+package tests
+
+import "core:testing"
+
+import test "src:testing"
+
+// #1562: package-level consts used in `when` (MAP_ENABLED :: !ODIN_BEDROCK)
+
+@(test)
+ast_when_const_map_enabled_pattern :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		// Mirrors base/runtime/core_builtin.odin
+		MAP_ENABLED :: !ODIN_BEDROCK
+
+		when MAP_ENABLED {
+			map_insert_like :: proc(m: ^map[int]int, key: int, value: int) {}
+		}
+
+		main :: proc() {
+			map_insert_li{*}ke
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_hover(
+		t,
+		&source,
+		"test.map_insert_like :: proc(m: ^map[int]int, key: int, value: int)",
+	)
+}
+
+@(test)
+ast_when_const_true_literal :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		ALWAYS :: true
+
+		when ALWAYS {
+			visible :: proc() {}
+		}
+
+		main :: proc() {
+			visib{*}le
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_hover(t, &source, "test.visible :: proc()")
+}
+
+@(test)
+ast_when_const_false_skips_body :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		NEVER :: false
+
+		when NEVER {
+			hidden :: proc() {}
+		} else {
+			shown :: proc() {}
+		}
+
+		main :: proc() {
+			sho{*}wn
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_hover(t, &source, "test.shown :: proc()")
+}
+
+@(test)
+ast_when_const_chain :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		A :: true
+		B :: A
+		C :: B && true
+
+		when C {
+			chained :: proc() {}
+		}
+
+		main :: proc() {
+			chain{*}ed
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_hover(t, &source, "test.chained :: proc()")
+}
+
+@(test)
+ast_when_direct_not_define_still_works :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		when !ODIN_BEDROCK {
+			direct :: proc() {}
+		}
+
+		main :: proc() {
+			direc{*}t
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_hover(t, &source, "test.direct :: proc()")
+}
+
+@(test)
+ast_when_local_const_condition :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+
+		FLAG :: true
+
+		main :: proc() {
+			when FLAG {
+				foo: i32 = 5
+			} else {
+				foo: i64 = 6
+			}
+			fo{*}
+		}
+		`,
+		packages = {},
+	}
+
+	test.expect_completion_docs(t, &source, "", {"test.foo: i32"})
+}


### PR DESCRIPTION
 Fixes #1562

This expands WHEN evaluations to check for simple static booleans. 

nothing fancy, just a quality of life improvement