### PR TITLE
Use nil check instead of 0 comparison for os.Error

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -1930,11 +1930,11 @@ search_for_packages :: proc(fullpath: string) -> []string {
 
 	fh, err := os.open(fullpath)
 
-	if err != 0 {
+	if err != nil {
 		return {}
 	}
 
-	if files, err := os.read_dir(fh, 0, context.temp_allocator); err == 0 {
+	if files, err := os.read_dir(fh, 0, context.temp_allocator); err == nil {
 		for file in files {
 			if file.type == .Directory {
 				append(&packages, file.fullpath)


### PR DESCRIPTION
Odin compiler crashes on `os.Error == 0` due to an old hack in the compiler. Worked around it by using `nil` check instead. Compiler still needs to be fixed, but probably be removing that `0` comparison capability and making it a real error.

Note: The hack has been removed in Odin compiler now, so there is a real error message instead of the compiler crash. This PR still fixes the compilation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
