### PR TITLE
Add document SymbolAndNode map cache

### DIFF
--- a/src/server/caches.odin
+++ b/src/server/caches.odin
@@ -2,52 +2,10 @@ package server
 
 import "src:common"
 
-import "core:mem/virtual"
 import "core:os"
 import "core:path/filepath"
 import "core:strings"
 import "core:time"
-
-//Used in semantic tokens and inlay hints to handle the entire file being resolved.
-
-FileResolve :: struct {
-	symbols: map[uintptr]SymbolAndNode,
-}
-
-
-FileResolveCache :: struct {
-	files: map[string]FileResolve,
-}
-
-@(thread_local)
-file_resolve_cache: FileResolveCache
-
-resolve_entire_file_cached :: proc(document: ^Document) -> FileResolve {
-
-	file, cached := file_resolve_cache.files[document.uri.uri]
-
-	if !cached {
-		file = {
-			symbols = resolve_entire_file(document, .None, virtual.arena_allocator(document.allocator)),
-		}
-		file_resolve_cache.files[document.uri.uri] = file
-	}
-
-	return file
-}
-
-resolve_ranged_file_cached :: proc(document: ^Document, range: common.Range, allocator := context.allocator) -> FileResolve {
-
-	file, cached := file_resolve_cache.files[document.uri.uri]
-
-	if !cached {
-		file = {
-			symbols = resolve_ranged_file(document, range, allocator),
-		}
-	}
-
-	return file
-}
 
 BuildCache :: struct {
 	loaded_pkgs: map[string]PackageCacheInfo,

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -1,8 +1,9 @@
 package server
 
 import "base:intrinsics"
-import "core:os"
+import "base:runtime"
 
+import "core:os"
 import "core:fmt"
 import "core:log"
 import "core:mem/virtual"
@@ -46,6 +47,7 @@ Document :: struct {
 	allocator:        ^virtual.Arena, //because parser does not support freeing I use arena allocators for each document
 	operating_on:     int, //atomic
 	version:          Maybe(int),
+	symbols:          Maybe(SymbolAndNodeMap), // Cache resolved symbols for open documents, cleared on change
 }
 
 
@@ -74,7 +76,7 @@ document_storage_shutdown :: proc() {
 	delete(document_storage.documents)
 }
 
-document_get_allocator :: proc() -> ^virtual.Arena {
+document_get_new_allocator :: proc() -> ^virtual.Arena {
 	if len(document_storage.free_allocators) > 0 {
 		return pop(&document_storage.free_allocators)
 	} else {
@@ -83,9 +85,12 @@ document_get_allocator :: proc() -> ^virtual.Arena {
 		return allocator
 	}
 }
-
+document_allocator :: proc(document: Document) -> (runtime.Allocator, bool) #optional_ok {
+	if document.allocator == nil do return {}, false
+	return virtual.arena_allocator(document.allocator), true
+}
 document_free_allocator :: proc(allocator: ^virtual.Arena) {
-	free_all(virtual.arena_allocator(allocator))
+	virtual.arena_free_all(allocator)
 	append(&document_storage.free_allocators, allocator)
 }
 
@@ -138,7 +143,7 @@ document_open :: proc(uri_string: string, text: string, config: ^common.Config, 
 		document.client_owned = true
 		document.text = transmute([]u8)text
 		document.used_text = len(document.text)
-		document.allocator = document_get_allocator()
+		document.allocator = document_get_new_allocator()
 
 		document_setup(document)
 
@@ -151,7 +156,7 @@ document_open :: proc(uri_string: string, text: string, config: ^common.Config, 
 			text         = transmute([]u8)text,
 			client_owned = true,
 			used_text    = len(text),
-			allocator    = document_get_allocator(),
+			allocator    = document_get_new_allocator(),
 		}
 
 		document_setup(&document)
@@ -298,13 +303,10 @@ document_close :: proc(uri_string: string) -> common.Error {
 		return .InvalidRequest
 	}
 
-	if document.uri.uri in file_resolve_cache.files {
-		delete_key(&file_resolve_cache.files, document.uri.uri)
-	}
-
 	document_free_allocator(document.allocator)
 
 	document.allocator = nil
+	document.symbols = nil
 	document.client_owned = false
 
 	common.delete_uri(document.uri)
@@ -392,11 +394,7 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 
 	current_errors = make([dynamic]ParserError, context.temp_allocator)
 
-	if document.uri.uri in file_resolve_cache.files {
-		delete_key(&file_resolve_cache.files, document.uri.uri)
-	}
-
-	free_all(virtual.arena_allocator(document.allocator))
+	virtual.arena_free_all(document.allocator)
 
 	context.allocator = virtual.arena_allocator(document.allocator)
 
@@ -415,6 +413,7 @@ parse_document :: proc(document: ^Document, config: ^common.Config) -> ([]Parser
 		src      = string(document.text[:document.used_text]),
 		pkg      = pkg,
 	}
+	document.symbols = nil // Invalidate symbols cache
 
 	parse_file(&p, &document.ast)
 

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -7,6 +7,8 @@ import "core:strings"
 import "src:common"
 import "src:spall"
 
+SymbolAndNodeMap :: map[uintptr]SymbolAndNode
+
 ResolveReferenceFlag :: enum {
 	None,
 	Identifier,
@@ -26,54 +28,39 @@ reset_position_context :: proc(position_context: ^DocumentPositionContext) {
 	position_context.index = nil
 }
 
-resolve_ranged_file :: proc(
-	document: ^Document,
-	range: common.Range,
-	allocator := context.allocator,
-) -> map[uintptr]SymbolAndNode {
-
-	spall.trace(#procedure, document.fullpath)
-
-	ast_context := make_ast_context(
-		document.ast,
-		document.imports,
-		document.package_name,
-		document.uri.uri,
-		document.fullpath,
-		allocator,
-	)
-
-	position_context: DocumentPositionContext
-	position_context.functions = make([dynamic]^ast.Proc_Lit, context.temp_allocator)
-
-	get_globals(document.ast, &ast_context)
-
-	ast_context.current_package = ast_context.document_package
-
-	symbols := make(map[uintptr]SymbolAndNode, 10000, allocator)
-
-	margin := 20
-
-	for decl in document.ast.decls {
-		//Look for declarations that overlap with range
-		if range.start.line - margin <= decl.end.line && decl.pos.line <= range.end.line + margin {
-			resolve_decl(&position_context, &ast_context, document, decl, &symbols, .None, false, allocator)
-			clear(&ast_context.locals)
-		}
-	}
-
-	return symbols
-}
-
 resolve_entire_file :: proc(
 	document: ^Document,
 	flag := ResolveReferenceFlag.None,
 	allocator := context.allocator,
 	target_name := "",
 	save_unresolved := false,
-) -> map[uintptr]SymbolAndNode {
-
+) -> (symbols: SymbolAndNodeMap) {
 	spall.trace(#procedure, document.fullpath)
+
+	should_use_cache := (
+		// Only cache symbols for open documents
+		document.client_owned == true &&
+		document.allocator != nil &&
+		// flag changes the symbols output
+		flag == .None
+	)
+
+	reuse_cached: if should_use_cache {
+		symbols = document.symbols.? or_break reuse_cached
+		return symbols
+	}
+
+	allocator, target_name, save_unresolved := allocator, target_name, save_unresolved
+
+	if should_use_cache {
+		allocator = document_allocator(document^)
+		// clear filters to cache full symbols map
+		save_unresolved = true
+		target_name = ""
+	}
+	defer if should_use_cache {
+		document.symbols = symbols
+	}
 
 	ast_context := make_ast_context(
 		document.ast,
@@ -91,7 +78,7 @@ resolve_entire_file :: proc(
 
 	ast_context.current_package = ast_context.document_package
 
-	symbols := make(map[uintptr]SymbolAndNode, 10000, allocator)
+	symbols = make(SymbolAndNodeMap, 10000, allocator)
 
 	for decl in document.ast.decls {
 		resolve_decl(
@@ -102,7 +89,6 @@ resolve_entire_file :: proc(
 			&symbols,
 			flag,
 			save_unresolved,
-			allocator,
 			target_name,
 		)
 		clear(&ast_context.locals)
@@ -113,7 +99,7 @@ resolve_entire_file :: proc(
 
 FileResolveData :: struct {
 	ast_context:      ^AstContext,
-	symbols:          ^map[uintptr]SymbolAndNode,
+	symbols:          ^SymbolAndNodeMap,
 	id_counter:       int,
 	document:         ^Document,
 	position_context: ^DocumentPositionContext,
@@ -128,10 +114,9 @@ resolve_decl :: proc(
 	ast_context: ^AstContext,
 	document: ^Document,
 	decl: ^ast.Node,
-	symbols: ^map[uintptr]SymbolAndNode,
+	symbols: ^SymbolAndNodeMap,
 	flag: ResolveReferenceFlag,
 	save_unresolved: bool,
-	allocator := context.allocator,
 	target_name := "",
 ) {
 	data := FileResolveData {

--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -1,5 +1,6 @@
 package server
 
+import "base:runtime"
 import "core:odin/ast"
 import "core:odin/tokenizer"
 import "core:strings"
@@ -28,39 +29,19 @@ reset_position_context :: proc(position_context: ^DocumentPositionContext) {
 	position_context.index = nil
 }
 
-resolve_entire_file :: proc(
-	document: ^Document,
-	flag := ResolveReferenceFlag.None,
-	allocator := context.allocator,
-	target_name := "",
-	save_unresolved := false,
-) -> (symbols: SymbolAndNodeMap) {
+// Should only be called for open documents
+resolve_entire_file :: proc(document: ^Document) -> (symbols: SymbolAndNodeMap) {
 	spall.trace(#procedure, document.fullpath)
 
-	should_use_cache := (
-		// Only cache symbols for open documents
-		document.client_owned == true &&
-		document.allocator != nil &&
-		// flag changes the symbols output
-		flag == .None
-	)
+	assert(document.client_owned, #procedure + " should only be called for open documents")
 
-	reuse_cached: if should_use_cache {
-		symbols = document.symbols.? or_break reuse_cached
-		return symbols
-	}
+	allocator, has_allocator := document_allocator(document^)
+	assert(has_allocator, "Open document should have an allocator set")
 
-	allocator, target_name, save_unresolved := allocator, target_name, save_unresolved
-
-	if should_use_cache {
-		allocator = document_allocator(document^)
-		// clear filters to cache full symbols map
-		save_unresolved = true
-		target_name = ""
+	reuse_cached: {
+		return document.symbols.? or_break reuse_cached
 	}
-	defer if should_use_cache {
-		document.symbols = symbols
-	}
+	defer document.symbols = symbols
 
 	ast_context := make_ast_context(
 		document.ast,
@@ -87,9 +68,53 @@ resolve_entire_file :: proc(
 			document,
 			decl,
 			&symbols,
-			flag,
-			save_unresolved,
-			target_name,
+			flag = .None,
+			save_unresolved = true,
+			target_name = "",
+		)
+		clear(&ast_context.locals)
+	}
+
+	return symbols
+}
+
+// Should only be called when resolving references
+resolve_entire_file_for_references :: proc(
+	document:    ^Document,
+	allocator:   runtime.Allocator,
+	flag:        ResolveReferenceFlag,
+	target_name: string,
+) -> (symbols: SymbolAndNodeMap) {
+	spall.trace(#procedure, document.fullpath)
+
+	ast_context := make_ast_context(
+		document.ast,
+		document.imports,
+		document.package_name,
+		document.uri.uri,
+		document.fullpath,
+		allocator,
+	)
+
+	position_context: DocumentPositionContext
+	position_context.functions = make([dynamic]^ast.Proc_Lit, context.temp_allocator)
+
+	get_globals(document.ast, &ast_context)
+
+	ast_context.current_package = ast_context.document_package
+
+	symbols = make(SymbolAndNodeMap, 10000, allocator)
+
+	for decl in document.ast.decls {
+		resolve_decl(
+			&position_context,
+			&ast_context,
+			document,
+			decl,
+			&symbols,
+			flag = flag,
+			save_unresolved = false,
+			target_name = target_name,
 		)
 		clear(&ast_context.locals)
 	}

--- a/src/server/imports.odin
+++ b/src/server/imports.odin
@@ -99,10 +99,10 @@ find_used_not_imported :: proc(
 find_unused_imports :: proc(document: ^Document, allocator := context.temp_allocator) -> []Package {
 	spall.trace(#procedure, document.fullpath)
 
-	file := resolve_entire_file_cached(document)
+	symbols := resolve_entire_file(document, allocator=allocator)
 
 	pkgs := make(map[string]struct{}, context.temp_allocator)
-	for _, v in file.symbols {
+	for _, v in symbols {
 		pkgs[v.symbol.pkg] = {}
 	}
 

--- a/src/server/imports.odin
+++ b/src/server/imports.odin
@@ -25,7 +25,7 @@ find_used_not_imported :: proc(
 
 	context.allocator = runtime.arena_allocator(&arena)
 
-	symbols_and_nodes := resolve_entire_file(document, .None, context.allocator, "", true)
+	symbols_and_nodes := resolve_entire_file(document)
 
 	already_imported := make(map[string]struct{})
 
@@ -99,7 +99,7 @@ find_used_not_imported :: proc(
 find_unused_imports :: proc(document: ^Document, allocator := context.temp_allocator) -> []Package {
 	spall.trace(#procedure, document.fullpath)
 
-	symbols := resolve_entire_file(document, allocator=allocator)
+	symbols := resolve_entire_file(document)
 
 	pkgs := make(map[string]struct{}, context.temp_allocator)
 	for _, v in symbols {

--- a/src/server/inlay_hints.odin
+++ b/src/server/inlay_hints.odin
@@ -10,7 +10,7 @@ import "src:spall"
 get_inlay_hints :: proc(
 	document: ^Document,
 	range: common.Range,
-	symbols: map[uintptr]SymbolAndNode,
+	symbols: SymbolAndNodeMap,
 	config: ^common.Config,
 ) -> (
 	[]InlayHint,
@@ -21,7 +21,7 @@ get_inlay_hints :: proc(
 	Visitor_Data :: struct {
 		document: ^Document,
 		range:    common.Range,
-		symbols:  map[uintptr]SymbolAndNode,
+		symbols:  SymbolAndNodeMap,
 		config:   ^common.Config,
 		hints:    [dynamic]InlayHint,
 		depth:    int,

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -252,7 +252,7 @@ resolve_references :: proc(
 	}
 
 	target_name := get_target_name(position_context, resolve_flag)
-	symbols_and_nodes := resolve_entire_file(document, resolve_flag, ast_context.allocator, target_name)
+	symbols_and_nodes := resolve_entire_file_for_references(document, ast_context.allocator, resolve_flag, target_name)
 
 	for k, v in symbols_and_nodes {
 		if strings.equal_fold(v.symbol.uri, symbol.uri) && v.symbol.range == symbol.range {
@@ -375,7 +375,7 @@ resolve_references :: proc(
 		}
 
 		if in_pkg || symbol.pkg == document.package_name {
-			symbols_and_nodes := resolve_entire_file(&document, resolve_flag, context.allocator, target_name)
+			symbols_and_nodes := resolve_entire_file_for_references(&document, context.allocator, resolve_flag, target_name)
 			for k, v in symbols_and_nodes {
 				if strings.equal_fold(v.symbol.uri, symbol.uri) && v.symbol.range == symbol.range {
 					node_uri := common.create_uri(v.node.pos.file, ast_context.allocator)

--- a/src/server/references.odin
+++ b/src/server/references.odin
@@ -293,17 +293,12 @@ resolve_references :: proc(
 
 
 	arena: runtime.Arena
+	_ = runtime.arena_init(&arena, mem.Megabyte * 40, context.temp_allocator)
 
-	_ = runtime.arena_init(&arena, mem.Megabyte * 40, runtime.default_allocator())
+	for fullpath in slice.unique(fullpaths[:]) {
 
-	defer runtime.arena_destroy(&arena)
-
-	context.allocator = runtime.arena_allocator(&arena)
-
-	paths := slice.unique(fullpaths[:])
-
-	for fullpath in paths {
-		defer free_all(context.allocator)
+		context.allocator = runtime.arena_allocator(&arena)
+		defer runtime.arena_free_all(&arena)
 
 		fullpath := fullpath
 		when ODIN_OS == .Windows {

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -851,8 +851,6 @@ request_initialize :: proc(
 		append(&indexer.builtin_packages, indexer.runtime_package)
 	}
 
-	file_resolve_cache.files = make(map[string]FileResolve, 200)
-
 	builtin_path := get_builtin_path(context.allocator)
 	config.builtin_path = builtin_path
 	// we still need to ensure the index is setup even if the builtin folder was not found
@@ -1321,12 +1319,10 @@ request_semantic_token_full :: proc(
 	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
-		resolve_entire_file_cached(document)
+		symbols := resolve_entire_file(document, allocator=context.temp_allocator)
 
-		if file, ok := file_resolve_cache.files[document.uri.uri]; ok {
-			tokens := get_semantic_tokens(document, range, file.symbols)
-			tokens_params = semantic_tokens_to_response_params(tokens)
-		}
+		tokens := get_semantic_tokens(document, range, symbols)
+		tokens_params = semantic_tokens_to_response_params(tokens)
 	}
 
 	response := make_response_message(params = tokens_params, id = id)
@@ -1363,9 +1359,9 @@ request_semantic_token_range :: proc(
 	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
-		file := resolve_ranged_file_cached(document, semantic_params.range, context.temp_allocator)
+		symbols := resolve_entire_file(document, allocator=context.temp_allocator)
 
-		tokens := get_semantic_tokens(document, semantic_params.range, file.symbols)
+		tokens := get_semantic_tokens(document, semantic_params.range, symbols)
 		tokens_params = semantic_tokens_to_response_params(tokens)
 	}
 
@@ -1465,9 +1461,9 @@ request_inlay_hint :: proc(
 	document := document_get(inlay_params.textDocument.uri)
 	if document == nil do return .InternalError
 
-	file := resolve_ranged_file_cached(document, inlay_params.range, context.temp_allocator)
+	symbols := resolve_entire_file(document, allocator=context.temp_allocator)
 
-	hints, hints_ok := get_inlay_hints(document, inlay_params.range, file.symbols, config)
+	hints, hints_ok := get_inlay_hints(document, inlay_params.range, symbols, config)
 	if !hints_ok do return .InternalError
 
 	response := make_response_message(params = hints, id = id)

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -1319,7 +1319,7 @@ request_semantic_token_full :: proc(
 	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
-		symbols := resolve_entire_file(document, allocator=context.temp_allocator)
+		symbols := resolve_entire_file(document)
 
 		tokens := get_semantic_tokens(document, range, symbols)
 		tokens_params = semantic_tokens_to_response_params(tokens)
@@ -1359,7 +1359,7 @@ request_semantic_token_range :: proc(
 	tokens_params: SemanticTokensResponseParams
 
 	if config.enable_semantic_tokens {
-		symbols := resolve_entire_file(document, allocator=context.temp_allocator)
+		symbols := resolve_entire_file(document)
 
 		tokens := get_semantic_tokens(document, semantic_params.range, symbols)
 		tokens_params = semantic_tokens_to_response_params(tokens)
@@ -1461,7 +1461,7 @@ request_inlay_hint :: proc(
 	document := document_get(inlay_params.textDocument.uri)
 	if document == nil do return .InternalError
 
-	symbols := resolve_entire_file(document, allocator=context.temp_allocator)
+	symbols := resolve_entire_file(document)
 
 	hints, hints_ok := get_inlay_hints(document, inlay_params.range, symbols, config)
 	if !hints_ok do return .InternalError

--- a/src/server/semantic_tokens.odin
+++ b/src/server/semantic_tokens.odin
@@ -118,7 +118,7 @@ SemanticTokensResponseParams :: struct {
 SemanticTokenBuilder :: struct {
 	current_start: int,
 	tokens:        [dynamic]SemanticToken,
-	symbols:       map[uintptr]SymbolAndNode,
+	symbols:       SymbolAndNodeMap,
 	src:           string,
 }
 
@@ -129,7 +129,7 @@ semantic_tokens_to_response_params :: proc(tokens: []SemanticToken) -> SemanticT
 get_semantic_tokens :: proc(
 	document: ^Document,
 	range: common.Range,
-	symbols: map[uintptr]SymbolAndNode,
+	symbols: SymbolAndNodeMap,
 ) -> []SemanticToken {
 	spall.trace(#procedure, document.fullpath)
 

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -1,6 +1,5 @@
 package ols_testing
 
-import "core:os"
 import "base:runtime"
 import "core:fmt"
 import "core:log"
@@ -923,7 +922,7 @@ expect_semantic_tokens :: proc(t: ^testing.T, src: ^Source, expected: []server.S
 
 
 	resolve_flag: server.ResolveReferenceFlag
-	symbols_and_nodes := server.resolve_entire_file(src.document, resolve_flag, context.temp_allocator)
+	symbols_and_nodes := server.resolve_entire_file(src.document)
 
 	range := common.Range {
 		end = {line = 9000000},
@@ -1011,7 +1010,7 @@ expect_inlay_hints :: proc(t: ^testing.T, src: ^Source) {
 	setup(src)
 	defer teardown(src)
 
-	symbols_and_nodes := server.resolve_entire_file(src.document, allocator = context.temp_allocator)
+	symbols_and_nodes := server.resolve_entire_file(src.document)
 
 	range := common.Range {
 		end = {line = 9000000},


### PR DESCRIPTION
After https://github.com/DanielGavin/ols/pull/1629 was merged, the performance should be the same for people with `enable_unused_imports_reporting` enabled—as finding unused imports will resolve entire file and update the cache on `textDocument/didChange` request. But if you had that disabled, ranged-semantic-tokens request wouldn't write to cache so you could re-resolve the same file multiple times, depending on the order of the requests.

This cleans up the symbol map caching a bit.
- Instead of a separate cache map, cached symbol-and-node-maps are now stored directly on the document struct. This is mostly just to reduce code, as we only cache symbols for open documents anyway and the symbols map allocations use document.allocator.
- Removes `resolve_ranged_file` as it's result couldn't be written to cache and the cost of resolving file multiple times—even partially—is greater than the difference between ranged and full resolve. So it's better to just resolve it entirely on first request that needs it and cache so subsequent requests don't need to do it again.
- Makes `resolve_ranged_file(document)` separate from `resolve_entire_file_for_references(document, allocator, flag, target_name)` as `resolve_ranged_file` can be cashed, uses document.allocator and is not configurable, while the other is used only for references and uses special flags to alter or filter the results.