### PR TITLE
Compile on OpenBSD

### DIFF
--- a/src/common/util.odin
+++ b/src/common/util.odin
@@ -79,7 +79,7 @@ resolve_home_dir :: proc(
 }
 
 FILE :: struct {}
-when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .Linux || ODIN_OS == .NetBSD {
+when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .Linux || ODIN_OS == .NetBSD {
 
 	run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) {
 		fp := popen(strings.clone_to_cstring(command, context.temp_allocator), "r")


### PR DESCRIPTION
I had a need to use ols on OpenBSD. After making the small adjustment in '/src/common/util.odin' I'm happy to report it works with no noticeable issues so far.  