### PR TITLE
Add support for Any type

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1907,6 +1907,14 @@ resolve_selector_expression :: proc(ast_context: ^AstContext, node: ^ast.Selecto
 			}
 		case SymbolBasicValue:
 			if s.ident != nil && node.field != nil {
+				if selector.name == "any" {
+					ident := new_type(ast.Ident, s.ident.pos, s.ident.end, context.temp_allocator)
+					ident.name = node.field.name == "id" ? "typeid" : "rawptr"
+					basic_sym := make_symbol_basic_type_from_ast(ast_context, ident)
+					basic_sym.type = .Field
+					basic_sym.flags = {.Mutable}
+					return basic_sym, true
+				}
 				if symbol, ok := resolve_field_access_through_imported_alias(ast_context, s.ident, node); ok {
 					return symbol, true
 				}

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1032,6 +1032,28 @@ get_selector_completion :: proc(
 		append_magic_map_completion(position_context, selector, results)
 
 	case SymbolBasicValue:
+		if selector.name == "any" {
+			append(
+				results,
+				CompletionResult {
+					completion_item = CompletionItem {
+						label = "data",
+						kind = .Field,
+						detail = fmt.tprintf("%v.data", selector.name),
+					},
+				},
+			)
+			append(
+				results,
+				CompletionResult {
+					completion_item = CompletionItem {
+						label = "id",
+						kind = .Field,
+						detail = fmt.tprintf("%v.id", selector.name),
+					},
+				},
+			)
+		}
 		if selector.signature == "string" {
 			append_magic_array_like_completion(position_context, selector, results)
 		}

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -401,6 +401,18 @@ get_hover_information :: proc(document: ^Document, position: common.Position) ->
 					return hover, true, true
 				}
 			}
+		case SymbolBasicValue:
+			if selector.name == "any" {
+				name := field == "id" ? "typeid" : "rawptr"
+				symbol := Symbol {
+					name      = name,
+					pkg       = selector.pkg,
+					signature = name,
+					type      = .Field,
+				}
+				hover.contents = write_hover_content(&ast_context, symbol)
+				return hover, true, true
+			}
 		}
 	} else if position_context.implicit_selector_expr != nil {
 		implicit_selector := position_context.implicit_selector_expr


### PR DESCRIPTION
Adds hover and completion support for the any type.

* Hover
<img width="256" height="144" alt="left_id" src="https://github.com/user-attachments/assets/c4636c29-943b-4ff8-9ead-1ee62dc4857e" />
<img width="253" height="146" alt="right_id" src="https://github.com/user-attachments/assets/b9395dda-0cae-46ff-8328-1f7e245024bd" />

* Completion
<img width="285" height="129" alt="comple" src="https://github.com/user-attachments/assets/0ff07fda-958e-4e28-8b8c-378f951ca538" />

