### PR TITLE
Return edit range along with completion text

### DIFF
--- a/src/common/config.odin
+++ b/src/common/config.odin
@@ -18,6 +18,7 @@ StructFieldUnderscoreMeaning :: enum {
 Config :: struct {
 	workspace_folders:                       [dynamic]WorkspaceFolder,
 	completion_support_md:                   bool,
+	completion_insert_replace_support:       bool,
 	hover_support_md:                        bool,
 	signature_offset_support:                bool,
 	collections:                             map[string]string,

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -13,6 +13,7 @@ import "core:reflect"
 import "core:slice"
 import "core:strconv"
 import "core:strings"
+import "core:unicode/utf8"
 
 import "src:common"
 import "src:spall"
@@ -181,6 +182,7 @@ get_completion_list :: proc(
 		arg_symbol,
 		config,
 	)
+	add_completion_text_edits(items, &position_context, completion_type, position, config)
 	list.items = items
 	list.isIncomplete = is_incomplete
 	return list, true
@@ -400,6 +402,72 @@ convert_completion_results :: proc(
 	}
 
 	return items[:]
+}
+
+
+@(private = "file")
+add_completion_text_edits :: proc(
+	items: []CompletionItem,
+	position_context: ^DocumentPositionContext,
+	completion_type: Completion_Type,
+	position: common.Position,
+	config: ^common.Config,
+) {
+	if completion_type != .Identifier && completion_type != .Selector do return
+	insert_range, replace_range := get_completion_edit_ranges(position_context, position)
+	for &item in items {
+		// Preserve supplied primary edits
+		if item.textEdit != nil do continue
+		// Preserve context-specific multi-edit completions, such as auto-imports and implicit selectors.
+		if len(item.additionalTextEdits.? or_else nil) > 0 do continue
+
+		new_text := item.insertText.(string) or_else item.label
+		if config.completion_insert_replace_support {
+			item.textEdit = InsertReplaceEdit {
+				newText = new_text,
+				insert  = insert_range,
+				replace = replace_range,
+			}
+		} else {
+			item.textEdit = TextEdit {
+				newText = new_text,
+				range   = insert_range,
+			}
+		}
+	}
+}
+
+@(private = "file")
+get_completion_edit_ranges :: proc(
+	position_context: ^DocumentPositionContext,
+	position: common.Position,
+) -> (insert, replace: common.Range) {
+	insert = { start = position, end = position}
+	replace = { start = position, end = position}
+
+	src := transmute([]u8)position_context.file.src
+	cursor := position_context.position
+	if cursor < 0 || cursor > len(src) do return insert, replace
+
+	start, end := cursor, cursor
+
+	for start > 0 {
+		r, width := utf8.decode_last_rune(src[:start])
+		if width == 0 || (!tokenizer.is_letter(r) && !tokenizer.is_digit(r)) do break
+		start -= width
+	}
+
+	for end < len(src) {
+		r, width := utf8.decode_rune(src[end:])
+		if width == 0 || (!tokenizer.is_letter(r) && !tokenizer.is_digit(r)) do break
+		end += width
+	}
+
+	insert.start.character -= common.get_character_offset_u8_to_u16(cursor - start, src[start:cursor])
+	replace.start = insert.start
+	replace.end.character += common.get_character_offset_u8_to_u16(end - cursor, src[cursor:end])
+
+	return insert, replace
 }
 
 should_add_parens_snippet :: proc(position_context: ^DocumentPositionContext, config: ^common.Config, result_type: SymbolType) -> bool{

--- a/src/server/requests.odin
+++ b/src/server/requests.odin
@@ -784,6 +784,8 @@ request_initialize :: proc(
 
 	config.enable_label_details =
 		initialize_params.capabilities.textDocument.completion.completionItem.labelDetailsSupport
+	config.completion_insert_replace_support =
+		initialize_params.capabilities.textDocument.completion.completionItem.insertReplaceSupport
 
 	client_snippet_supprot := initialize_params.capabilities.textDocument.completion.completionItem.snippetSupport
 	config.enable_snippets &= client_snippet_supprot

--- a/src/server/types.odin
+++ b/src/server/types.odin
@@ -204,8 +204,9 @@ GeneralClientCapabilities :: struct {
 }
 
 CompletionItemCapabilities :: struct {
-	snippetSupport:      bool,
-	labelDetailsSupport: bool,
+	snippetSupport:       bool,
+	labelDetailsSupport:  bool,
+	insertReplaceSupport: bool,
 }
 
 CompletionClientCapabilities :: struct {
@@ -268,6 +269,11 @@ InsertReplaceEdit :: struct {
 	insert:  common.Range,
 	newText: string,
 	replace: common.Range,
+}
+
+CompletionTextEdit :: union {
+	TextEdit,
+	InsertReplaceEdit,
 }
 
 DiagnosticSeverity :: enum {
@@ -379,7 +385,7 @@ CompletionItem :: struct {
 	insertTextFormat:    Maybe(InsertTextFormat),
 	insertText:          Maybe(string),
 	InsertTextMode:      Maybe(InsertTextMode),
-	textEdit:            Maybe(TextEdit),
+	textEdit:            CompletionTextEdit,
 	additionalTextEdits: Maybe([]TextEdit),
 	tags:                []CompletionItemTag,
 	deprecated:          bool,

--- a/src/testing/testing.odin
+++ b/src/testing/testing.odin
@@ -1,12 +1,12 @@
 package ols_testing
 
-import "core:os"
 import "base:runtime"
 import "core:fmt"
 import "core:log"
 import "core:mem/virtual"
 import "core:odin/ast"
 import "core:odin/parser"
+import "core:os"
 import "core:slice"
 import "core:strings"
 import "core:testing"
@@ -192,20 +192,7 @@ source_remove_cursor :: proc(src: ^Source) -> (cursor: common.Position) {
 	source^ = string(new_source)
 
 	// find cursor (line,col) position
-	last: u8
-	for j := 0; j < marker_pos; j += 1 {
-		ch := source[j]
-		defer last = ch
-
-		if last == '\r' || ch == '\n' {
-			cursor.line += 1
-			cursor.character = 0
-		} else {
-			cursor.character += 1
-		}
-	}
-
-	return
+	return common.get_relative_token_position(marker_pos, transmute([]u8)source^, 0)
 }
 
 expect_signature_labels :: proc(
@@ -500,6 +487,41 @@ expect_completion_edit_text :: proc(
 	if !found {
 		log.errorf("Expected completion label '%v' not found in %v", label, completion_list.items)
 	}
+}
+
+expect_completion_edits :: proc(
+	t: ^testing.T,
+	src: ^Source,
+	trigger_character: string,
+	label: string,
+	expected_edit: server.CompletionTextEdit,
+	expected_additional_edits: []server.TextEdit = nil,
+) {
+	cursor := source_remove_cursor(src)
+
+	setup(src)
+	defer teardown(src)
+
+	completion_context := server.CompletionContext {
+		triggerCharacter = trigger_character,
+	}
+
+	completion_list, ok := server.get_completion_list(src.document, cursor, completion_context, &src.config)
+	if !ok {
+		log.error("Failed get_completion_list")
+		return
+	}
+
+	for completion in completion_list.items {
+		if completion.label != label do continue
+
+		testing.expect_value(t, completion.textEdit, expected_edit)
+		additional_edits := completion.additionalTextEdits.([]server.TextEdit) or_else nil
+		testing.expect(t, slice.equal(additional_edits, expected_additional_edits))
+		return
+	}
+
+	testing.expectf(t, false, "Expected completion label '%v' not found in %v", label, completion_list.items)
 }
 
 expect_hover :: proc(t: ^testing.T, src: ^Source, expect_hover_string: string) {

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -4,7 +4,96 @@ package tests
 import "core:strings"
 import "core:testing"
 
+import "src:server"
 import test "src:testing"
+
+@(test)
+completion_insert_replace_edit :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+			target_extra :: proc(value: int) {}
+			main :: proc() {
+				_ = targ{*}et
+			}
+			`,
+		config = {enable_snippets = true, enable_procedure_snippet = true, completion_insert_replace_support = true},
+	}
+
+	expected_edit := server.InsertReplaceEdit {
+		newText = "target_extra($0)",
+		insert = {start = {line = 3, character = 8}, end = {line = 3, character = 12}},
+		replace = {start = {line = 3, character = 8}, end = {line = 3, character = 14}},
+	}
+
+	test.expect_completion_edits(t, &source, "", "target_extra", expected_edit)
+}
+
+@(test)
+completion_insert_replace_edit_fallback :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+			target_extra :: proc(value: int) {}
+			main :: proc() {
+				_ = targ{*}et
+			}
+			`,
+		config = {enable_snippets = true, enable_procedure_snippet = true, completion_insert_replace_support = false},
+	}
+
+	expected_edit := server.TextEdit {
+		newText = "target_extra($0)",
+		range = {start = {line = 3, character = 8}, end = {line = 3, character = 12}},
+	}
+
+	test.expect_completion_edits(t, &source, "", "target_extra", expected_edit)
+}
+
+@(test)
+completion_insert_replace_edit_utf16 :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		Thing :: struct {héllö_extra: int}
+		main :: proc() {
+			thing: Thing
+			_ = "😀"; _ = thing.héll{*}ö
+		}
+		`,
+		config = {completion_insert_replace_support = true},
+	}
+
+	test.expect_completion_edits(
+		t,
+		&source,
+		".",
+		"héllö_extra",
+		server.InsertReplaceEdit {
+			newText = "héllö_extra",
+			insert = {start = {line = 4, character = 23}, end = {line = 4, character = 27}},
+			replace = {start = {line = 4, character = 23}, end = {line = 4, character = 28}},
+		},
+	)
+}
+
+@(test)
+completion_insert_replace_with_additional_edits :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package test
+		main :: proc() {
+			_ = ff{*}
+		}
+		`,
+		config = {enable_snippets = true, completion_insert_replace_support = true},
+	}
+
+	test.expect_completion_edits(
+		t,
+		&source,
+		"",
+		"ff",
+		nil,
+		{{newText = "import \"core:fmt\" \n", range = {start = {line = 2}, end = {line = 2}}}},
+	)
+}
 
 @(test)
 ast_simple_struct_completion :: proc(t: ^testing.T) {


### PR DESCRIPTION
Resolves #1638

Instead of letting the editor decide/guess the range and operation, we can explicitly return [insert and replace range](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#insertReplaceEdit). This will prevent some editors from unexpectedly replacing the surrounding tokens/identifiers. So, for example, in zed, I can use one with insert with Enter (`ses|existing` → `sessionexisting`) and replace one with `Shift+Enter` (replace `ses|existing` → `session`)

---

I tested this with zed and vs code.