### PR TITLE
Keep range loop headers on one line

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1204,25 +1204,29 @@ visit_stmt :: proc(
 			document = cons(document, text("#reverse"), break_with_no_newline())
 		}
 
-		document = cons(document, text("for"))
+		range_document := text("for")
 
 		if v.init != nil {
-			document = cons(document, break_with_space(), visit_stmt(p, v.init), text(";"))
+			range_document = cons(range_document, break_with_space(), visit_stmt(p, v.init), text(";"))
 		}
 
 		if len(v.vals) >= 1 {
-			document = cons_with_opl(document, visit_expr(p, v.vals[0]))
+			range_document = cons_with_opl(range_document, visit_expr(p, v.vals[0]))
 		}
 
 		if len(v.vals) >= 2 {
 			for val in v.vals[1:] {
-				document = cons(document, cons_with_opl(text(","), visit_expr(p, val)))
+				range_document = cons(range_document, cons_with_opl(text(","), visit_expr(p, val)))
 			}
 		}
 
-		document = cons_with_opl(document, text("in"))
+		range_document = cons_with_opl(range_document, text("in"))
 
-		document = cons_with_opl(document, visit_expr(p, v.expr))
+		range_document = cons_with_opl(range_document, visit_expr(p, v.expr))
+
+		// Newlines in a range-loop header trigger semicolon insertion and turn the
+		// header into invalid Odin, so it must remain on one physical line.
+		document = cons(document, enforce_fit(range_document))
 
 		set_source_position(p, v.body.pos)
 		document = cons_with_nopl(document, visit_stmt(p, v.body))

--- a/tools/odinfmt/tests/.snapshots/for.odin
+++ b/tools/odinfmt/tests/.snapshots/for.odin
@@ -19,3 +19,29 @@ long_range_headers_stay_on_one_line :: proc() {
 	for expedition_index in passage.contract.ship_indices[:passage.contract.ship_count] do use(expedition_index)
 	for _ in 0 ..< an_expression_long_enough_to_push_this_range_loop_header_past_the_formatter_width do tick()
 }
+
+broken_surrounding_document_keeps_range_header_on_one_line :: proc(
+) {top_rail(s); draw_text(
+		"THREE PROJECT SLOTS · INDUSTRY IS COMMITTED IMMEDIATELY",
+		28,
+		113,
+		TYPE_SMALL_EMPHASIS,
+		UX.info,
+	)
+	for project, i in s.campaign.projects {rect := R(
+			28 + f32(i) * 405,
+			150,
+			380,
+			180,
+		)
+		panel(rect, true)
+		draw_fmt(
+			rect.x + 22,
+			rect.y + 20,
+			TYPE_BODY_COMPACT,
+			UX.dim,
+			"SLOT %d",
+			i + 1,
+		)
+	}
+}

--- a/tools/odinfmt/tests/.snapshots/for.odin
+++ b/tools/odinfmt/tests/.snapshots/for.odin
@@ -14,3 +14,8 @@ for_with_init :: proc() {
 		x += len(foo)
 	}
 }
+
+long_range_headers_stay_on_one_line :: proc() {
+	for expedition_index in passage.contract.ship_indices[:passage.contract.ship_count] do use(expedition_index)
+	for _ in 0 ..< an_expression_long_enough_to_push_this_range_loop_header_past_the_formatter_width do tick()
+}

--- a/tools/odinfmt/tests/for.odin
+++ b/tools/odinfmt/tests/for.odin
@@ -14,3 +14,8 @@ for_with_init :: proc () {
 		x += len(foo)
 	}   
 }
+
+long_range_headers_stay_on_one_line :: proc() {
+	for expedition_index in passage.contract.ship_indices[:passage.contract.ship_count] do use(expedition_index)
+	for _ in 0 ..< an_expression_long_enough_to_push_this_range_loop_header_past_the_formatter_width do tick()
+}

--- a/tools/odinfmt/tests/for.odin
+++ b/tools/odinfmt/tests/for.odin
@@ -19,3 +19,21 @@ long_range_headers_stay_on_one_line :: proc() {
 	for expedition_index in passage.contract.ship_indices[:passage.contract.ship_count] do use(expedition_index)
 	for _ in 0 ..< an_expression_long_enough_to_push_this_range_loop_header_past_the_formatter_width do tick()
 }
+
+broken_surrounding_document_keeps_range_header_on_one_line :: proc() {top_rail(s); draw_text(
+		"THREE PROJECT SLOTS · INDUSTRY IS COMMITTED IMMEDIATELY",
+		28,
+		113,
+		TYPE_SMALL_EMPHASIS,
+		UX.info,
+	)
+	for project, i in s.campaign.projects {rect := R(28 + f32(i) * 405, 150, 380, 180); panel(rect, true); draw_fmt(
+			rect.x + 22,
+			rect.y + 20,
+			TYPE_BODY_COMPACT,
+			UX.dim,
+			"SLOT %d",
+			i + 1,
+		)
+	}
+}


### PR DESCRIPTION
## What changed

- keep range-loop headers on one physical line during formatting
- add regression coverage for long collection and range expressions

## Why

`Range_Stmt` currently builds its header with optional line breaks around the loop variables, `in`, and the iterated expression. When a header exceeds `character_width`, those breaks become physical newlines:

```odin
for
	expedition_index
	in
	passage.contract.ship_indices[:passage.contract.ship_count] {
```

Odin's semicolon insertion makes that output invalid. The formatter can therefore turn valid source into code that no longer parses.

This change builds the range header separately and applies `enforce_fit` before attaching the body, preserving valid syntax even when the header exceeds the configured width.

## Validation

- built `odinfmt` from this branch
- added input and snapshot regression cases for long range-loop headers
- formatted a 25-file downstream Odin package that previously reproduced the failure
- verified the formatted downstream package with `odin check`

The full formatter snapshot run reaches an unrelated existing mismatch in `tests/random/demo.odin`: current `master` removes trailing whitespace while its checked-in snapshot still contains it. The focused `for.odin` snapshot passes.
