### PR TITLE
Fix crashes due to nil pointers in structs with poly_params

### DIFF
--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -655,6 +655,9 @@ write_poly_list :: proc(sb: ^strings.Builder, poly: ^ast.Field_List, poly_names:
 		poly_name_index := 0
 		strings.write_string(sb, "(")
 		for field, i in poly.list {
+			if field == nil {
+				continue
+			}
 			write_type := true
 			for name, j in field.names {
 				if poly_name_index < len(poly_names) {

--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -760,6 +760,9 @@ resolve_poly_struct :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuild
 	clear(&b.poly_names)
 
 	for param in poly_params.list {
+		if param == nil {
+			continue
+		}
 		for name in param.names {
 			append(&b.poly_names, node_to_string(name))
 			if len(ast_context.call.args) <= i {

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -1273,6 +1273,9 @@ get_locals_poly :: proc(file: ast.File, params: ^ast.Field_List, ast_context: ^A
 		return
 	}
 	for param in params.list {
+		if param == nil {
+			continue
+		}
 		for name in param.names {
 			if poly, ok := name.derived.(^ast.Poly_Type); ok {
 				str := get_ast_node_string(poly.type, file.src)

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -57,6 +57,9 @@ split_all_field_arguments :: proc(symbol: ^Symbol, allocator := context.temp_all
 separate_fields :: proc(list: []^ast.Field, allocator := context.allocator) -> []^ast.Field {
 	fields := make([dynamic]^ast.Field, allocator)
 	for arg, i in list {
+		if arg == nil {
+			continue
+		}
 		if len(arg.names) == 1 {
 			append(&fields, arg)
 			continue
@@ -198,9 +201,9 @@ add_proc_signature :: proc(
 
 	if value, ok := call.value.(SymbolProcedureValue); ok {
 		add_signature_info(call, value.orig_arg_types, &active_parameter, signature_information)
-	} else if value, ok := call.value.(SymbolStructValue); ok && value.poly.list != nil {
+	} else if value, ok := call.value.(SymbolStructValue); ok && value.poly != nil && value.poly.list != nil {
 		add_signature_info(call, value.poly.list, &active_parameter, signature_information)
-	} else if value, ok := call.value.(SymbolUnionValue); ok && value.poly.list != nil {
+	} else if value, ok := call.value.(SymbolUnionValue); ok && value.poly != nil && value.poly.list != nil {
 		add_signature_info(call, value.poly.list, &active_parameter, signature_information)
 	} else if value, ok := call.value.(SymbolAggregateValue); ok {
 		//function overloaded procedures


### PR DESCRIPTION
This fixes two issues with poly_params in structs.

* Having more poly_param arguments then parameters would crash due the ```ast.Field``` being nil . 

``` odin
Val :: struct(v: int) {}

main :: proc() {
	val := Val(35, 36){}
}
```
* Having parentheses on a struct with no poly_params would crash due to the ```ast.Field_List``` being nil.

``` odin
Tst :: struct {}

main :: proc() {
	 tst := Tst(){}
}
```

To fix these issues I added some checks that continue if there is a nil pointer.