### PR TITLE
bugfix: four odinfmt defects that silently damage or refuse valid source

### DIFF
--- a/src/odin/printer/document.odin
+++ b/src/odin/printer/document.odin
@@ -475,6 +475,10 @@ format :: proc(width: int, list: ^[dynamic]Tuple, builder: ^strings.Builder, p: 
 			if len(suffix_builder.buf) == 0 {
 				pending_suffix_column = consumed
 				pending_suffix_alignable = v.alignable
+			} else {
+				// Suffixes landing on the same output line would otherwise concatenate, and
+				// `// a// b` makes the second `//` literal text inside the first comment.
+				strings.write_string(&suffix_builder, " ")
 			}
 			strings.write_string(&suffix_builder, v.value)
 		case Document_Break_Parent:

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -40,6 +40,9 @@ Disabled_Info :: struct {
 	empty:      bool,
 	start_line: int,
 	end_line:   int,
+	// Where `text` starts in the source. A suppressed declaration can begin earlier than this,
+	// since its attributes sit above the directive, so visit_disabled emits those separately.
+	begin:      int,
 }
 
 Trailing_Comment_Record :: struct {
@@ -246,6 +249,7 @@ build_disabled_lines_info :: proc(p: ^Printer) {
 					end_line   = comment.pos.line,
 					text       = p.src[begin:end],
 					empty      = empty,
+					begin      = begin,
 				}
 
 				for line in disable_position.line ..= comment.pos.line {

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -188,7 +188,14 @@ visit_disabled :: proc(p: ^Printer, node: ^ast.Node) -> ^Document {
 	p.source_position = node.end
 	p.source_position.line = disabled_info.end_line
 
-	document := cons(move, text(disabled_info.text))
+	// Attributes are part of the declaration but sit above the directive, so they fall outside
+	// `text` and outside ordinary visiting. Dropping them silently un-privatises a declaration.
+	prefix := empty()
+	if node_pos.offset < disabled_info.begin {
+		prefix = text(p.src[node_pos.offset:disabled_info.begin])
+	}
+
+	document := cons(move, prefix, text(disabled_info.text))
 
 	for comment_before_or_in_line(p, disabled_info.end_line + 1) {
 		// we need to handle the rest of the comment group
@@ -1286,7 +1293,12 @@ visit_stmt :: proc(
 		set_source_position(p, v.body.end)
 
 		if v.else_stmt != nil {
-			else_on_newline := p.config.brace_style == .Allman || p.config.brace_style == .Stroustrup
+			// A `do` body has no closing brace, so an `else` on the same line is not valid Odin.
+			// If_Stmt already does this.
+			else_on_newline :=
+				p.config.brace_style == .Allman ||
+				p.config.brace_style == .Stroustrup ||
+				(!p.config.convert_do && block_uses_do(v.body))
 			if else_on_newline {
 				document = cons(document, newline(1))
 			}
@@ -1298,6 +1310,10 @@ visit_stmt :: proc(
 			} else {
 				document = cons_with_nopl(document, cons_with_nopl(text("else"), visit_stmt(p, v.else_stmt)))
 			}
+		}
+
+		if !p.config.convert_do {
+			document = enforce_fit_if_do(v.body, document)
 		}
 	case ^ast.Branch_Stmt:
 		document = cons(document, text(v.tok.text))
@@ -2100,6 +2116,23 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		declaration_align := empty()
 
 		p.source_position = field.pos
+
+		// A field is neither a Decl nor a Stmt, so it reaches neither place that consults
+		// disabled_lines and the region has to be emitted here. Its text already carries the
+		// source's indentation, hence escape_nest and the trim of the first line.
+		if info, disabled := p.disabled_lines[field.pos.line]; disabled && info.text != "" {
+			if p.disabled_until_line > field.pos.line {
+				continue // already emitted by an earlier iteration
+			}
+			p.disabled_until_line = info.end_line
+			p.source_position = field.end
+			p.source_position.line = info.end_line
+			document = cons(document, escape_nest(text(strings.trim_left(info.text, " \t"))))
+			if i != len(list.list) - 1 {
+				document = cons(document, newline(1))
+			}
+			continue
+		}
 
 		if i == 0 && .Enforce_Newline in options {
 			comment, ok := visit_comments(p, list.list[i].pos)

--- a/tools/odinfmt/tests/.snapshots/comments.odin
+++ b/tools/odinfmt/tests/.snapshots/comments.odin
@@ -85,3 +85,29 @@ Bar :: struct{}
 
 // Foo doc
 Foo :: struct {}
+
+// Merged trailing comments must not glue into `// first// second`.
+check_two :: proc(cond: bool, msg: string) {}
+
+two_trailing_comments_on_one_line :: proc() {
+	check_two(
+		len("a") > 0 && len("b") > 0, // first // second
+		"message",
+	)
+}
+
+// An attribute above the directive is still part of the declaration and must survive.
+@(private)
+//odinfmt:disable
+guarded_private_helper :: proc() -> int {
+	return 1
+}
+//odinfmt:enable
+
+// A disable region inside a field list must be honoured, not dropped.
+Guarded_Fields :: struct {
+	//odinfmt:disable
+	code:  string,
+	//odinfmt:enable
+	why:  string,
+}

--- a/tools/odinfmt/tests/.snapshots/when_do.odin
+++ b/tools/odinfmt/tests/.snapshots/when_do.odin
@@ -1,0 +1,9 @@
+package when_do
+
+// A `do` body has no closing brace, so flattening this chain produces invalid Odin.
+current_platform_string :: proc() -> string {
+	when ODIN_OS == .Darwin do return "darwin"
+	else when ODIN_OS == .Linux do return "linux"
+	else when ODIN_OS == .Windows do return "win32"
+	else do return "unknown"
+}

--- a/tools/odinfmt/tests/comments.odin
+++ b/tools/odinfmt/tests/comments.odin
@@ -85,3 +85,30 @@ Bar :: struct{}
 
 // Foo doc
 Foo :: struct   {}
+
+// Merged trailing comments must not glue into `// first// second`.
+check_two :: proc(cond: bool, msg: string) {}
+
+two_trailing_comments_on_one_line :: proc() {
+	check_two(
+		len("a") > 0 && // first
+		len("b") > 0, // second
+		"message",
+	)
+}
+
+// An attribute above the directive is still part of the declaration and must survive.
+@(private)
+//odinfmt:disable
+guarded_private_helper :: proc() -> int {
+	return 1
+}
+//odinfmt:enable
+
+// A disable region inside a field list must be honoured, not dropped.
+Guarded_Fields :: struct {
+	//odinfmt:disable
+	code:  string,
+	//odinfmt:enable
+	why:   string,
+}

--- a/tools/odinfmt/tests/when_do.odin
+++ b/tools/odinfmt/tests/when_do.odin
@@ -1,0 +1,9 @@
+package when_do
+
+// A `do` body has no closing brace, so flattening this chain produces invalid Odin.
+current_platform_string :: proc() -> string {
+	when ODIN_OS == .Darwin do return "darwin"
+	else when ODIN_OS == .Linux do return "linux"
+	else when ODIN_OS == .Windows do return "win32"
+	else do return "unknown"
+}


### PR DESCRIPTION
Each of these was found by running odinfmt over a 2392-file Odin codebase, and each one is silent: three produce output that looks fine, and the compiler cannot object to any of them because comments and attributes are not behaviour. The exception is the `when`/`do` one, which emits source that does not compile at all.

--------------------------------------------------------------------------------
1. Two trailing comments merged onto one line are glued together

Line suffixes are queued and flushed at the next newline, so when the layout puts two commented lines onto one output line their texts meet in the same builder. They were concatenated with no separator, turning the second `//` from a marker into literal text inside the first comment. The merged form is a fixed point, so `odinfmt -w` reports the file clean on every run afterwards.

before:
	check(
		strings.contains("a", "b") && // first
		strings.contains("c", "d"), // second
		"message",
	)
	// becomes, and is then stable forever:
	check(
		strings.contains("a", "b") && strings.contains("c", "d"), // first// second
		"message",
	)

after:
	check(
		strings.contains("a", "b") && strings.contains("c", "d"), // first // second
		"message",
	)

--------------------------------------------------------------------------------
2. odinfmt:disable between an attribute and its declaration drops the attribute

An attribute is part of the declaration it precedes but is written on an earlier line. When a disable region begins between the two, the declaration is skipped from ordinary visiting because its line is disabled, and the raw slice that replaces it starts at the directive -- so the attribute is emitted by neither mechanism. visit_disabled already rewinds its cursor to the attribute and then writes text that begins lower down, stepping over it.

This is not a formatting change: `@(private)` disappearing makes a package-private declaration exported, silently, inside a region the author marked untouchable.

before:
	@(private)
	//odinfmt:disable
	helper :: proc() -> int { return 1 }
	//odinfmt:enable
	// becomes -- note the missing attribute:
	//odinfmt:disable
	helper :: proc() -> int { return 1 }
	//odinfmt:enable

after: the attribute survives.

--------------------------------------------------------------------------------
3. A `when ... do ... else when ...` chain is flattened into source that does not compile

A `do` body has no closing brace to separate it from a following `else`, so the chain cannot be laid out on one line -- the parser wants a `;` or a newline. If_Stmt already keeps the newline for a `do` body; When_Stmt was missed, so formatting a compiling file produced a file that does not.

before:
	when ODIN_OS == .Darwin do return "darwin"
	else when ODIN_OS == .Linux do return "linux"
	else do return "unknown"
	// becomes, and `odin check` then rejects it with `Expected ';', got else`:
	when ODIN_OS == .Darwin do return "darwin" else when ODIN_OS == .Linux do return "linux" else do return "unknown"

after: the chain keeps its newlines and the output compiles.

--------------------------------------------------------------------------------
4. odinfmt:disable inside a field list is silently a no-op

A field is neither a Decl nor a Stmt, so it never reaches either of the two places that consult disabled_lines. Both directives were consumed as ordinary comments and dropped, and the fields between them were formatted anyway -- a guard that silently does nothing, which is worse than one that fails loudly.

before:
	Err :: struct {
		//odinfmt:disable
		code: string,
		//odinfmt:enable
		why:  string,
	}
	// becomes -- directives gone, alignment applied inside the guarded region:
	Err :: struct {

		code: string,
		why:  string,
	}

after: the region is emitted verbatim and both directives survive.

-------------------------------------------------------------------------------- Tested: the existing snapshot suite plus regression cases for all four (tools/odinfmt/tests/comments.odin and tools/odinfmt/tests/when_do.odin), each verified to fail without its fix. Also run over a 2392-file codebase: no file becomes unparseable, the formatter remains a fixed point, and no file outside vendored third-party trees changes.