### PR TITLE
Setup spall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.exp
 *.sqlite
 *.suo
+*.spall
 *node_modules
 /ols
 /odinfmt

--- a/src/common/uri.odin
+++ b/src/common/uri.odin
@@ -7,6 +7,8 @@ import "core:strconv"
 import "core:strings"
 import "core:unicode/utf8"
 
+import "src:spall"
+
 Uri :: struct {
 	uri:         string,
 	path:        string,
@@ -31,6 +33,9 @@ parse_uri :: proc(value: string, allocator: mem.Allocator) -> (Uri, bool) {
 
 //Note(Daniel, Again some really incomplete and scuffed uri writer)
 create_uri :: proc(path: string, allocator: mem.Allocator) -> Uri {
+
+	spall.trace(#procedure, path)
+
 	path_forward, _ := filepath.replace_separators(path, '/', context.temp_allocator)
 
 	builder := strings.builder_make(allocator)

--- a/src/main.odin
+++ b/src/main.odin
@@ -8,8 +8,7 @@ import "core:thread"
 
 import "src:common"
 import "src:server"
-
-@require import "src:spall"
+import "src:spall"
 
 VERSION := #config(VERSION, "dev")
 
@@ -103,6 +102,8 @@ end :: proc() {
 }
 
 main :: proc() {
+	spall.name_thread("main")
+
 	if len(os.args) > 1 && os.args[1] == "version" {
 		fmt.println("ols version", VERSION)
 		os.exit(0)

--- a/src/main.odin
+++ b/src/main.odin
@@ -102,7 +102,7 @@ end :: proc() {
 }
 
 main :: proc() {
-	spall.name_thread("main")
+	spall.thread("main")
 
 	if len(os.args) > 1 && os.args[1] == "version" {
 		fmt.println("ols version", VERSION)

--- a/src/main.odin
+++ b/src/main.odin
@@ -1,7 +1,5 @@
 package main
 
-import "base:intrinsics"
-
 import "core:fmt"
 import "core:log"
 import "core:mem"
@@ -10,6 +8,8 @@ import "core:thread"
 
 import "src:common"
 import "src:server"
+
+@require import "src:spall"
 
 VERSION := #config(VERSION, "dev")
 

--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -13,6 +13,7 @@ import "core:strconv"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 DeferredDepth :: 35
 
@@ -1242,6 +1243,9 @@ get_proc_return_types :: proc(
 	call: ^ast.Call_Expr,
 	is_mutable: bool,
 ) -> []^ast.Expr {
+
+	spall.trace(#procedure, symbol.name)
+
 	return_types := make([dynamic]^ast.Expr, context.temp_allocator)
 	if ret, ok := check_builtin_proc_return_type(ast_context, symbol, call, is_mutable); ok {
 		appended := false
@@ -1344,6 +1348,8 @@ internal_resolve_type_expression :: proc(ast_context: ^AstContext, node: ^ast.Ex
 	if node == nil {
 		return false
 	}
+
+	spall.trace(#procedure)
 
 	//Try to prevent stack overflows and prevent indexing out of bounds.
 	if ast_context.deferred_count >= DeferredDepth {
@@ -1834,6 +1840,9 @@ resolve_soa_selector_field :: proc(
 }
 
 resolve_selector_expression :: proc(ast_context: ^AstContext, node: ^ast.Selector_Expr) -> (Symbol, bool) {
+
+	spall.trace(#procedure)
+
 	selector := Symbol{}
 	if ok := internal_resolve_type_expression(ast_context, node.expr, &selector); ok {
 		set_ast_package_from_symbol_scoped(ast_context, selector)
@@ -2089,6 +2098,9 @@ resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ident) -> (S
 }
 
 internal_resolve_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ident) -> (Symbol, bool) {
+
+	spall.trace(#procedure, node.name)
+
 	ident := node.derived.(^ast.Ident)
 	if check_node_recursion(&ast_context.recursion_map, ident) {
 		return {}, false
@@ -2240,6 +2252,8 @@ resolve_identifier_expr :: proc(
 	is_mutable:   bool,
 ) -> (symbol: Symbol, ok: bool) {
 
+	spall.trace(#procedure, node.name)
+
 	#partial switch v in expr.derived {
 	case ^ast.Distinct_Type:
 		symbol, ok = resolve_identifier_expr(ast_context, v.type, v.type, node, name, attributes, is_mutable)
@@ -2305,6 +2319,9 @@ resolve_identifier_expr :: proc(
 }
 
 resolve_local_identifier :: proc(ast_context: ^AstContext, node: ast.Ident, local: ^DocumentLocal) -> (symbol: Symbol, ok: bool) {
+
+	spall.trace(#procedure, node.name)
+
 	if local.rhs == nil {
 		return {}, false
 	}
@@ -3147,6 +3164,8 @@ resolve_location_type_identifier :: proc(ast_context: ^AstContext, node: ast.Ide
 resolve_location_identifier :: proc(ast_context: ^AstContext, node: ast.Ident) -> (Symbol, bool) {
 	symbol: Symbol
 
+	spall.trace(#procedure, node.name)
+
 	if local, ok := get_local(ast_context^, node); ok {
 		symbol.range = common.get_token_range(local.lhs, ast_context.file.src)
 		uri := common.create_uri(local.lhs.pos.file, ast_context.allocator)
@@ -3295,6 +3314,8 @@ resolve_location_comp_lit_field :: proc(
 	symbol: Symbol,
 	ok: bool,
 ) {
+	spall.trace(#procedure)
+
 	reset_ast_context(ast_context)
 
 	set_ast_package_set_scoped(ast_context, ast_context.document_package)
@@ -3332,6 +3353,8 @@ resolve_location_implicit_selector :: proc(
 	ok: bool,
 ) {
 	ok = true
+
+	spall.trace(#procedure)
 
 	reset_ast_context(ast_context)
 
@@ -3440,6 +3463,8 @@ resolve_symbol_selector :: proc(
 	Symbol,
 	bool,
 ) {
+	spall.trace(#procedure)
+
 	field: string
 	symbol := symbol
 

--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -9,6 +9,8 @@ import path "core:path/slashpath"
 import "core:strings"
 import "core:log"
 
+import "src:spall"
+
 keyword_map: map[string]struct{} = {
 	"typeid"        = {},
 	"string"        = {},
@@ -102,6 +104,12 @@ GlobalExpr :: struct {
 	deprecated: bool,
 	private:    parser.Private_Flag,
 	builtin:    bool,
+}
+
+parse_file :: proc (p: ^parser.Parser, file: ^ast.File, allocator := context.allocator) -> bool {
+	context.allocator = allocator 
+	spall.trace(#procedure, file.fullpath)
+	return parser.parse_file(p, file)
 }
 
 get_attribute_objc_type :: proc(attributes: []^ast.Attribute) -> ^ast.Expr {
@@ -556,10 +564,14 @@ collect_when_body :: proc(
 }
 
 collect_globals :: proc(file: ast.File) -> []GlobalExpr {
+
+	spall.trace(#procedure, file.fullpath)
+
 	file_tags := parser.parse_file_tags(file, context.temp_allocator)
 	if !should_collect_file(file_tags) {
 		return {}
 	}
+
 	exprs := make([dynamic]GlobalExpr, context.temp_allocator)
 	defer shrink(&exprs)
 
@@ -592,7 +604,12 @@ collect_globals :: proc(file: ast.File) -> []GlobalExpr {
 }
 
 get_ast_node_string :: proc(node: ^ast.Node, src: string) -> string {
-	return strings.trim_prefix(string(src[node.pos.offset:node.end.offset]), "$")
+	return strings.trim_prefix(src[node.pos.offset:node.end.offset], "$")
+}
+get_ast_node_string_safe :: proc(node: ^ast.Node, src: string) -> (str: string, ok: bool) #optional_ok {
+	if node.pos.offset >= len(src) do return
+	if node.end.offset >= len(src) do return
+	return get_ast_node_string(node, src), true
 }
 
 COMMENT_DELIMITER_LENGTH :: len("//")

--- a/src/server/build.odin
+++ b/src/server/build.odin
@@ -16,6 +16,7 @@ import "core:strings"
 import "core:time"
 
 import "src:common"
+import "src:spall"
 
 platform_os: map[string]struct{} = {
 	"windows" = {},
@@ -170,10 +171,14 @@ should_collect_file :: proc(file_tags: parser.File_Tags) -> bool {
 }
 
 try_build_package :: proc(pkg_name: string) {
+	spall.trace(#procedure, pkg_name)
+
 	if pkg, ok := build_cache.loaded_pkgs[pkg_name]; ok {
 		return
 	}
 	defer clear_index_cache()
+
+	spall.trace(#procedure, pkg_name)
 
 	matches, err := filepath.glob(fmt.tprintf("%v/*.odin", pkg_name), context.temp_allocator)
 
@@ -226,7 +231,7 @@ try_build_package :: proc(pkg_name: string) {
 				pkg      = pkg,
 			}
 
-			ok := parser.parse_file(&p, &file)
+			ok := parse_file(&p, &file)
 
 			if !ok {
 				if !is_ols_builtin_file(fullpath) {
@@ -288,6 +293,8 @@ index_file :: proc(uri: common.Uri, text: string) -> common.Error {
 	ok: bool
 	defer clear_index_cache()
 
+	spall.trace(#procedure, uri.path)
+
 	fullpath := uri.path
 
 	p := parser.Parser {
@@ -325,7 +332,7 @@ index_file :: proc(uri: common.Uri, text: string) -> common.Error {
 		context.allocator = context.temp_allocator
 		defer context.allocator = allocator
 
-		ok = parser.parse_file(&p, &file)
+		ok = parse_file(&p, &file)
 
 		if !ok {
 			if !is_ols_builtin_file(fullpath) {

--- a/src/server/check.odin
+++ b/src/server/check.odin
@@ -14,6 +14,7 @@ import "core:thread"
 import "core:time"
 
 import "src:common"
+import "src:spall"
 
 Json_Error :: struct {
 	type: string,
@@ -125,6 +126,8 @@ check_unused_imports :: proc(document: ^Document, config: ^common.Config) {
 	if !config.enable_unused_imports_reporting {
 		return
 	}
+
+	spall.trace(#procedure, document.fullpath)
 
 	unused_imports := find_unused_imports(document, context.temp_allocator)
 

--- a/src/server/clone.odin
+++ b/src/server/clone.odin
@@ -1,5 +1,6 @@
 package server
 
+import "core:fmt"
 import "base:intrinsics"
 
 import "core:mem"
@@ -7,6 +8,8 @@ import "core:odin/ast"
 import "core:odin/tokenizer"
 import "core:reflect"
 import "core:strings"
+
+import "src:spall"
 
 new_type :: proc($T: typeid, pos, end: tokenizer.Pos, allocator: mem.Allocator) -> ^T {
 	n, _ := mem.new(T, allocator)
@@ -66,6 +69,8 @@ clone_node :: proc(node: ^ast.Node, allocator: mem.Allocator, unique_strings: ^m
 	if node == nil {
 		return nil
 	}
+
+	spall.trace(#procedure)
 
 	size := size_of(ast.Node)
 	align := align_of(ast.Node)

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -7,6 +7,7 @@ import path "core:path/slashpath"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 SymbolCollection :: struct {
 	allocator:      mem.Allocator,
@@ -757,6 +758,9 @@ get_package_decl_doc_comment :: proc(file: ast.File, allocator := context.temp_a
 }
 
 collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: string) -> common.Error {
+
+	spall.trace(#procedure, file.fullpath)
+
 	forward, _ := filepath.replace_separators(file.fullpath, '/', context.temp_allocator)
 	directory := path.dir(forward, context.temp_allocator)
 	package_map := get_package_mapping(file, collection.config, directory)

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -15,6 +15,7 @@ import "core:strconv"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 CompletionResult :: struct {
 	symbol:          Symbol,
@@ -43,6 +44,8 @@ get_completion_list :: proc(
 	CompletionList,
 	bool,
 ) {
+	spall.trace(#procedure, document.fullpath)
+
 	list: CompletionList
 
 	position_context, ok := get_document_position_context(document, position, .Completion)
@@ -81,6 +84,9 @@ get_completion_list :: proc(
 
 	get_globals(document.ast, &ast_context)
 	get_locals(&ast_context, &position_context)
+
+	// Track own logic separately
+	spall.trace(#procedure + " self", document.fullpath)
 
 	completion_type: Completion_Type = .Identifier
 
@@ -235,6 +241,8 @@ convert_completion_results :: proc(
 	target_symbol: Maybe(Symbol),
 	config: ^common.Config,
 ) -> []CompletionItem {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	for &result in results {
 		score_completion_item(&result, ast_context.current_package)
 	}
@@ -449,6 +457,8 @@ handle_matching :: proc(
 	item: ^CompletionItem,
 	completion_type: Completion_Type,
 ) {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	should_skip :: proc(arg_symbol, result_symbol: Symbol) -> bool {
 		if v, ok := arg_symbol.value.(SymbolBasicValue); ok {
 			if v.ident.name == "any" {
@@ -555,6 +565,8 @@ handle_matching :: proc(
 
 @(private = "file")
 position_should_skip_struct_type_decl :: proc(position_context: ^DocumentPositionContext) -> bool {
+	spall.trace(#procedure)
+
 	if position_context.value_decl == nil {
 		return false
 	}
@@ -691,6 +703,8 @@ get_directive_completion :: proc(
 	position_context: ^DocumentPositionContext,
 	results: ^[dynamic]CompletionResult,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	is_incomplete := false
 
 	// Right now just return all the possible completions, but later on I should give the context specific ones
@@ -704,6 +718,7 @@ get_comp_lit_completion :: proc(
 	results: ^[dynamic]CompletionResult,
 	config: ^common.Config,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
 
 	if symbol, ok := resolve_comp_literal(ast_context, position_context); ok {
 		#partial switch v in symbol.value {
@@ -812,6 +827,8 @@ get_selector_completion :: proc(
 	results: ^[dynamic]CompletionResult,
 	config: ^common.Config,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	ast_context.current_package = ast_context.document_package
 
 	selector: Symbol
@@ -1240,6 +1257,8 @@ get_implicit_completion :: proc(
 	position_context: ^DocumentPositionContext,
 	results: ^[dynamic]CompletionResult,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	is_incomplete := false
 
 	selector: Symbol
@@ -1630,6 +1649,8 @@ get_identifier_completion :: proc(
 	results: ^[dynamic]CompletionResult,
 	config: ^common.Config,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	lookup_name := ""
 	is_incomplete := true
 
@@ -1829,6 +1850,8 @@ get_package_completion :: proc(
 	results: ^[dynamic]CompletionResult,
 	config: ^common.Config,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	is_incomplete := false
 
 	without_quotes := position_context.import_stmt.fullpath
@@ -1980,6 +2003,8 @@ get_type_switch_completion :: proc(
 	position_context: ^DocumentPositionContext,
 	results: ^[dynamic]CompletionResult,
 ) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	is_incomplete := false
 
 	used_unions := make(map[string]struct{}, 5, context.temp_allocator)

--- a/src/server/definition.odin
+++ b/src/server/definition.odin
@@ -7,12 +7,15 @@ import "core:odin/tokenizer"
 import "core:path/filepath"
 
 import "src:common"
+import "src:spall"
 
 get_all_package_file_locations :: proc(
 	document: ^Document,
 	import_decl: ^ast.Import_Decl,
 	locations: ^[dynamic]common.Location,
 ) -> bool {
+	spall.trace(#procedure, document.fullpath)
+
 	path := ""
 
 	for imp in document.imports {
@@ -35,6 +38,8 @@ get_all_package_file_locations :: proc(
 }
 
 get_definition_location :: proc(document: ^Document, position: common.Position, config: ^common.Config) -> ([]common.Location, bool) {
+	spall.trace(#procedure, document.fullpath)
+
 	locations := make([dynamic]common.Location, context.temp_allocator)
 
 	location: common.Location
@@ -172,6 +177,8 @@ try_resolve_proc_group_overload :: proc(
 	symbol: Symbol,
 	selector_expr: ^ast.Node = nil,
 ) -> Symbol {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	if position_context.call == nil {
 		return symbol
 	}

--- a/src/server/diagnostics.odin
+++ b/src/server/diagnostics.odin
@@ -5,6 +5,8 @@ import "core:slice"
 import "core:strings"
 import "core:sync"
 
+import "src:spall"
+
 DiagnosticType :: enum {
 	Syntax,
 	Unused,
@@ -16,8 +18,9 @@ diagnostic_mutex: sync.Mutex
 
 @(private = "file")
 remove_diagnostics_locked :: proc(type: DiagnosticType, uri: string) {
-	diagnostic_type := &diagnostics[type]
+	spall.trace(#procedure, uri)
 
+	diagnostic_type := &diagnostics[type]
 	if diagnostic_type == nil {
 		log.errorf("Diagnostic type did not exist: %v", type)
 		return
@@ -41,6 +44,8 @@ remove_diagnostics_locked :: proc(type: DiagnosticType, uri: string) {
 }
 
 add_diagnostics :: proc(type: DiagnosticType, uri: string, diagnostic: Diagnostic) {
+	spall.trace(#procedure, uri)
+
 	sync.lock(&diagnostic_mutex)
 	defer sync.unlock(&diagnostic_mutex)
 

--- a/src/server/document_symbols.odin
+++ b/src/server/document_symbols.odin
@@ -3,8 +3,11 @@ package server
 import "core:odin/ast"
 
 import "src:common"
+import "src:spall"
 
 get_document_symbols :: proc(document: ^Document) -> []DocumentSymbol {
+	spall.trace(#procedure, document.fullpath)
+
 	ast_context := make_ast_context(
 		document.ast,
 		document.imports,

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -7,6 +7,8 @@ import path "core:path/slashpath"
 import "core:slice"
 import "core:strings"
 
+import "src:spall"
+
 DOC_SECTION_DELIMITER :: "\n---\n" // The string separating each section of documentation
 DOC_FMT_ODIN :: "```odin\n%v\n```" // The format for wrapping odin code in a markdown codeblock
 DOC_FMT_MARKDOWN :: DOC_FMT_ODIN + DOC_SECTION_DELIMITER + "%v" // The format for presenting documentation on hover
@@ -70,6 +72,8 @@ get_signature :: proc(ast_context: ^AstContext, symbol: Symbol, depth := 0) -> s
 
 write_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, symbol: Symbol, depth := 0) {
 	pointer_prefix := repeat("^", symbol.pointers, ast_context.allocator)
+
+	spall.trace(#procedure, symbol.name)
 
 	#partial switch v in symbol.value {
 	case SymbolEnumValue:
@@ -219,6 +223,8 @@ get_short_signature :: proc(ast_context: ^AstContext, symbol: Symbol) -> string 
 }
 
 write_short_signature :: proc(sb: ^strings.Builder, ast_context: ^AstContext, symbol: Symbol) {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	pointer_prefix := repeat("^", symbol.pointers, ast_context.allocator)
 	if .Distinct in symbol.flags {
 		strings.write_string(sb, "distinct ")

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -14,6 +14,7 @@ import path "core:path/slashpath"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 ParserError :: struct {
 	message: string,
@@ -87,8 +88,8 @@ document_free_allocator :: proc(allocator: ^virtual.Arena) {
 }
 
 document_get :: proc(uri_string: string) -> ^Document {
-	uri, parsed_ok := common.parse_uri(uri_string, context.temp_allocator)
 
+	uri, parsed_ok := common.parse_uri(uri_string, context.temp_allocator)
 	if !parsed_ok {
 		return nil
 	}
@@ -116,8 +117,10 @@ document_release :: proc(document: ^Document) {
 */
 
 document_open :: proc(uri_string: string, text: string, config: ^common.Config, writer: ^Writer) -> common.Error {
-	uri, parsed_ok := common.parse_uri(uri_string, context.allocator)
 
+	spall.trace(#procedure, uri_string)
+
+	uri, parsed_ok := common.parse_uri(uri_string, context.allocator)
 	if !parsed_ok {
 		log.error("Failed to parse uri")
 		return .ParseError
@@ -203,6 +206,9 @@ document_apply_changes :: proc(
 	config: ^common.Config,
 	writer: ^Writer,
 ) -> common.Error {
+
+	spall.trace(#procedure, uri_string)
+
 	uri, parsed_ok := common.parse_uri(uri_string, context.temp_allocator)
 
 	if !parsed_ok {
@@ -310,6 +316,9 @@ document_close :: proc(uri_string: string) -> common.Error {
 }
 
 document_refresh :: proc(document: ^Document, config: ^common.Config, writer: ^Writer) -> common.Error {
+
+	spall.trace(#procedure, document.fullpath)
+
 	errors, ok := parse_document(document, config)
 
 	if !ok {
@@ -370,6 +379,9 @@ parser_error_handler :: proc(pos: tokenizer.Pos, msg: string, args: ..any) {
 }
 
 parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]ParserError, bool) {
+
+	spall.trace(#procedure, document.fullpath)
+
 	p := parser.Parser {
 		err   = parser_error_handler,
 		warn  = common.parser_warning_handler,
@@ -402,7 +414,7 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 		pkg      = pkg,
 	}
 
-	parser.parse_file(&p, &document.ast)
+	parse_file(&p, &document.ast)
 
 	parse_imports(document, config)
 
@@ -415,6 +427,9 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 }
 
 parse_imports :: proc(document: ^Document, config: ^common.Config) {
+
+	spall.trace(#procedure, document.fullpath)
+
 	imports := make([dynamic]Package)
 
 	for imp, index in document.ast.imports {

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -5,6 +5,7 @@ import "core:odin/tokenizer"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 ResolveReferenceFlag :: enum {
 	None,
@@ -30,6 +31,9 @@ resolve_ranged_file :: proc(
 	range: common.Range,
 	allocator := context.allocator,
 ) -> map[uintptr]SymbolAndNode {
+
+	spall.trace(#procedure, document.fullpath)
+
 	ast_context := make_ast_context(
 		document.ast,
 		document.imports,
@@ -68,6 +72,9 @@ resolve_entire_file :: proc(
 	target_name := "",
 	save_unresolved := false,
 ) -> map[uintptr]SymbolAndNode {
+
+	spall.trace(#procedure, document.fullpath)
+
 	ast_context := make_ast_context(
 		document.ast,
 		document.imports,
@@ -223,6 +230,8 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 	if node == nil {
 		return
 	}
+
+	spall.trace(#procedure)
 
 	reset_ast_context(data.ast_context)
 

--- a/src/server/generics.odin
+++ b/src/server/generics.odin
@@ -6,6 +6,7 @@ import "core:odin/tokenizer"
 import "core:reflect"
 
 import "src:common"
+import "src:spall"
 
 resolve_poly :: proc(
 	ast_context: ^AstContext,
@@ -17,6 +18,8 @@ resolve_poly :: proc(
 	if poly_node == nil || call_node == nil {
 		return false
 	}
+
+	spall.trace(#procedure)
 
 	specialization: ^ast.Expr
 	type: ^ast.Expr
@@ -568,6 +571,8 @@ resolve_generic_function_symbol :: proc(
 		return {}, false
 	}
 
+	spall.trace(#procedure, proc_symbol.name)
+
 	call_expr := ast_context.call
 
 	poly_map := make(map[string]^ast.Expr, 0, context.temp_allocator)
@@ -756,6 +761,8 @@ resolve_poly_struct :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuild
 		return
 	}
 
+	spall.trace(#procedure)
+
 	i := 0
 
 	poly_map := make(map[string]^ast.Expr, 0, context.temp_allocator)
@@ -921,6 +928,8 @@ resolve_poly_union :: proc(ast_context: ^AstContext, poly_params: ^ast.Field_Lis
 	if symbol_value == nil {
 		return
 	}
+
+	spall.trace(#procedure)
 
 	i := 0
 

--- a/src/server/hover.odin
+++ b/src/server/hover.odin
@@ -7,6 +7,7 @@ import "core:odin/tokenizer"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupContent {
 	cat := construct_symbol_information(ast_context, symbol)
@@ -15,6 +16,8 @@ write_hover_content :: proc(ast_context: ^AstContext, symbol: Symbol) -> MarkupC
 }
 
 get_hover_information :: proc(document: ^Document, position: common.Position) -> (Hover, bool, bool) {
+	spall.trace(#procedure, document.fullpath)
+
 	hover := Hover {
 		contents = {kind = "plaintext"},
 	}

--- a/src/server/imports.odin
+++ b/src/server/imports.odin
@@ -10,6 +10,7 @@ import "core:odin/ast"
 import path "core:path/slashpath"
 
 import "src:common"
+import "src:spall"
 
 find_used_not_imported :: proc(
 	document: ^Document,
@@ -96,6 +97,7 @@ find_used_not_imported :: proc(
 }
 
 find_unused_imports :: proc(document: ^Document, allocator := context.temp_allocator) -> []Package {
+	spall.trace(#procedure, document.fullpath)
 
 	file := resolve_entire_file_cached(document)
 

--- a/src/server/indexer.odin
+++ b/src/server/indexer.odin
@@ -1,8 +1,10 @@
 package server
 
+import "core:fmt"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 Indexer :: struct {
 	builtin_packages: [dynamic]string,
@@ -60,6 +62,8 @@ lookup_builtin_symbol :: proc(name: string, current_pkg: string, current_file_ur
 }
 
 lookup :: proc(name: string, pkg: string, current_file: string, loc := #caller_location) -> (Symbol, bool) {
+	spall.trace(#procedure, fmt.tprint(name, pkg, current_file))
+
 	if name == "" {
 		return {}, false
 	}
@@ -96,6 +100,8 @@ fuzzy_search :: proc(
 	[]FuzzyResult,
 	bool,
 ) {
+	spall.trace(#procedure, fmt.tprint(name, pkgs, current_file))
+
 	results, ok := memory_index_fuzzy_search(&indexer.index, name, pkgs, current_file, resolve_fields, limit = limit)
 	if !ok {
 		return {}, false

--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -5,6 +5,7 @@ import "core:fmt"
 import "core:odin/ast"
 
 import "src:common"
+import "src:spall"
 
 get_inlay_hints :: proc(
 	document: ^Document,
@@ -15,6 +16,8 @@ get_inlay_hints :: proc(
 	[]InlayHint,
 	bool,
 ) {
+	spall.trace(#procedure, document.fullpath)
+
 	Visitor_Data :: struct {
 		document: ^Document,
 		range:    common.Range,

--- a/src/server/locals.odin
+++ b/src/server/locals.odin
@@ -3,6 +3,8 @@ package server
 import "core:log"
 import "core:odin/ast"
 
+import "src:spall"
+
 LocalFlag :: enum {
 	Mutable, // or constant
 	Variable, // or type
@@ -27,6 +29,9 @@ DocumentLocal :: struct {
 LocalGroup :: map[string][dynamic]DocumentLocal
 
 get_locals :: proc(ast_context: ^AstContext, position_context: ^DocumentPositionContext) {
+
+	spall.trace(#procedure, ast_context.fullpath)
+
 	if position_context.function != nil {
 		get_function_locals(ast_context.file, position_context.function, ast_context, position_context)
 	}

--- a/src/server/methods.odin
+++ b/src/server/methods.odin
@@ -6,7 +6,7 @@ import "core:odin/ast"
 import path "core:path/slashpath"
 
 import "src:common"
-
+import "src:spall"
 
 @(private)
 create_remove_edit :: proc(
@@ -49,6 +49,8 @@ append_method_completion :: proc(
 	results: ^[dynamic]CompletionResult,
 	receiver: string,
 ) {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	if selector_symbol.type != .Variable && selector_symbol.type != .Struct && selector_symbol.type != .Field {
 		return
 	}

--- a/src/server/reader.odin
+++ b/src/server/reader.odin
@@ -1,7 +1,5 @@
 package server
 
-import "core:mem"
-import "core:os"
 import "core:strings"
 
 ReaderFn :: proc(_: rawptr, _: []byte) -> (int, int)

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -12,6 +12,7 @@ import "core:slice"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 prepare_references :: proc(
 	document: ^Document,
@@ -22,7 +23,8 @@ prepare_references :: proc(
 	resolve_flag: ResolveReferenceFlag,
 	ok: bool,
 ) {
-	ok = false
+	spall.trace(#procedure, document.fullpath)
+
 	pkg := ""
 
 	if position_context.enum_type != nil {
@@ -239,6 +241,8 @@ resolve_references :: proc(
 	[]common.Location,
 	bool,
 ) {
+	spall.trace(#procedure, document.fullpath)
+
 	locations := make([dynamic]common.Location, 0, ast_context.allocator)
 	fullpaths := make([dynamic]string, 0, ast_context.allocator)
 
@@ -343,7 +347,7 @@ resolve_references :: proc(
 			pkg      = pkg,
 		}
 
-		ok := parser.parse_file(&p, &file)
+		ok := parse_file(&p, &file)
 
 		if !ok {
 			if !is_ols_builtin_file(fullpath) {

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -14,9 +14,9 @@ import "core:slice"
 import "core:strconv"
 import "core:strings"
 import "core:sync"
-import "core:time"
 
 import "src:common"
+import "src:spall"
 
 Header :: struct {
 	content_length: int,
@@ -346,30 +346,25 @@ call :: proc(value: json.Value, id: RequestId, writer: ^Writer, config: ^common.
 		return
 	}
 
-	diff: time.Duration
-	{
-		time.SCOPED_TICK_DURATION(&diff)
-
-		if fn, ok := call_map[method]; !ok {
-            // nil id == notification - do not respond
-            if id != nil {
-			response := make_response_message_error(
-				id = id,
-				error = ResponseError{code = .MethodNotFound, message = ""},
-			)
+	if fn, ok := call_map[method]; !ok {
+		// nil id == notification - do not respond
+		if id != nil {
+		response := make_response_message_error(
+			id = id,
+			error = ResponseError{code = .MethodNotFound, message = ""},
+		)
+		send_error(response, writer)
+		}
+	} else {
+		params := root["params"]
+		spall.trace(method, json.unparse(params) or_else "json.unparse error")
+		err := fn(params, id, config, writer)
+		// nil id == notification - do not respond
+		if err != .None && id != nil {
+			response := make_response_message_error(id = id, error = ResponseError{code = err, message = ""})
 			send_error(response, writer)
-            }
-		} else {
-			err := fn(root["params"], id, config, writer)
-			// nil id == notification - do not respond
-			if err != .None && id != nil {
-				response := make_response_message_error(id = id, error = ResponseError{code = err, message = ""})
-				send_error(response, writer)
-			}
 		}
 	}
-
-	//log.errorf("time duration %v for %v", time.duration_milliseconds(diff), method)
 }
 
 read_ols_initialize_options :: proc(config: ^common.Config, ols_config: OlsConfig, uri: common.Uri) {

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -61,6 +61,8 @@ requests: [dynamic]Request
 deletings: [dynamic]Request
 
 thread_request_main :: proc(data: rawptr) {
+	spall.name_thread("request")
+
 	request_data := cast(^RequestThreadData)data
 
 	for common.config.running {
@@ -110,6 +112,8 @@ thread_request_main :: proc(data: rawptr) {
 		sync.mutex_lock(&requests_mutex)
 
 		method := root["method"].(json.String)
+
+		spall.trace("request", fmt.tprint(method, id))
 
 		if method == "$/cancelRequest" {
 			append(&deletings, Request{id = id})
@@ -357,7 +361,7 @@ call :: proc(value: json.Value, id: RequestId, writer: ^Writer, config: ^common.
 		}
 	} else {
 		params := root["params"]
-		spall.trace(method, json.unparse(params) or_else "json.unparse error")
+		spall.trace(method)
 		err := fn(params, id, config, writer)
 		// nil id == notification - do not respond
 		if err != .None && id != nil {

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -61,7 +61,7 @@ requests: [dynamic]Request
 deletings: [dynamic]Request
 
 thread_request_main :: proc(data: rawptr) {
-	spall.name_thread("request")
+	spall.thread("request")
 
 	request_data := cast(^RequestThreadData)data
 

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -11,6 +11,7 @@ import "core:odin/tokenizer"
 import "core:unicode/utf8"
 
 import "src:common"
+import "src:spall"
 
 SemanticTokenTypes :: enum u32 {
 	Namespace,
@@ -130,6 +131,8 @@ get_semantic_tokens :: proc(
 	range: common.Range,
 	symbols: map[uintptr]SymbolAndNode,
 ) -> []SemanticToken {
+	spall.trace(#procedure, document.fullpath)
+
 	ast_context := make_ast_context(
 		document.ast,
 		document.imports,

--- a/src/server/signature.odin
+++ b/src/server/signature.odin
@@ -7,6 +7,7 @@ import "core:odin/tokenizer"
 import "core:strings"
 
 import "src:common"
+import "src:spall"
 
 SignatureInformationCapabilities :: struct {
 	parameterInformation: ParameterInformationCapabilities,
@@ -84,6 +85,8 @@ get_signature_information :: proc(
 	SignatureHelp,
 	bool,
 ) {
+	spall.trace(#procedure, document.fullpath)
+
 	signature_help: SignatureHelp
 
 	ast_context := make_ast_context(

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -6,6 +6,7 @@ import "core:odin/tokenizer"
 import "core:slice"
 
 import "src:common"
+import "src:spall"
 
 SymbolAndNode :: struct {
 	symbol:                            Symbol,
@@ -539,6 +540,8 @@ write_symbol_bitfield_value :: proc(
 }
 
 expand_usings :: proc(ast_context: ^AstContext, b: ^SymbolStructValueBuilder) {
+	spall.trace(#procedure, ast_context.fullpath)
+
 	base := len(b.names) - 1
 	for len(b.unexpanded_usings) > 0 {
 		u := pop_front(&b.unexpanded_usings)
@@ -710,6 +713,9 @@ new_clone_symbol :: proc(data: Symbol, allocator := context.allocator) -> ^Symbo
 }
 
 free_symbol :: proc(symbol: Symbol, allocator: mem.Allocator) {
+
+	spall.trace(#procedure, symbol.name)
+
 	if symbol.signature != "" &&
 	   symbol.signature != "struct" &&
 	   symbol.signature != "union" &&

--- a/src/server/workspace_symbols.odin
+++ b/src/server/workspace_symbols.odin
@@ -8,6 +8,7 @@ import "core:strings"
 import "core:time"
 
 import "src:common"
+import "src:spall"
 
 dir_blacklist :: []string{"node_modules", ".git"}
 
@@ -20,6 +21,8 @@ WorkspaceCache :: struct {
 cache: WorkspaceCache
 
 get_workspace_symbols :: proc(query: string) -> (workspace_symbols: []WorkspaceSymbol, ok: bool) {
+	spall.trace(#procedure, query)
+
 	if time.since(cache.time) > 20 * time.Second {
 		for pkg in cache.pkgs {
 			delete(pkg)

--- a/src/spall/spall.odin
+++ b/src/spall/spall.odin
@@ -1,10 +1,12 @@
 package ols_spall
 
+import "base:runtime"
+
 import "core:fmt"
 import "core:time"
-import "base:runtime"
 import "core:prof/spall"
 import "core:sync"
+import "core:os"
 
 SPALL_ENABLED           :: #config(SPALL_ENABLED, false)
 INSTRUMENTATION_ENABLED :: #config(INSTRUMENTATION_ENABLED, false)
@@ -18,12 +20,17 @@ when SPALL_ENABLED {
 	@init _init :: proc "contextless" () {
 		context = runtime.default_context()
 
-		filename := fmt.tprintf("ols_trace_%i.spall", time.time_to_unix(time.now()))
+		dirname, _ := os.join_path({#directory, "..", "..", "traces"}, context.temp_allocator)
+		os.make_directory(dirname)
+
+		filename, _ := os.join_path({dirname, fmt.tprintf("%i.spall", time.time_to_unix(time.now()))}, context.temp_allocator)
 		spall_ctx = spall.context_create(filename)
 
 		buffer_backing = make([]u8, spall.BUFFER_DEFAULT_SIZE)
 
 		spall_buffer = spall.buffer_create(buffer_backing, u32(sync.current_thread_id()))
+
+		spall._buffer_name_process(&spall_ctx, &spall_buffer, "OLS")
 	}
 
 	@fini _fini :: proc "contextless" () {
@@ -47,23 +54,29 @@ when SPALL_ENABLED {
 	}
 
 	@(no_instrumentation)
-	trace_begin :: proc (name: string, args: string = "", loc := #caller_location) {
+	name_thread :: proc "contextless" (name: string, loc := #caller_location) {
+		spall._buffer_name_thread(&spall_ctx, &spall_buffer, name, loc)
+	}
+	@(no_instrumentation)
+	trace_begin :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {
 		spall._buffer_begin(&spall_ctx, &spall_buffer, name, args, loc)
 	}
 	@(no_instrumentation)
-	trace_end :: proc () {
+	trace_end :: proc "contextless" () {
 		spall._buffer_end(&spall_ctx, &spall_buffer)
 	}
 	@(no_instrumentation, deferred_none=trace_end)
-	trace :: proc (name: string, args: string = "", loc:= #caller_location) {
+	trace :: proc "contextless" (name: string, args: string = "", loc:= #caller_location) {
 		trace_begin(name, args, loc)
 	}
 } else {
 	@(no_instrumentation, disabled=true)
-	trace_begin :: proc (name: string, args: string = "", loc := #caller_location) {}
+	name_thread :: proc "contextless" (name: string, loc := #caller_location) {}
 	@(no_instrumentation, disabled=true)
-	trace_end :: proc () {}
+	trace_begin :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {}
 	@(no_instrumentation, disabled=true)
-	trace :: proc (name: string, args: string = "", loc := #caller_location) {}
+	trace_end :: proc "contextless" () {}
+	@(no_instrumentation, disabled=true)
+	trace :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {}
 }
 

--- a/src/spall/spall.odin
+++ b/src/spall/spall.odin
@@ -15,7 +15,6 @@ when SPALL_ENABLED {
 
 	spall_ctx: spall.Context
 	@(thread_local) spall_buffer: spall.Buffer
-	buffer_backing: []u8
 
 	@init _init :: proc "contextless" () {
 		context = runtime.default_context()
@@ -25,58 +24,65 @@ when SPALL_ENABLED {
 
 		filename, _ := os.join_path({dirname, fmt.tprintf("%i.spall", time.time_to_unix(time.now()))}, context.temp_allocator)
 		spall_ctx = spall.context_create(filename)
-
-		buffer_backing = make([]u8, spall.BUFFER_DEFAULT_SIZE)
-
-		spall_buffer = spall.buffer_create(buffer_backing, u32(sync.current_thread_id()))
-
-		spall._buffer_name_process(&spall_ctx, &spall_buffer, "OLS")
 	}
 
 	@fini _fini :: proc "contextless" () {
 		context = runtime.default_context()
-
-		spall.buffer_destroy(&spall_ctx, &spall_buffer)
-		delete(buffer_backing)
 		spall.context_destroy(&spall_ctx)
 	}
-
-	when INSTRUMENTATION_ENABLED {
-		@(instrumentation_enter)
-		_spall_enter :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
-			trace_begin("", "", loc)
-		}
-
-		@(instrumentation_exit)
-		_spall_exit :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
-			trace_end()
-		}
-	}
-
-	@(no_instrumentation)
-	name_thread :: proc "contextless" (name: string, loc := #caller_location) {
-		spall._buffer_name_thread(&spall_ctx, &spall_buffer, name, loc)
-	}
-	@(no_instrumentation)
-	trace_begin :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {
-		spall._buffer_begin(&spall_ctx, &spall_buffer, name, args, loc)
-	}
-	@(no_instrumentation)
-	trace_end :: proc "contextless" () {
-		spall._buffer_end(&spall_ctx, &spall_buffer)
-	}
-	@(no_instrumentation, deferred_none=trace_end)
-	trace :: proc "contextless" (name: string, args: string = "", loc:= #caller_location) {
-		trace_begin(name, args, loc)
-	}
-} else {
-	@(no_instrumentation, disabled=true)
-	name_thread :: proc "contextless" (name: string, loc := #caller_location) {}
-	@(no_instrumentation, disabled=true)
-	trace_begin :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {}
-	@(no_instrumentation, disabled=true)
-	trace_end :: proc "contextless" () {}
-	@(no_instrumentation, disabled=true)
-	trace :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {}
 }
 
+@(no_instrumentation, disabled=!SPALL_ENABLED)
+thread_begin :: proc (name: string = "", loc := #caller_location) {
+	when SPALL_ENABLED {
+		buffer_backing := make([]u8, spall.BUFFER_DEFAULT_SIZE)
+		spall_buffer = spall.buffer_create(buffer_backing, u32(sync.current_thread_id()))
+		if name != "" {
+			spall._buffer_name_thread(&spall_ctx, &spall_buffer, name, loc)
+		}
+	}
+}
+@(no_instrumentation, disabled=!SPALL_ENABLED)
+thread_end :: proc () {
+	when SPALL_ENABLED {
+		spall.buffer_destroy(&spall_ctx, &spall_buffer)
+		delete(spall_buffer.data)
+	}
+}
+@(no_instrumentation, deferred_none=thread_end, disabled=!SPALL_ENABLED)
+thread :: proc (name: string = "", loc:= #caller_location) {
+	when SPALL_ENABLED {
+		thread_begin(name, loc)
+	}
+}
+
+@(no_instrumentation, disabled=!SPALL_ENABLED)
+trace_begin :: proc "contextless" (name: string, args: string = "", loc := #caller_location) {
+	when SPALL_ENABLED {
+		spall._buffer_begin(&spall_ctx, &spall_buffer, name, args, loc)
+	}
+}
+@(no_instrumentation, disabled=!SPALL_ENABLED)
+trace_end :: proc "contextless" () {
+	when SPALL_ENABLED {
+		spall._buffer_end(&spall_ctx, &spall_buffer)
+	}
+}
+@(no_instrumentation, deferred_none=trace_end, disabled=!SPALL_ENABLED)
+trace :: proc "contextless" (name: string, args: string = "", loc:= #caller_location) {
+	when SPALL_ENABLED {
+		trace_begin(name, args, loc)
+	}
+}
+
+when SPALL_ENABLED && INSTRUMENTATION_ENABLED {
+	@(instrumentation_enter)
+	_spall_enter :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
+		trace_begin("", "", loc)
+	}
+
+	@(instrumentation_exit)
+	_spall_exit :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
+		trace_end()
+	}
+}

--- a/src/spall/spall.odin
+++ b/src/spall/spall.odin
@@ -1,0 +1,69 @@
+package ols_spall
+
+import "core:fmt"
+import "core:time"
+import "base:runtime"
+import "core:prof/spall"
+import "core:sync"
+
+SPALL_ENABLED           :: #config(SPALL_ENABLED, false)
+INSTRUMENTATION_ENABLED :: #config(INSTRUMENTATION_ENABLED, false)
+
+when SPALL_ENABLED {
+
+	spall_ctx: spall.Context
+	@(thread_local) spall_buffer: spall.Buffer
+	buffer_backing: []u8
+
+	@init _init :: proc "contextless" () {
+		context = runtime.default_context()
+
+		filename := fmt.tprintf("ols_trace_%i.spall", time.time_to_unix(time.now()))
+		spall_ctx = spall.context_create(filename)
+
+		buffer_backing = make([]u8, spall.BUFFER_DEFAULT_SIZE)
+
+		spall_buffer = spall.buffer_create(buffer_backing, u32(sync.current_thread_id()))
+	}
+
+	@fini _fini :: proc "contextless" () {
+		context = runtime.default_context()
+
+		spall.buffer_destroy(&spall_ctx, &spall_buffer)
+		delete(buffer_backing)
+		spall.context_destroy(&spall_ctx)
+	}
+
+	when INSTRUMENTATION_ENABLED {
+		@(instrumentation_enter)
+		_spall_enter :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
+			trace_begin("", "", loc)
+		}
+
+		@(instrumentation_exit)
+		_spall_exit :: proc "contextless" (proc_address, call_site_return_address: rawptr, loc: runtime.Source_Code_Location) {
+			trace_end()
+		}
+	}
+
+	@(no_instrumentation)
+	trace_begin :: proc (name: string, args: string = "", loc := #caller_location) {
+		spall._buffer_begin(&spall_ctx, &spall_buffer, name, args, loc)
+	}
+	@(no_instrumentation)
+	trace_end :: proc () {
+		spall._buffer_end(&spall_ctx, &spall_buffer)
+	}
+	@(no_instrumentation, deferred_none=trace_end)
+	trace :: proc (name: string, args: string = "", loc:= #caller_location) {
+		trace_begin(name, args, loc)
+	}
+} else {
+	@(no_instrumentation, disabled=true)
+	trace_begin :: proc (name: string, args: string = "", loc := #caller_location) {}
+	@(no_instrumentation, disabled=true)
+	trace_end :: proc () {}
+	@(no_instrumentation, disabled=true)
+	trace :: proc (name: string, args: string = "", loc := #caller_location) {}
+}
+

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -11,6 +11,7 @@ import "core:testing"
 
 import "src:common"
 import "src:server"
+import "src:spall"
 
 File :: struct {
 	name:   string,
@@ -34,6 +35,7 @@ Source :: struct {
 
 @(private)
 setup :: proc(src: ^Source) {
+	spall.trace(#procedure)
 
 	src.document = new(server.Document, context.temp_allocator)
 
@@ -207,6 +209,8 @@ expect_signature_labels :: proc(
 	expect_labels: []string,
 	expected_active_parameter := -1,
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -269,6 +273,8 @@ expect_completion_labels :: proc(
 	expect_labels: []string,
 	expect_excluded: []string = nil,
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -340,6 +346,8 @@ expect_completion_docs :: proc(
 	expect_details: []string,
 	expect_excluded: []string = nil,
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -402,6 +410,8 @@ expect_completion_insert_text :: proc(
 	trigger_character: string,
 	expect_inserts: []string,
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -488,6 +498,8 @@ expect_completion_edit_text :: proc(
 }
 
 expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -514,6 +526,8 @@ expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {
 }
 
 expect_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_locations: []common.Location) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -568,6 +582,8 @@ expect_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_location
 }
 
 expect_type_definition_locations :: proc(t: ^testing.T, src: ^Source, expect_locations: []common.Location) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -627,6 +643,8 @@ expect_reference_locations :: proc(
 	expect_locations: []common.Location,
 	include_declaration := true,
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -672,6 +690,8 @@ expect_reference_locations :: proc(
 }
 
 expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: common.Range) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -694,6 +714,8 @@ expect_prepare_rename_range :: proc(t: ^testing.T, src: ^Source, expect_range: c
 
 
 expect_action :: proc(t: ^testing.T, src: ^Source, expect_action_names: []string, ctx: server.CodeActionContext = {}) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -727,6 +749,8 @@ expect_action :: proc(t: ^testing.T, src: ^Source, expect_action_names: []string
 }
 
 expect_action_with_edit :: proc(t: ^testing.T, src: ^Source, action_name: string, expected_new_text: string) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -777,6 +801,8 @@ expect_action_applied :: proc(
 	expected: string,
 	ctx: server.CodeActionContext = {},
 ) {
+	spall.trace(#procedure)
+
 	cursor := source_remove_cursor(src)
 
 	setup(src)
@@ -885,6 +911,8 @@ edits_conflict :: proc(a, b: common.AbsoluteRange) -> bool {
 }
 
 expect_semantic_tokens :: proc(t: ^testing.T, src: ^Source, expected: []server.SemanticToken) {
+	spall.trace(#procedure)
+
 	setup(src)
 	defer teardown(src)
 
@@ -927,6 +955,7 @@ expect_semantic_tokens :: proc(t: ^testing.T, src: ^Source, expected: []server.S
 }
 
 expect_inlay_hints :: proc(t: ^testing.T, src: ^Source) {
+	spall.trace(#procedure)
 
 	src_builder := strings.builder_make(context.temp_allocator)
 	expected_hints := make([dynamic]server.InlayHint, context.temp_allocator)

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -133,7 +133,7 @@ setup :: proc(src: ^Source) {
 			pkg      = pkg,
 		}
 
-		ok := parser.parse_file(&p, &file)
+		ok := server.parse_file(&p, &file)
 
 		if !ok || file.syntax_error_count > 0 {
 			panic("Parser error in test package source")

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -1,5 +1,7 @@
 package ols_testing
 
+import "core:os"
+import "base:runtime"
 import "core:fmt"
 import "core:log"
 import "core:mem/virtual"
@@ -35,6 +37,8 @@ Source :: struct {
 
 @(private)
 setup :: proc(src: ^Source) {
+	spall.thread_begin()
+
 	spall.trace(#procedure)
 
 	src.document = new(server.Document, context.temp_allocator)
@@ -156,6 +160,7 @@ teardown :: proc(src: ^Source) {
 	server.indexer.index = {}
 	server.build_cache.pkg_aliases = {}
 	virtual.arena_destroy(src.document.allocator)
+	spall.thread_end()
 }
 
 source_remove_cursor :: proc(src: ^Source) -> (cursor: common.Position) {


### PR DESCRIPTION
This sets up ols to be easily used with spall for trace profiling.
It won't do anything by default.
Emitting spall traces can be enabled with `SPALL_ENABLED` and full instrumentation with `INSTRUMENTATION_ENABLED` defines.
I've added some traces to most important locations for now—so far it shows how big chunk of most requests is taken by `resolve_entire_file`, even when reporting unused imports is disabled, since each resolve call takes ~400ms (in ols).
This could be modified to support other profilers as well, but spall is just easiest to get into, and its bindings are in core.