### PR TITLE
Use resolve_entire_file_cached when finding unused imports

### DIFF
--- a/src/server/imports.odin
+++ b/src/server/imports.odin
@@ -1,7 +1,6 @@
 package server
 
 import "core:fmt"
-import "core:log"
 import "core:mem"
 import "core:strings"
 
@@ -97,24 +96,15 @@ find_used_not_imported :: proc(
 }
 
 find_unused_imports :: proc(document: ^Document, allocator := context.temp_allocator) -> []Package {
-	arena: runtime.Arena
 
-	_ = runtime.arena_init(&arena, mem.Megabyte * 40, runtime.default_allocator())
-
-	defer runtime.arena_destroy(&arena)
-
-	context.allocator = runtime.arena_allocator(&arena)
-
-	symbols_and_nodes := resolve_entire_file(document)
+	file := resolve_entire_file_cached(document)
 
 	pkgs := make(map[string]struct{}, context.temp_allocator)
-
-	for _, v in symbols_and_nodes {
+	for _, v in file.symbols {
 		pkgs[v.symbol.pkg] = {}
 	}
 
 	unused := make([dynamic]Package, allocator)
-
 	for imp in document.imports {
 		if imp.base != "_" && imp.name not_in pkgs {
 			append(&unused, imp)


### PR DESCRIPTION
`resolve_entire_file_cached` is used for semantic tokens requests as full `resolve_entire_file` can be pretty heavy—takes about 100ms for a 1000 line file for me.
This uses the same in `find_unused_imports` to reduce that time for few requests when the file is the same.
Reporting seems to work just like before.