### PR TITLE
Support fake methods for using fields

### DIFF
--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -1,6 +1,5 @@
 package server
 
-import "core:log"
 import "core:fmt"
 import "core:mem"
 import "core:odin/ast"
@@ -55,13 +54,10 @@ append_method_completion :: proc(
 	}
 
 	remove_edit, ok := create_remove_edit(position_context)
-	if !ok {
-		return
-	}
+	if !ok do return
 
-	if value, ok := selector_symbol.value.(SymbolUntypedValue); ok {
-		cases := untyped_map[value.type]
-		for c in cases {
+	if value, is_untyped := selector_symbol.value.(SymbolUntypedValue); is_untyped {
+		for c in untyped_map[value.type] {
 			method := Method {
 				name = c,
 				pkg  = "$builtin", // Untyped values are always builtin types
@@ -77,14 +73,10 @@ append_method_completion :: proc(
 			)
 		}
 	} else {
-		// For typed values, check if it's a builtin type
-		method_pkg := selector_symbol.pkg
-		if is_builtin_type_name(selector_symbol.name) {
-			method_pkg = "$builtin"
-		}
 		method := Method {
 			name = selector_symbol.name,
-			pkg  = method_pkg,
+			// For typed values, check if it's a builtin type
+			pkg  = selector_symbol.pkg if !is_builtin_type_name(selector_symbol.name) else "$builtin",
 		}
 		collect_methods(
 			ast_context,
@@ -95,8 +87,28 @@ append_method_completion :: proc(
 			remove_edit,
 			results,
 		)
-	}
 
+		// Handle using fields in structs
+		if struct_value, is_struct := selector_symbol.value.(SymbolStructValue); is_struct {
+			for using_idx in struct_value.usings {
+				if using_idx >= len(struct_value.types) do continue
+
+				using_type_expr := struct_value.types[using_idx]
+				if using_type_expr == nil do continue
+
+				using_symbol := resolve_type_expression(ast_context, using_type_expr) or_continue
+
+				// Recursively collect methods for the using field's type
+				append_method_completion(
+					ast_context,
+					using_symbol,
+					position_context,
+					results,
+					receiver,
+				)
+			}
+		}
+	}
 }
 
 @(private = "file")

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -5588,6 +5588,33 @@ ast_completion_fake_method_proc_group_single_arg_cursor_position :: proc(t: ^tes
 }
 
 @(test)
+ast_completion_fake_method_using_subtype :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		import "lib"
+		main :: proc() {
+			outer: lib.Outer
+			outer.{*}
+		}
+		`,
+		packages = {
+			{
+				pkg = "lib",
+				source = `package lib
+					Inner :: struct {foo: int}
+					Outer :: struct {using inner: Inner}
+
+					takes_inner :: proc (inner: Inner) {}
+				`,
+			},
+		},
+		config = {enable_fake_method = true},
+	}
+
+	test.expect_completion_labels(t, &source, ".", {"takes_inner", "inner", "foo"})
+}
+
+@(test)
 ast_completion_fake_method_proc_alias :: proc(t: ^testing.T) {
 	source := test.Source {
 		main = `package test


### PR DESCRIPTION
fixes #1568

Looks like `append_method_completion` was missing a recursive call for fields with `using`