### PR TITLE
Fix resolving proc groups with using

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1082,6 +1082,7 @@ resolve_function_overload :: proc(ast_context: ^AstContext, group: ^ast.Proc_Gro
 									if is_symbol_same_typed(ast_context, symbol, arg_symbol, proc_arg.flags) {
 										using_score = min(k, using_score)
 										found = true
+										continue
 									}
 
 									// foo :: proc (bar: ^Bar)      — level 1 (arg_symbol)

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -1074,12 +1074,23 @@ resolve_function_overload :: proc(ast_context: ^AstContext, group: ^ast.Proc_Gro
 							if value, ok := call_arg.symbol.value.(SymbolStructValue); ok {
 								using_score := 1000000
 								for k in value.usings {
-									if symbol, ok := resolve_type_expression(ast_context, value.types[k]); ok {
+									symbol := resolve_type_expression(ast_context, value.types[k]) or_continue
+
+									// foo :: proc (bar: ^Bar)       — level 1 (arg_symbol)
+									// baz: struct {using bar: ^Bar} — level 1 (symbol)
+									// foo(&baz)                     — level 1 (call_arg.symbol)
+									if is_symbol_same_typed(ast_context, symbol, arg_symbol, proc_arg.flags) {
+										using_score = min(k, using_score)
+										found = true
+									}
+
+									// foo :: proc (bar: ^Bar)      — level 1 (arg_symbol)
+									// baz: struct {using bar: Bar} — level 0 (symbol)
+									// foo(&baz)                    — level 1 (call_arg.symbol)
+									if call_arg.symbol.pointers != symbol.pointers {
 										symbol.pointers = call_arg.symbol.pointers
 										if is_symbol_same_typed(ast_context, symbol, arg_symbol, proc_arg.flags) {
-											if k < using_score {
-												using_score = k
-											}
+											using_score = min(k, using_score)
 											found = true
 										}
 									}

--- a/tests/hover_test.odin
+++ b/tests/hover_test.odin
@@ -2804,6 +2804,30 @@ ast_hover_overloading_struct_with_usings_with_pointers :: proc(t: ^testing.T) {
 }
 
 @(test)
+ast_hover_proc_group_with_using_pointer :: proc(t: ^testing.T) {
+	source := test.Source {
+		main     = `package test
+
+		Nested :: struct {foo: int}
+		Inner  :: struct {using nested: Nested}
+		Outer  :: struct {using inner: Inner}
+
+		takes_int    :: proc (arg: int)       {}
+		takes_nested :: proc (nested: Nested) {}
+		takes_inner  :: proc (inner: Inner)   {}
+		takes        :: proc {takes_int, takes_nested, takes_inner}
+
+		main :: proc() {
+			outer: ^Outer
+			ta{*}kes(outer)
+		}
+		`,
+		packages = {},
+	}
+	test.expect_hover(t, &source, "test.takes :: proc(inner: Inner)")
+}
+
+@(test)
 ast_hover_proc_calling_convention :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test


### PR DESCRIPTION
fixes #1569

A `symbol.pointers = call_arg.symbol.pointers` hack was added in 931bb7c8 to solve the case where param type and field type pointer levels didn't match.
But it broke the case where they do match.
This adds another hack to make it work.