### PR TITLE
Distinct types failed to autocomplete

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -2242,7 +2242,7 @@ resolve_identifier_expr :: proc(
 
 	#partial switch v in expr.derived {
 	case ^ast.Distinct_Type:
-		symbol, ok = resolve_identifier_expr(ast_context, v.type, orig_expr, node, name, attributes, is_mutable)
+		symbol, ok = resolve_identifier_expr(ast_context, v.type, v.type, node, name, attributes, is_mutable)
 		symbol.name = name
 		symbol.flags |= {.Distinct}
 	case ^ast.Ident:

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -6004,3 +6004,31 @@ ast_completion_const_value_in_struct_decl :: proc(t: ^testing.T) {
 
 	test.expect_completion_docs(t, &source, "", {"test.Foo :: struct{}"}, {"test.FOO :: 8"})
 }
+
+@(test)
+ast_distinct_selector_array_swizzle_completion :: proc(t: ^testing.T) {
+	packages := make([dynamic]test.Package, context.temp_allocator)
+
+	append(
+		&packages,
+		test.Package{pkg = "mypkg", source = `package mypkg
+			Vector4f32 :: [4]f32
+		`},
+	)
+
+	source := test.Source {
+		main     = `package main
+		import "mypkg"
+
+		Pixel :: distinct mypkg.Vector4f32
+
+		main :: proc() {
+			p: Pixel
+			p.{*}
+		}
+		`,
+		packages = packages[:],
+	}
+
+	test.expect_completion_labels(t, &source, ".", {"x", "y", "z", "w", "r", "g", "b", "a"})
+}


### PR DESCRIPTION
checker: v.type as orig_expr on distinct recursion

Distinct types wrapping a package alias (example: `distinct linalg.Vector4f32`) failed to autocomplete. 
`Selector_Expr` falls through to a default case that resolved the stale outer `Distinct_Type` node instead of the unwrapped type. `internal_resolve_type_expression` has no case for `Distinct_Type` at all, so it just fails silently.

Regression test is added to cover this case.

Noticed this immediately when trying to work with and trying to use any .xyzw 
`Pixel :: distinct linalg.Vector4f32`