### PR TITLE
Improve references/definition test errors

### DIFF
--- a/src/testing/helpers.odin
+++ b/src/testing/helpers.odin
@@ -74,8 +74,9 @@ source_location_display :: proc (
 
 	max_digits := math.count_digits_of_base(end.line, 10)
 
-	it := file.source
 	line_idx := 0
+	in_location: bool
+	it := file.source
 	for line in strings.split_lines_iterator(&it) {
 		defer line_idx += 1
 
@@ -87,13 +88,23 @@ source_location_display :: proc (
 		}
 
 		// Write line number aligned to largest
-		buf: [4]byte
-		line_idx_str := strconv.write_int(buf[:], i64(line_idx), 10)
-		for _ in 0..<max_digits-len(line_idx_str) {
-			strings.write_rune(&sb, ' ')
+		{
+			if in_location {
+				strings.write_string(&sb, after)
+			}
+
+			buf: [4]byte
+			line_idx_str := strconv.write_int(buf[:], i64(line_idx), 10)
+			for _ in 0..<max_digits-len(line_idx_str) {
+				strings.write_rune(&sb, ' ')
+			}
+			strings.write_string(&sb, line_idx_str)
+			strings.write_rune(&sb, '|')
+
+			if in_location {
+				strings.write_string(&sb, before)
+			}
 		}
-		strings.write_string(&sb, line_idx_str)
-		strings.write_rune(&sb, '|')
 
 		if start.line > line_idx { // before but include
 			// Write line
@@ -104,18 +115,29 @@ source_location_display :: proc (
 
 		// Write line with colored location
 		for ch, i in line {
-			if i == start.character {
+			if !in_location && start.line == line_idx && i == start.character {
+				in_location = true
 				strings.write_string(&sb, before)
 			}
 
 			strings.write_rune(&sb, ch)
 
-			if i == end.character-1 {
+			if in_location && end.line == line_idx && i == end.character-1 {
+				in_location = false
 				strings.write_string(&sb, after)
 			}
 		}
 
+		if in_location && line_idx >= end.line {
+			in_location = false
+			strings.write_string(&sb, after)
+		}
+
 		strings.write_rune(&sb, '\n')
+	}
+
+	if in_location {
+		strings.write_string(&sb, after)
 	}
 
 	return strings.to_string(sb)
@@ -124,7 +146,7 @@ source_location_display :: proc (
 compare_expected_slice_set :: proc (
 	actual, expected: []$T,
 	excluded: []T = nil,
-	equals: proc (a, b: T) -> bool,
+	equals: proc (a, e: T) -> bool,
 	allocator := context.allocator,
 ) -> (
 	extra_expected: []int,

--- a/src/testing/helpers.odin
+++ b/src/testing/helpers.odin
@@ -1,0 +1,175 @@
+package ols_testing
+
+import "core:terminal/ansi"
+import "core:math"
+import "core:strconv"
+import "core:strings"
+import "src:common"
+
+uri_to_path :: proc (uri: string, allocator := context.allocator) -> string {
+	path := common.uri_to_path(uri, context.temp_allocator)
+	path = strings.trim_prefix(path, "test/")
+	return path
+}
+
+find_source_file_by_path :: proc (src: Source, path: string) -> (File, bool) {
+
+	for file in src.files {
+		if path == file.name do return file, true
+	}
+
+	for pkg in src.packages {
+		for file in pkg.files {
+			if path == file.name do return file, true
+		}
+	}
+
+	return {}, false
+}
+
+ANSI_RESET    :: ansi.CSI + ansi.RESET + ansi.SGR
+ANSI_WHITE_BG :: ansi.CSI + ansi.BG_WHITE + ";" + ansi.FG_BLACK + ";" + ansi.BOLD + ansi.SGR
+ANSI_RED_BG   :: ansi.CSI + ansi.BG_RED   + ";" + ansi.FG_BLACK + ";" + ansi.BOLD + ansi.SGR
+ANSI_GREEN_BG :: ansi.CSI + ansi.BG_GREEN + ";" + ansi.FG_BLACK + ";" + ansi.BOLD + ansi.SGR
+
+source_location_display :: proc (
+	src:      Source,
+	location: common.Location,
+	before    := ANSI_WHITE_BG,
+	after     := ANSI_RESET,
+	allocator := context.allocator,
+) -> string {
+
+	TAB :: "    "
+	LINES_BEFORE :: 2
+
+	start, end := **location.range
+	path := uri_to_path(location.uri, context.temp_allocator)
+
+	sb := strings.builder_make(allocator)
+
+	// Write location path as `uri/path(start_line:start_col-end_line:end_col)`
+	{
+		strings.write_string(&sb, path)
+		strings.write_rune(&sb, '(')
+		strings.write_int(&sb, start.line)
+		strings.write_rune(&sb, ':')
+		strings.write_int(&sb, start.character)
+		strings.write_rune(&sb, '-')
+		strings.write_int(&sb, end.line)
+		strings.write_rune(&sb, ':')
+		strings.write_int(&sb, end.character)
+		strings.write_rune(&sb, ')')
+	}
+
+	// Write source lines around the location
+	// with location highlighted by the `before` and `after` strings
+
+	file, found_file := find_source_file_by_path(src, path)
+	if !found_file {
+		return strings.to_string(sb)
+	}
+
+	strings.write_rune(&sb, '\n')
+
+	max_digits := math.count_digits_of_base(end.line, 10)
+
+	it := file.source
+	line_idx := 0
+	for line in strings.split_lines_iterator(&it) {
+		defer line_idx += 1
+
+		if start.line - line_idx > LINES_BEFORE {
+			continue // before
+		}
+		if line_idx > end.line {
+			break // after
+		}
+
+		// Write line number aligned to largest
+		buf: [4]byte
+		line_idx_str := strconv.write_int(buf[:], i64(line_idx), 10)
+		for _ in 0..<max_digits-len(line_idx_str) {
+			strings.write_rune(&sb, ' ')
+		}
+		strings.write_string(&sb, line_idx_str)
+		strings.write_rune(&sb, '|')
+
+		if start.line > line_idx { // before but include
+			// Write line
+			strings.write_string(&sb, line)
+			strings.write_rune(&sb, '\n')
+			continue
+		}
+
+		// Write line with colored location
+		for ch, i in line {
+			if i == start.character {
+				strings.write_string(&sb, before)
+			}
+
+			strings.write_rune(&sb, ch)
+
+			if i == end.character-1 {
+				strings.write_string(&sb, after)
+			}
+		}
+
+		strings.write_rune(&sb, '\n')
+	}
+
+	return strings.to_string(sb)
+}
+
+compare_expected_slice_set :: proc (
+	actual, expected: []$T,
+	excluded: []T = nil,
+	equals: proc (a, b: T) -> bool,
+	allocator := context.allocator,
+) -> (
+	extra_expected: []int,
+	extra_actual:   []int,
+	all_good:       bool,
+) {
+	all_good = true
+
+	extra_expected_dyn := make([dynamic]int, allocator)
+	extra_actual_dyn   := make([dynamic]int, allocator)
+
+	defer shrink(&extra_expected_dyn)
+	defer shrink(&extra_actual_dyn)
+
+	found_expected := make([]bool, len(expected), context.temp_allocator)
+
+	actual_loop: for a, ai in actual {
+
+		if excluded != nil do for e, ei in excluded {
+			if equals(a, e) {
+				append(&extra_actual_dyn, ai)
+				all_good = false
+				continue actual_loop
+			}
+		}
+
+		for e, ei in expected {
+			if !found_expected[ei] && equals(a, e) {
+				found_expected[ei] = true
+				continue actual_loop
+			}
+		}
+
+		append(&extra_actual_dyn, ai)
+		all_good = false
+	}
+
+	for _, ei in expected {
+		if found_expected[ei] {
+			continue
+		}
+		append(&extra_expected_dyn, ei)
+	}
+
+	extra_expected = extra_expected_dyn[:]
+	extra_actual   = extra_actual_dyn[:]
+	return
+}

--- a/src/testing/helpers.odin
+++ b/src/testing/helpers.odin
@@ -188,6 +188,7 @@ compare_expected_slice_set :: proc (
 		if found_expected[ei] {
 			continue
 		}
+		all_good = false
 		append(&extra_expected_dyn, ei)
 	}
 

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -591,7 +591,6 @@ expect_reference_locations :: proc(
 	t: ^testing.T,
 	src: ^Source,
 	expect_locations: []common.Location,
-	expect_excluded: []common.Location = nil,
 	include_declaration := true,
 ) {
 	cursor := source_remove_cursor(src)
@@ -599,35 +598,43 @@ expect_reference_locations :: proc(
 	setup(src)
 	defer teardown(src)
 
-	locations, ok := server.get_references(src.document, cursor, include_declaration = include_declaration)
+	locations, got_references := server.get_references(src.document, cursor, include_declaration = include_declaration)
+	if !got_references && len(expect_locations) > 0 {
+		log.error("No references found.")
+		return
+	}
 
-	for expect_location in expect_locations {
-		match := false
-		for location in locations {
-			if location.range == expect_location.range {
-				match = true
+	extra_expected, extra_locations, all_good := compare_expected_slice_set(locations, expect_locations,
+	                                                                        equals = proc (a, b: common.Location) -> bool {return a.range == b.range})
+	if all_good do return
+
+	sb := strings.builder_make()
+
+	if len(extra_expected) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_expected))
+		strings.write_string(&sb,  " Reference(s) expected but not reported:\n")
+		for i in extra_expected {
+			loc := expect_locations[i]
+			if loc.uri == "" {
+				loc.uri = "test/main.odin"
 			}
-		}
-		if !match {
-			ok = false
-			log.errorf("Failed to match with location: %v", expect_location)
+			strings.write_string(&sb,
+				source_location_display(src^, loc, before=ANSI_RED_BG))
 		}
 	}
 
-	if !ok {
-		log.error("Received:")
-		for location in locations {
-			log.errorf("%v \n", location)
+	if len(extra_locations) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_locations))
+		strings.write_string(&sb,  " Reference(s) reported but not expected:\n")
+		for i in extra_locations {
+			strings.write_string(&sb,
+				source_location_display(src^, locations[i], before=ANSI_GREEN_BG))
 		}
 	}
 
-	for expect_exclude in expect_excluded {
-		for location in locations {
-			if expect_exclude.range == location.range {
-				log.errorf("Expected location %v to not be included\n", expect_exclude)
-			}
-		}
-	}
+	log.error(strings.to_string(sb))
 }
 
 expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: common.Range) {

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -520,30 +520,51 @@ expect_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_location
 	defer teardown(src)
 
 	locations, ok := server.get_definition_location(src.document, cursor, &src.config)
-
-	if !ok {
-		log.error("Failed get_definition_location")
+	if !ok && len(expect_locations) > 0 {
+		log.error("No definitions found.")
+		return
 	}
 
-	if len(expect_locations) == 0 && len(locations) > 0 {
-		log.errorf("Expected empty locations, but received %v", locations)
-	}
-
-	flags := make([]int, len(expect_locations), context.temp_allocator)
-
-	for expect_location, i in expect_locations {
-		for location, j in locations {
-			if location.range == expect_location.range {
-				flags[i] += 1
+	extra_expected, extra_locations, all_good := compare_expected_slice_set(
+		locations, expect_locations, equals = proc (a, e: common.Location) -> bool {
+			if e.uri != "" {
+				if a.range == e.range && a.uri == e.uri {
+					return true
+				}
+			} else if a.range == e.range {
+				return true
 			}
+			return false
+	})
+	if all_good do return
+
+	sb := strings.builder_make()
+
+	if len(extra_expected) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_expected))
+		strings.write_string(&sb,  " Definition(s) expected but not reported:\n")
+		for i in extra_expected {
+			loc := expect_locations[i]
+			if loc.uri == "" {
+				loc.uri = "test/main.odin"
+			}
+			strings.write_string(&sb,
+				source_location_display(src^, loc, before=ANSI_RED_BG))
 		}
 	}
 
-	for flag, i in flags {
-		if flag != 1 {
-			log.errorf("Expected location %v, but received %v", expect_locations[i].range, locations)
+	if len(extra_locations) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_locations))
+		strings.write_string(&sb,  " Definition(s) reported but not expected:\n")
+		for i in extra_locations {
+			strings.write_string(&sb,
+				source_location_display(src^, locations[i], before=ANSI_GREEN_BG))
 		}
 	}
+
+	log.error(strings.to_string(sb))
 }
 
 expect_type_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_locations: []common.Location) {
@@ -553,38 +574,51 @@ expect_type_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_loc
 	defer teardown(src)
 
 	locations, ok := server.get_type_definition_locations(src.document, cursor)
-
-	if !ok {
-		log.error("Failed get_definition_location")
+	if !ok && len(expect_locations) > 0 {
+		log.error("No type definitions found.")
+		return
 	}
 
-	if len(expect_locations) == 0 && len(locations) > 0 {
-		log.errorf("Expected empty locations, but received %v", locations)
-	}
-
-	flags := make([]int, len(expect_locations), context.temp_allocator)
-
-	for expect_location, i in expect_locations {
-		for location, j in locations {
-			if expect_location.uri != "" {
-				if location.range == expect_location.range && location.uri == expect_location.uri {
-					flags[i] += 1
+	extra_expected, extra_locations, all_good := compare_expected_slice_set(
+		locations, expect_locations, equals = proc (a, e: common.Location) -> bool {
+			if e.uri != "" {
+				if a.range == e.range && a.uri == e.uri {
+					return true
 				}
-			} else if location.range == expect_location.range {
-				flags[i] += 1
+			} else if a.range == e.range {
+				return true
 			}
+			return false
+	})
+	if all_good do return
+
+	sb := strings.builder_make()
+
+	if len(extra_expected) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_expected))
+		strings.write_string(&sb,  " Type definition(s) expected but not reported:\n")
+		for i in extra_expected {
+			loc := expect_locations[i]
+			if loc.uri == "" {
+				loc.uri = "test/main.odin"
+			}
+			strings.write_string(&sb,
+				source_location_display(src^, loc, before=ANSI_RED_BG))
 		}
 	}
 
-	for flag, i in flags {
-		if flag != 1 {
-			if expect_locations[i].uri == "" {
-				log.errorf("Expected location %v, but received %v", expect_locations[i].range, locations)
-			} else {
-				log.errorf("Expected location %v, but received %v", expect_locations[i], locations)
-			}
+	if len(extra_locations) > 0 {
+		strings.write_rune(&sb, '\n')
+		strings.write_int(&sb, len(extra_locations))
+		strings.write_string(&sb,  " Type definition(s) reported but not expected:\n")
+		for i in extra_locations {
+			strings.write_string(&sb,
+				source_location_display(src^, locations[i], before=ANSI_GREEN_BG))
 		}
 	}
+
+	log.error(strings.to_string(sb))
 }
 
 expect_reference_locations :: proc(

--- a/tests/references_test.odin
+++ b/tests/references_test.odin
@@ -115,11 +115,10 @@ reference_variables_in_function_parameters :: proc(t: ^testing.T) {
 		`,
 	}
 
-	test.expect_reference_locations(
-		t,
-		&source,
-		{{range = {start = {line = 1, character = 22}, end = {line = 1, character = 23}}}},
-	)
+	test.expect_reference_locations(t, &source, {
+		{range = {start = {line = 1, character = 22}, end = {line = 1, character = 23}}},
+		{range = {start = {line = 2, character = 8}, end = {line = 2, character = 9}}},
+	})
 }
 
 @(test)
@@ -464,7 +463,7 @@ ast_reference_variable_in_switch_case :: proc(t: ^testing.T) {
 	}
 
 	locations := []common.Location {
-		{range = {start = {line = 17, character = 4}, end = {line = 17, character = 7}}},
+		{range = {start = {line = 16, character = 4}, end = {line = 16, character = 7}}},
 		{range = {start = {line = 17, character = 4}, end = {line = 17, character = 7}}},
 	}
 
@@ -785,11 +784,8 @@ ast_reference_struct_and_enum_variant_same_name :: proc(t: ^testing.T) {
 		{range = {start = {line = 7, character = 2}, end = {line = 7, character = 5}}},
 		{range = {start = {line = 12, character = 8}, end = {line = 12, character = 11}}},
 	}
-	expect_excluded := []common.Location {
-		{range = {start = {line = 11, character = 8}, end = {line = 11, character = 11}}},
-	}
 
-	test.expect_reference_locations(t, &source, locations[:], expect_excluded)
+	test.expect_reference_locations(t, &source, locations[:])
 }
 
 @(test)
@@ -1571,11 +1567,8 @@ ast_references_should_skip_declaration :: proc(t: ^testing.T) {
 	locations := []common.Location {
 		{range = {start = {line = 4, character = 8}, end = {line = 4, character = 11}}},
 	}
-	exclude := []common.Location{
-		{range = {start = {line = 1, character = 2}, end = {line = 1, character = 5}}},
-	}
 
-	test.expect_reference_locations(t, &source, locations, exclude, include_declaration = false)
+	test.expect_reference_locations(t, &source, locations, include_declaration = false)
 }
 
 @(test)


### PR DESCRIPTION
Got annoyed with error messages and checking of references in tests while working on #1620 so I've improved them a bit:

- Adds helpers for pretty displaying `common.Location` with code lines
- Removes `expected_excluded` param from `expect_reference_locations`.
  All expected locations are required, any additional are disallowed.
- Fixes couple of bad tests due to these changes.
- Adds similar changes to `expect_definition_locations` and `expect_type_definition_locations`.

<img width="750" height="408" alt="image" src="https://github.com/user-attachments/assets/0dc67f55-38f6-40ac-b484-f9b7d7730ba1" />
