### PR TITLE
Feature #1571: Ignore last new line with imports

### DIFF
--- a/src/server/action.odin
+++ b/src/server/action.odin
@@ -179,14 +179,14 @@ add_missing_imports :: proc(
 				if pkg == name.name {
 					import_edit : TextEdit
 					if config.enable_add_import_to_bottom {
-						most_bottom_line := find_most_bottom_line_number(ast_context)
+						most_bottom_line, is_import := find_most_bottom_line_number(ast_context)
 
 						import_edit = TextEdit {
 							range = {
-								start = {line = most_bottom_line + 1, character = 0},
-								end = {line = most_bottom_line + 1, character = 0},
+								start = {line = most_bottom_line, character = 0},
+								end = {line = most_bottom_line, character = 0},
 							},
-							newText = fmt.tprintf("\nimport \"%v:%v\"", collection, pkg),
+							newText = is_import ? fmt.tprintf("import \"%v:%v\"\n", collection, pkg) : fmt.tprintf("\nimport \"%v:%v\"", collection, pkg),
 						}
 					} else {
 						pkg_decl := ast_context.file.pkg_decl

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -2063,21 +2063,25 @@ get_range_from_selection_start_to_dot :: proc(position_context: ^DocumentPositio
 	return {}, false
 }
 
-find_most_bottom_line_number :: proc(ast_context: ^AstContext) -> int {
+find_most_bottom_line_number :: proc(ast_context: ^AstContext) -> (int, bool) {
 	most_bottom_line := 0
+	is_import := false
 	for decl in ast_context.file.decls {
 		most_bottom_line = max(decl.end.line, most_bottom_line)
-	}
-
-	for import_node in ast_context.file.imports {
-		most_bottom_line = max(import_node.end.line, most_bottom_line)
 	}
 
 	for comment_node in ast_context.file.comments {
 		most_bottom_line = max(comment_node.end.line, most_bottom_line)
 	}
 
-	return most_bottom_line
+	for import_node in ast_context.file.imports {
+		if import_node.end.line >= most_bottom_line {
+			most_bottom_line = import_node.end.line
+			is_import = true
+		}
+	}
+
+	return most_bottom_line, is_import
 }
 
 append_non_imported_packages :: proc(
@@ -2109,14 +2113,14 @@ append_non_imported_packages :: proc(
 				import_edit : TextEdit
 
 				if config.enable_add_import_to_bottom {
-					most_bottom_line := find_most_bottom_line_number(ast_context)
+					most_bottom_line, is_import := find_most_bottom_line_number(ast_context)
 
 					import_edit = TextEdit {
 						range = {
-							start = {line = most_bottom_line + 1, character = 0},
-							end = {line = most_bottom_line + 1, character = 0},
+							start = {line = most_bottom_line, character = 0},
+							end = {line = most_bottom_line, character = 0},
 						},
-						newText = fmt.tprintf("\nimport \"%v:%v\"", collection, pkg),
+						newText = is_import ? fmt.tprintf("import \"%v:%v\"\n", collection, pkg) : fmt.tprintf("\nimport \"%v:%v\"", collection, pkg),
 					}
 				} else {
 					import_edit = TextEdit {


### PR DESCRIPTION
When the file ends with a import statement the newline that is usually inserted with each autocompleted import statement should be remove in order to not break up the import block.

Some edge cases still exist if the newline inserted with the import statement during autocomplete is manually removed the next autocompleted import will be on the same line.

Fix for https://github.com/DanielGavin/ols/pull/1571#issuecomment-5048572341

https://github.com/user-attachments/assets/118d51b5-67e6-443d-812d-9c5fe5d76e73

