### PR TITLE
Skip nil arenas when shutting down document storage

### DIFF
--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -58,7 +58,6 @@ document_storage: DocumentStorage
 
 document_storage_shutdown :: proc() {
 	for k, v in document_storage.documents {
-		//`document_close` returns the arena to `free_allocators` and nils the field, but keeps the document in the map
 		if v.allocator != nil {
 			virtual.arena_destroy(v.allocator)
 			free(v.allocator)

--- a/src/server/documents.odin
+++ b/src/server/documents.odin
@@ -58,8 +58,11 @@ document_storage: DocumentStorage
 
 document_storage_shutdown :: proc() {
 	for k, v in document_storage.documents {
-		virtual.arena_destroy(v.allocator)
-		free(v.allocator)
+		//`document_close` returns the arena to `free_allocators` and nils the field, but keeps the document in the map
+		if v.allocator != nil {
+			virtual.arena_destroy(v.allocator)
+			free(v.allocator)
+		}
 		delete(k)
 	}
 


### PR DESCRIPTION
Fixes #1641.

`ols` segfaults on every exit if the client closed a document during the session. In a real editor the trigger is just: open a file, close the buffer, quit.

## Cause

`document_close` returns the document's arena to the reuse pool and nils the field, but leaves the `Document` in the map:

```odin
document_free_allocator(document.allocator)

document.allocator = nil
document.client_owned = false
```

`document_storage_shutdown` then walked every map entry and destroyed `v.allocator` unconditionally. For any closed document that pointer is nil, and `virtual.arena_destroy` locks `arena.mutex` on its first line:

```odin
arena_destroy :: proc(arena: ^Arena, loc := #caller_location) {
	sync.mutex_guard(&arena.mutex)
	...
}
```

`mutex` sits at offset `0x38` in `virtual.Arena`, which matches the fault exactly — `segfault at 38`, `error 6` (user-mode write to a non-present page), `rdi = 0x0`, faulting on `xchg %esi,0x38(%rdi)`.

This is a regression from 02658e0e, which swapped `common.Scratch_Allocator` for `core:mem/virtual.Arena`. The old `scratch_allocator_destroy` opened with `if s == nil { return }`; `arena_destroy` has no such guard, and the check was deleted along with the old allocator. `document.allocator = nil` has been there since 2020 and was safe until that swap.

## Fix

Skip the nil case. The reuse pool is otherwise sound — a recycled arena is owned by either a document or `free_allocators`, never both — so the second loop still destroys it exactly once. No double free, no leak.

## Verification

Driving the server over stdio, before and after:

| sequence | before | after |
|---|---|---|
| `didOpen` → `exit` | exit 0 | exit 0 |
| `didOpen` → `didClose` → `exit` | **SIGSEGV** | exit 0 |
| `didOpen` → `didClose` → `didOpen` → `exit` | **SIGSEGV** | exit 0 |

The repro script is in #1641.

Local CI is green: 888/888 tests pass, and the odinfmt snapshot tests pass.
