### PR TITLE
Remove docs and comments hack

### DIFF
--- a/src/server/analysis.odin
+++ b/src/server/analysis.odin
@@ -4276,9 +4276,6 @@ make_symbol_bit_field_from_ast :: proc(
 	name: string,
 	inlined := false,
 ) -> Symbol {
-	// We clone this so we don't override docs and comments with temp allocated docs and comments
-	v := cast(^ast.Bit_Field_Type)clone_node(v, ast_context.allocator, nil)
-	construct_bit_field_field_docs(ast_context.file, v)
 	symbol := Symbol {
 		range = common.get_token_range(v, ast_context.file.src),
 		type  = .Struct,

--- a/src/server/ast.odin
+++ b/src/server/ast.odin
@@ -413,7 +413,6 @@ collect_value_decl :: proc(
 		return
 	}
 	comment, _ := get_file_comment(file, value_decl.pos.line)
-
 	attributes := merge_attributes(value_decl.attributes[:], foreign_attrs)
 
 	global_expr := GlobalExpr {
@@ -1473,92 +1472,6 @@ repeat :: proc(value: string, count: int, allocator := context.allocator) -> str
 		return ""
 	}
 	return strings.repeat(value, count, allocator)
-}
-
-// Corrects docs and comments on a Struct_Type. Creates new nodes and adds them to the provided struct
-// using the provided allocator, so `v` should have the same lifetime as the allocator.
-construct_struct_field_docs :: proc(file: ast.File, v: ^ast.Struct_Type, allocator := context.temp_allocator) {
-	if v.fields == nil {
-		return
-	}
-	for field, i in v.fields.list {
-		// There is currently a bug in the odin parser where it adds line comments for a field to the
-		// docs of the following field, we address this problem here.
-		// see https://github.com/odin-lang/Odin/issues/5353
-		// Edit 2025-07-12 it looks like the comments are now added (for structs), however the comments are still
-		// incorrectly added to the following fields docs, and there's an issue where it will only
-		// append the comment if there is a ',' at the end of the line (meaning it can easily be
-		// skipped on the last line) eg
-		// Foo :: struct {
-		//     foo: int // my int <-- skipped as no ',' after 'int'
-		// }
-
-		// remove any unwanted docs
-		if i != len(v.fields.list) - 1 {
-			next_field := v.fields.list[i + 1]
-			if next_field.docs != nil && len(next_field.docs.list) > 0 {
-				list := next_field.docs.list
-				if list[0].pos.line == field.pos.line {
-					// if the comment is missing from the appropriate field, we add it (for older versions of the parser)
-					if field.comment == nil {
-						field.comment = new_type(ast.Comment_Group, list[0].pos, parser.end_pos(list[0]), allocator)
-						field.comment.list = list[:1]
-					}
-					if len(list) > 1 {
-						next_field.docs = new_type(
-							ast.Comment_Group,
-							list[1].pos,
-							parser.end_pos(list[len(list) - 2]),
-							allocator,
-						)
-						next_field.docs.list = list[1:]
-					} else {
-						next_field.docs = nil
-					}
-				}
-			}
-		} else if field.comment == nil {
-			// We need to check the file to see if it contains a line comment as it might be skipped
-			field.comment, _ = get_file_comment(file, field.pos.line, allocator = allocator)
-		}
-	}
-}
-
-// Corrects docs and comments on a Bit_Field_Type. Creates new nodes and adds them to the provided bit_field
-// using the provided allocator, so `v` should have the same lifetime as the allocator.
-construct_bit_field_field_docs :: proc(file: ast.File, v: ^ast.Bit_Field_Type, allocator := context.temp_allocator) {
-	for field, i in v.fields {
-		// There is currently a bug in the odin parser where it adds line comments for a field to the
-		// docs of the following field, we address this problem here.
-		// see https://github.com/odin-lang/Odin/issues/5353
-		// We check if the comment is at the start of the next field
-		if i != len(v.fields) - 1 {
-			next_field := v.fields[i + 1]
-			if next_field.docs != nil && len(next_field.docs.list) > 0 {
-				list := next_field.docs.list
-				if list[0].pos.line == field.pos.line {
-					if field.comments == nil {
-						field.comments = new_type(ast.Comment_Group, list[0].pos, parser.end_pos(list[0]), allocator)
-						field.comments.list = list[:1]
-					}
-					if len(list) > 1 {
-						next_field.docs = new_type(
-							ast.Comment_Group,
-							list[1].pos,
-							parser.end_pos(list[len(list) - 2]),
-							allocator,
-						)
-						next_field.docs.list = list[1:]
-					} else {
-						next_field.docs = nil
-					}
-				}
-			}
-		} else if field.comments == nil {
-			// We need to check the file to see if it contains a line comment as there is no next field
-			field.comments, _ = get_file_comment(file, field.pos.line, allocator = allocator)
-		}
-	}
 }
 
 // Retrives the comment group from the specified line of the file

--- a/src/server/collector.odin
+++ b/src/server/collector.odin
@@ -140,7 +140,6 @@ collect_struct_fields :: proc(
 	file: ast.File,
 ) -> SymbolStructValue {
 	b := symbol_struct_value_builder_make(collection.allocator)
-	construct_struct_field_docs(file, struct_type, collection.allocator)
 
 	for field in struct_type.fields.list {
 		for n in field.names {
@@ -201,7 +200,6 @@ collect_bit_field_fields :: proc(
 	package_map: map[string]string,
 	file: ast.File,
 ) -> SymbolBitFieldValue {
-	construct_bit_field_field_docs(file, bit_field_type, collection.allocator)
 	names := make([dynamic]string, 0, len(bit_field_type.fields), collection.allocator)
 	types := make([dynamic]^ast.Expr, 0, len(bit_field_type.fields), collection.allocator)
 	ranges := make([dynamic]common.Range, 0, len(bit_field_type.fields), collection.allocator)
@@ -964,8 +962,7 @@ collect_symbols :: proc(collection: ^SymbolCollection, file: ast.File, uri: stri
 		symbol.uri = get_index_unique_string(collection, uri)
 		symbol.type_expr = clone_type(expr.type_expr, collection.allocator, &collection.unique_strings)
 		symbol.value_expr = clone_type(expr.value_expr, collection.allocator, &collection.unique_strings)
-		comment, _ := get_file_comment(file, symbol.range.start.line + 1)
-		symbol.comment = get_comment(comment, collection.allocator)
+		symbol.comment = get_comment(expr.comment, collection.allocator)
 
 		// symbol.pkg was already set earlier before the switch
 

--- a/src/server/symbol.odin
+++ b/src/server/symbol.odin
@@ -395,9 +395,6 @@ write_struct_type :: proc(
 	base_using_index: int,
 ) {
 	b.poly = v.poly_params
-	// We clone this so we don't override docs and comments with temp allocated docs and comments
-	v := cast(^ast.Struct_Type)clone_node(v, ast_context.allocator, nil)
-	construct_struct_field_docs(ast_context.file, v, ast_context.allocator)
 	for field in v.fields.list {
 		for n in field.names {
 			if identifier, ok := n.derived.(^ast.Ident); ok && field.type != nil {


### PR DESCRIPTION
Now that https://github.com/odin-lang/Odin/pull/7481 has been merged, we no longer need these hacks for managing the docs and comments.