### PR TITLE
Fix composite literal `return` in single statement case

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -1258,7 +1258,7 @@ visit_stmt :: proc(
 			if is_return_stmt_ending_with_comp_lit_expr(v.results) {
 				document = cons(
 					document,
-					if_break_or_document(empty(), text(" ")),
+					text(" "),
 					visit_exprs(p, v.results, {.Add_Comma}),
 				)
 			} else if !is_return_stmt_ending_with_call_expr(v.results) {

--- a/tools/odinfmt/tests/single_line_switch/.snapshots/returns.odin
+++ b/tools/odinfmt/tests/single_line_switch/.snapshots/returns.odin
@@ -1,0 +1,21 @@
+package single_line_switch
+
+return_inline_literal :: proc() -> i8 {
+	switch {
+	case: return i8{}
+	}
+}
+
+T :: [4]u64
+
+return_multiline_literal :: proc() -> T {
+	switch {
+	case:
+		return T {
+				11111111111111111111,
+				2222222222222222222,
+				3333333333333333333,
+				4444444444444444444,
+			}
+	}
+}

--- a/tools/odinfmt/tests/single_line_switch/returns.odin
+++ b/tools/odinfmt/tests/single_line_switch/returns.odin
@@ -1,0 +1,21 @@
+package single_line_switch
+
+return_inline_literal :: proc() -> i8 {
+	switch {
+	case: 
+		return i8{}
+	}
+}
+
+T :: [4]u64
+
+return_multiline_literal :: proc() -> T {
+	switch {
+	case: return T{
+		11111111111111111111,
+		2222222222222222222,
+		3333333333333333333,
+		4444444444444444444,
+	}
+	}
+}


### PR DESCRIPTION
fixes https://github.com/DanielGavin/ols/issues/1255

Fix formatting of composite literal returns when a single-statement case wraps.

```odin
case:
   return i8{}
```

now formats as:

```odin
case: return i8{}
```
