### PR TITLE
This feature makes possible to align constants

### DIFF
--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -85,6 +85,11 @@
 			"type": "boolean",
 			"default": false,
 			"description": "Align the struct declaration symbol in struct fields so they all start at the same column"
+		},
+		"align_constant_definitions": {
+			"type": "boolean",
+			"default": false,
+			"description": "Align the :: or : of consecutive constant declarations so they all start at the same column. Constants separated by a blank line form separate alignment groups. Constants with type annotations are aligned separately from those without."
 		}
 	},
 	"required": []

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -29,6 +29,7 @@ Printer :: struct {
 	force_statement_fit:  bool,
 	src:                  string,
 	errored_out:          bool,
+	constant_alignment:   map[int]int,
 }
 
 Disabled_Info :: struct {
@@ -39,22 +40,23 @@ Disabled_Info :: struct {
 }
 
 Config :: struct {
-	character_width:           int,
-	spaces:                    int, //Spaces per indentation
-	newline_limit:             int, //The limit of newlines between statements and declarations.
-	tabs:                      bool, //Enable or disable tabs
-	tabs_width:                int,
-	convert_do:                bool, //Convert all do statements to brace blocks
-	brace_style:               Brace_Style,
-	indent_cases:              bool,
-	newline_style:             Newline_Style,
-	sort_imports:              bool,
-	inline_single_stmt_case:   bool,
-	spaces_around_colons:      bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
-	space_single_line_blocks:  bool,
-	align_struct_fields:       bool,
-	align_struct_values:       bool,
-	align_struct_declarations: bool,
+	character_width:            int,
+	spaces:                     int, //Spaces per indentation
+	newline_limit:              int, //The limit of newlines between statements and declarations.
+	tabs:                       bool, //Enable or disable tabs
+	tabs_width:                 int,
+	convert_do:                 bool, //Convert all do statements to brace blocks
+	brace_style:                Brace_Style,
+	indent_cases:               bool,
+	newline_style:              Newline_Style,
+	sort_imports:               bool,
+	inline_single_stmt_case:    bool,
+	spaces_around_colons:       bool, //Put spaces to the left of a colon as well as the right. `foo: bar` => `foo : bar`
+	space_single_line_blocks:   bool,
+	align_struct_fields:        bool,
+	align_struct_values:        bool,
+	align_struct_declarations:  bool,
+	align_constant_definitions: bool,
 }
 
 Brace_Style :: enum {
@@ -93,42 +95,110 @@ Line_Suffix_Option :: enum {
 
 when ODIN_OS == .Windows {
 	default_style := Config {
-		spaces                    = 4,
-		newline_limit             = 2,
-		convert_do                = false,
-		tabs                      = true,
-		tabs_width                = 4,
-		brace_style               = ._1TBS,
-		indent_cases              = false,
-		newline_style             = .CRLF,
-		character_width           = 100,
-		sort_imports              = true,
-		spaces_around_colons      = false,
-		align_struct_fields       = true,
-		align_struct_values       = true,
-		align_struct_declarations = false,
+		spaces                     = 4,
+		newline_limit              = 2,
+		convert_do                 = false,
+		tabs                       = true,
+		tabs_width                 = 4,
+		brace_style                = ._1TBS,
+		indent_cases               = false,
+		newline_style              = .CRLF,
+		character_width            = 100,
+		sort_imports               = true,
+		spaces_around_colons       = false,
+		align_struct_fields        = true,
+		align_struct_values        = true,
+		align_struct_declarations  = false,
+		align_constant_definitions = false,
 	}
 } else {
 	default_style := Config {
-		spaces                    = 4,
-		newline_limit             = 2,
-		convert_do                = false,
-		tabs                      = true,
-		tabs_width                = 4,
-		brace_style               = ._1TBS,
-		indent_cases              = false,
-		newline_style             = .LF,
-		character_width           = 100,
-		sort_imports              = true,
-		spaces_around_colons      = false,
-		align_struct_fields       = true,
-		align_struct_values       = true,
-		align_struct_declarations = false,
+		spaces                     = 4,
+		newline_limit              = 2,
+		convert_do                 = false,
+		tabs                       = true,
+		tabs_width                 = 4,
+		brace_style                = ._1TBS,
+		indent_cases               = false,
+		newline_style              = .LF,
+		character_width            = 100,
+		sort_imports               = true,
+		spaces_around_colons       = false,
+		align_struct_fields        = true,
+		align_struct_values        = true,
+		align_struct_declarations  = false,
+		align_constant_definitions = false,
 	}
 }
 
 make_printer :: proc(config: Config, allocator := context.allocator) -> Printer {
 	return {config = config, allocator = allocator}
+}
+
+// Width of a constant's name as it'll render, counting "using " and the ", "
+// between multiple names.
+@(private)
+get_constant_name_width :: proc(v: ^ast.Value_Decl) -> int {
+	width := v.is_using ? 6 : 0 // "using "
+	for name, i in v.names {
+		width += get_node_length(name)
+		if i < len(v.names) - 1 {
+			width += 2 // ", "
+		}
+	}
+	return width
+}
+
+// Figures out how much padding each constant needs so consecutive ones line up
+// their :: or :. A blank line or a change in type annotation starts a new group,
+// since :: and : don't share an alignment point.
+@(private)
+compute_constant_alignment :: proc(p: ^Printer, decls: []^ast.Stmt) {
+	i := 0
+	for i < len(decls) {
+		decl := cast(^ast.Decl)decls[i]
+		v, ok := decl.derived.(^ast.Value_Decl)
+		// Mutable decls use :=, not ::, so they're not constants
+		if !ok || v.is_mutable {
+			i += 1
+			continue
+		}
+
+		has_type := v.type != nil
+		group_start := i
+		max_width := get_constant_name_width(v)
+
+		j := i + 1
+		for j < len(decls) {
+			next := cast(^ast.Decl)decls[j]
+			nv, is_value := next.derived.(^ast.Value_Decl)
+			if !is_value || nv.is_mutable {
+				break
+			}
+			// Different type annotation means a different alignment point
+			if (nv.type != nil) != has_type {
+				break
+			}
+			// Stop at blank lines
+			prev := cast(^ast.Decl)decls[j - 1]
+			if next.pos.line > prev.end.line + 1 {
+				break
+			}
+			max_width = max(max_width, get_constant_name_width(nv))
+			j += 1
+		}
+
+		// A lone constant doesn't need alignment
+		if j > group_start + 1 {
+			for k := group_start; k < j; k += 1 {
+				kd := cast(^ast.Decl)decls[k]
+				kv := kd.derived.(^ast.Value_Decl)
+				p.constant_alignment[kd.pos.offset] = max_width - get_constant_name_width(kv)
+			}
+		}
+
+		i = j
+	}
 }
 
 
@@ -219,6 +289,10 @@ print_file :: proc(p: ^Printer, file: ^ast.File) -> string {
 	}
 
 	build_disabled_lines_info(p)
+
+	if p.config.align_constant_definitions {
+		compute_constant_alignment(p, file.decls[:])
+	}
 
 	p.source_position.line = 1
 	p.source_position.column = 1

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -318,11 +318,17 @@ visit_decl :: proc(p: ^Printer, decl: ^ast.Decl, called_in_stmt := false) -> ^Do
 		lhs = cons(lhs, visit_exprs(p, v.names, {.Add_Comma, .Glue}))
 
 		if v.type != nil {
-			lhs = cons(lhs, text(" :" if p.config.spaces_around_colons else ":"))
+			// Typed constant/variable: pad before the colon so it lines up
+			type_colon := text(" :" if p.config.spaces_around_colons else ":")
+			padding := p.constant_alignment[decl.pos.offset]
+			lhs = cons(lhs, repeat_space(padding), type_colon)
 			lhs = cons_with_nopl(lhs, visit_expr(p, v.type))
 		} else {
 			if !v.is_mutable {
-				lhs = cons_with_nopl(lhs, cons(text(":"), text(":")))
+				// Constant (::): pad before the colons so it lines up
+				double_colon := cons(text(":"), text(":"))
+				padding := p.constant_alignment[decl.pos.offset]
+				lhs = cons_with_nopl(lhs, cons(repeat_space(padding), double_colon))
 			} else {
 				lhs = cons_with_nopl(lhs, text(":"))
 			}

--- a/tools/odinfmt/tests/constant_align/.snapshots/constant_align.odin
+++ b/tools/odinfmt/tests/constant_align/.snapshots/constant_align.odin
@@ -1,0 +1,36 @@
+package odinfmt_test
+
+// Basic constant alignment
+SCREEN_WIDTH  :: 800
+SCREEN_HEIGHT :: 450
+
+// Separate group after blank line
+PLAYER_POS_X :: 10
+PLAYER_POS_Y :: 100
+
+// Mixed: mutable and constant should not be grouped
+x := 10
+Y :: 20
+z := 30
+
+// Single constant (no alignment needed)
+LONELY :: 42
+
+// Constants with varying name lengths
+A                       :: 1
+VERY_LONG_CONSTANT_NAME :: 2
+B                       :: 3
+
+// Type-annotated constants should be aligned with each other
+TYPED_CONST  : int : 100
+ANOTHER_TYPED: int : 200
+
+// Mixed: typed and non-typed should not be aligned together
+X :: 10
+Y: int : 20
+Z :: 30
+
+// Type-annotated constants with varying name lengths
+SHORT         : int : 1
+VERY_LONG_NAME: int : 2
+MEDIUM        : int : 3

--- a/tools/odinfmt/tests/constant_align/constant_align.odin
+++ b/tools/odinfmt/tests/constant_align/constant_align.odin
@@ -1,0 +1,36 @@
+package odinfmt_test
+
+// Basic constant alignment
+SCREEN_WIDTH :: 800
+SCREEN_HEIGHT :: 450
+
+// Separate group after blank line
+PLAYER_POS_X :: 10
+PLAYER_POS_Y :: 100
+
+// Mixed: mutable and constant should not be grouped
+x := 10
+Y :: 20
+z := 30
+
+// Single constant (no alignment needed)
+LONELY :: 42
+
+// Constants with varying name lengths
+A :: 1
+VERY_LONG_CONSTANT_NAME :: 2
+B :: 3
+
+// Type-annotated constants should be aligned with each other
+TYPED_CONST : int : 100
+ANOTHER_TYPED : int : 200
+
+// Mixed: typed and non-typed should not be aligned together
+X :: 10
+Y : int : 20
+Z :: 30
+
+// Type-annotated constants with varying name lengths
+SHORT : int : 1
+VERY_LONG_NAME : int : 2
+MEDIUM : int : 3

--- a/tools/odinfmt/tests/constant_align/odinfmt.json
+++ b/tools/odinfmt/tests/constant_align/odinfmt.json
@@ -1,0 +1,3 @@
+{
+	"align_constant_definitions": true
+}


### PR DESCRIPTION
For instance:

```odin
package odinfmt_test

// Basic constant alignment
SCREEN_WIDTH :: 800
SCREEN_HEIGHT :: 450

// Separate group after blank line
PLAYER_POS_X :: 10
PLAYER_POS_Y :: 100

// Mixed: mutable and constant should not be grouped
x := 10
Y :: 20
z := 30

// Single constant (no alignment needed)
LONELY :: 42

// Constants with varying name lengths
A :: 1
VERY_LONG_CONSTANT_NAME :: 2
B :: 3

// Type-annotated constants should be aligned with each other
TYPED_CONST : int : 100
ANOTHER_TYPED : int : 200

// Mixed: typed and non-typed should not be aligned together
X :: 10
Y : int : 20
Z :: 30

// Type-annotated constants with varying name lengths
SHORT : int : 1
VERY_LONG_NAME : int : 2
MEDIUM : int : 3
```

Formats to:

```odin
package odinfmt_test

// Basic constant alignment
SCREEN_WIDTH  :: 800
SCREEN_HEIGHT :: 450

// Separate group after blank line
PLAYER_POS_X :: 10
PLAYER_POS_Y :: 100

// Mixed: mutable and constant should not be grouped
x := 10
Y :: 20
z := 30

// Single constant (no alignment needed)
LONELY :: 42

// Constants with varying name lengths
A                       :: 1
VERY_LONG_CONSTANT_NAME :: 2
B                       :: 3

// Type-annotated constants should be aligned with each other
TYPED_CONST   : int : 100
ANOTHER_TYPED : int : 200

// Mixed: typed and non-typed should not be aligned together
X :: 10
Y: int : 20
Z :: 30

// Type-annotated constants with varying name lengths
SHORT          : int : 1
VERY_LONG_NAME : int : 2
MEDIUM         : int : 3
```