### PR TITLE
Fix `expand_values` and `compress_values` variadics

### DIFF
--- a/builtin/builtin.odin
+++ b/builtin/builtin.odin
@@ -6,8 +6,8 @@ package ols_builtin
 @builtin len :: proc(array: Array_Type) -> int ---
 @builtin cap :: proc(array: Array_Type) -> int ---
 
-@builtin expand_values   :: proc(value: Struct_Or_Array) -> (A, B, C, ...) ---
-@builtin compress_values :: proc(values: ...) -> Struct_Or_Array_Like_Type ---
+@builtin expand_values   :: proc(value: Struct_Or_Array) -> (A, B, C, ..) ---
+@builtin compress_values :: proc(values: ..) -> Struct_Or_Array_Like_Type ---
 
 @builtin size_of      :: proc($T: typeid) -> int ---
 @builtin align_of     :: proc($T: typeid) -> int ---


### PR DESCRIPTION
I'm not entirely sure what the intention behind those builtins are, since it's just for `ols` and not valid Odin, so the bug may very well be in the parser.

Currently, whatever is immediately after `compress_values` doesn't show up in the autocomplete, in this case `size_of`.
Adding another random builtin like `snorlax` before it will make `size_of` show up (but notably not `snorlax`).

Changing `...` to `..` fixes this. I have no idea why. 

It's interesting to note that `..` is invalid Odin too, but it seems to work.