### PR TITLE
Implement attribute completion

### DIFF
--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -118,10 +118,6 @@ get_completion_list :: proc(
 		completion_type = .Directive
 	}
 
-	// Attributes are matched against the source rather than the AST. A
-	// half-typed `@(` leaves the declaration it belongs to unparseable, so by
-	// the time the user wants this completion there is no Attribute node to
-	// find — the same reason the position context has no field for one.
 	if is_in_attribute(&position_context) {
 		completion_type = .Attribute
 	}
@@ -747,17 +743,6 @@ get_completion_description :: proc(ast_context: ^AstContext, symbol: Symbol) -> 
 	return get_short_signature(ast_context, symbol)
 }
 
-/*
-	Is the position inside an attribute, i.e. after an `@` or inside its `(...)`?
-
-	Scans the source backwards from the cursor instead of consulting the AST: an
-	attribute is typed before the declaration it applies to, so while the user is
-	writing one there is no complete declaration to hang an ast.Attribute off.
-
-	Stops at a newline, since an attribute's `@` is always on the same line as
-	the name being completed, and bails on `)` so a finished `@(private)` on the
-	same line does not keep offering attributes afterwards.
-*/
 is_in_attribute :: proc(position_context: ^DocumentPositionContext) -> bool {
 	src := position_context.file.src
 	pos := position_context.position
@@ -766,15 +751,11 @@ is_in_attribute :: proc(position_context: ^DocumentPositionContext) -> bool {
 		return false
 	}
 
-	// `=` means a value is expected rather than another attribute name, but only
-	// for the pair being written: in `@(link_name="x", req|` the `=` belongs to a
-	// pair already finished off by the comma.
 	crossed_comma := false
 
 	for i := pos - 1; i >= 0; i -= 1 {
 		switch src[i] {
 		case '@':
-			// An `@` in a comment is not an attribute.
 			return !position_in_comment(position_context.file, pos)
 		case '\n', ')':
 			return false
@@ -787,7 +768,6 @@ is_in_attribute :: proc(position_context: ^DocumentPositionContext) -> bool {
 		case '(', ' ', '\t', '"':
 			continue
 		case:
-			// Only an identifier can sit between `@` and the cursor.
 			if !tokenizer.is_letter(rune(src[i])) && !tokenizer.is_digit(rune(src[i])) {
 				return false
 			}

--- a/src/server/completion.odin
+++ b/src/server/completion.odin
@@ -34,6 +34,7 @@ Completion_Type :: enum {
 	Comp_Lit,
 	Directive,
 	Package,
+	Attribute,
 }
 
 get_completion_list :: proc(
@@ -117,6 +118,14 @@ get_completion_list :: proc(
 		completion_type = .Directive
 	}
 
+	// Attributes are matched against the source rather than the AST. A
+	// half-typed `@(` leaves the declaration it belongs to unparseable, so by
+	// the time the user wants this completion there is no Attribute node to
+	// find — the same reason the position context has no field for one.
+	if is_in_attribute(&position_context) {
+		completion_type = .Attribute
+	}
+
 	if position_context.implicit {
 		completion_type = .Implicit
 	}
@@ -170,6 +179,8 @@ get_completion_list :: proc(
 		is_incomplete = get_type_switch_completion(&ast_context, &position_context, &results)
 	case .Directive:
 		is_incomplete = get_directive_completion(&ast_context, &position_context, &results)
+	case .Attribute:
+		is_incomplete = get_attribute_completion(&ast_context, &position_context, &results)
 	case .Package:
 		is_incomplete = get_package_completion(&ast_context, &position_context, &results, config)
 	}
@@ -736,13 +747,96 @@ get_completion_description :: proc(ast_context: ^AstContext, symbol: Symbol) -> 
 	return get_short_signature(ast_context, symbol)
 }
 
+/*
+	Is the position inside an attribute, i.e. after an `@` or inside its `(...)`?
+
+	Scans the source backwards from the cursor instead of consulting the AST: an
+	attribute is typed before the declaration it applies to, so while the user is
+	writing one there is no complete declaration to hang an ast.Attribute off.
+
+	Stops at a newline, since an attribute's `@` is always on the same line as
+	the name being completed, and bails on `)` so a finished `@(private)` on the
+	same line does not keep offering attributes afterwards.
+*/
+is_in_attribute :: proc(position_context: ^DocumentPositionContext) -> bool {
+	src := position_context.file.src
+	pos := position_context.position
+
+	if pos > len(src) {
+		return false
+	}
+
+	// `=` means a value is expected rather than another attribute name, but only
+	// for the pair being written: in `@(link_name="x", req|` the `=` belongs to a
+	// pair already finished off by the comma.
+	crossed_comma := false
+
+	for i := pos - 1; i >= 0; i -= 1 {
+		switch src[i] {
+		case '@':
+			// An `@` in a comment is not an attribute.
+			return !position_in_comment(position_context.file, pos)
+		case '\n', ')':
+			return false
+		case ',':
+			crossed_comma = true
+		case '=':
+			if !crossed_comma {
+				return false
+			}
+		case '(', ' ', '\t', '"':
+			continue
+		case:
+			// Only an identifier can sit between `@` and the cursor.
+			if !tokenizer.is_letter(rune(src[i])) && !tokenizer.is_digit(rune(src[i])) {
+				return false
+			}
+		}
+	}
+
+	return false
+}
+
+position_in_comment :: proc(file: ast.File, position: common.AbsolutePosition) -> bool {
+	for group in file.comments {
+		if group.pos.offset <= position && position <= group.end.offset {
+			return true
+		}
+	}
+
+	return false
+}
+
+completion_items_attributes: []CompletionResult
+
+@(init)
+_init_completion_items_attributes :: proc "contextless" () {
+	context = runtime.default_context()
+	attributes := make([dynamic]CompletionResult, 0, len(attribute_docs), allocator = context.allocator)
+	for name, doc in attribute_docs {
+		documentation := MarkupContent {
+			kind  = "markdown",
+			value = doc,
+		}
+		append(
+			&attributes,
+			CompletionResult {
+				completion_item = CompletionItem{label = name, kind = .Keyword, documentation = documentation},
+			},
+		)
+	}
+	completion_items_attributes = attributes[:]
+}
+
 get_attribute_completion :: proc(
 	ast_context: ^AstContext,
 	position_context: ^DocumentPositionContext,
-	list: ^CompletionList,
-) {
+	results: ^[dynamic]CompletionResult,
+) -> bool {
+	spall.trace(#procedure, ast_context.fullpath)
 
-
+	append(results, ..completion_items_attributes[:])
+	return false
 }
 
 completion_items_directives: []CompletionResult

--- a/src/server/documentation.odin
+++ b/src/server/documentation.odin
@@ -1160,3 +1160,68 @@ directive_docs: map[string]string = {
 	"load_hash"                = "```odin\n#load_hash(<string-path>, <string-hash>)\n```\n\nReturns a constant integer of the hash of a file’s contents at compile time..\n\nAvailable hashes:\n\n- adler32\n- crc32\n- crc64\n- fnv32\n- fnv64\n- fnv32a\n- fnv64a\n- murmur32\n- murmur64",
 	"load_directory"           = "```odin\n#load_directory(<string-path>)\n```\n\nLoads all files within a directory, at compile time. All the data of those files will be baked into your program. Returns `[]runtime.Load_Directory_File`.",
 }
+
+attribute_docs: map[string]string = {
+	// Visibility
+	"private"                    = "```odin\n@(private)\n// or\n@(private=\"file\")\n// or\n@(private=\"package\")\n```\n\nRestricts the visibility of a declaration. `@(private)` alone is equivalent to `@(private=\"package\")`: the entity is visible within its own package but not exported. `@(private=\"file\")` narrows it further to the file it is declared in.",
+	"export"                     = "```odin\n@(export)\n// or\n@(export=<boolean>)\n```\n\nExports the symbol from the compiled object, making it visible to other languages and linkers. Useful when building a shared library.",
+	"link_name"                  = "```odin\n@(link_name=<string>)\n```\n\nSets the symbol name used by the linker, rather than deriving it from the Odin declaration. Common when binding to an existing C symbol whose name is not a valid Odin identifier.",
+	"link_prefix"                = "```odin\n@(link_prefix=<string>)\n```\n\nPrepends a string to the linker names of all procedures in a `foreign` block. Lets bindings drop a repeated C prefix from the Odin-side names.",
+	"link_suffix"                = "```odin\n@(link_suffix=<string>)\n```\n\nAppends a string to the linker names of all procedures in a `foreign` block.",
+	"link_section"               = "```odin\n@(link_section=<string>)\n```\n\nPlaces the entity in a specific section of the object file.",
+	"linkage"                    = "```odin\n@(linkage=<string>)\n```\n\nSets the linkage of the entity. One of `\"internal\"`, `\"strong\"`, `\"weak\"`, `\"link_once\"`.",
+	// Deferred calls
+	"deferred_none"              = "```odin\n@(deferred_none=<procedure>)\n```\n\nCalls `<procedure>` when the scope containing the call to the attributed procedure exits. No arguments are passed to the deferred procedure.\n\nUseful for pairing acquire/release procedures so callers cannot forget the release.",
+	"deferred_in"                = "```odin\n@(deferred_in=<procedure>)\n```\n\nCalls `<procedure>` on scope exit, passing it the *arguments* that were given to the attributed procedure.",
+	"deferred_out"               = "```odin\n@(deferred_out=<procedure>)\n```\n\nCalls `<procedure>` on scope exit, passing it the *return values* of the attributed procedure.",
+	"deferred_in_out"            = "```odin\n@(deferred_in_out=<procedure>)\n```\n\nCalls `<procedure>` on scope exit, passing it both the arguments and the return values of the attributed procedure.",
+	"deferred_in_by_ptr"         = "```odin\n@(deferred_in_by_ptr=<procedure>)\n```\n\nAs `deferred_in`, but the arguments are passed by pointer.",
+	"deferred_out_by_ptr"        = "```odin\n@(deferred_out_by_ptr=<procedure>)\n```\n\nAs `deferred_out`, but the return values are passed by pointer.",
+	"deferred_in_out_by_ptr"     = "```odin\n@(deferred_in_out_by_ptr=<procedure>)\n```\n\nAs `deferred_in_out`, but the values are passed by pointer.",
+	// Program lifecycle
+	"init"                       = "```odin\n@(init)\n```\n\nRuns the procedure automatically before `main` is entered. The procedure must take no arguments and return nothing.",
+	"fini"                       = "```odin\n@(fini)\n```\n\nRuns the procedure automatically after `main` returns. The procedure must take no arguments and return nothing.",
+	"test"                       = "```odin\n@(test)\n```\n\nMarks the procedure as a test, to be run by `odin test`. The procedure takes a single `^testing.T` parameter.",
+	// Call-site requirements
+	"require_results"            = "```odin\n@(require_results)\n```\n\nMakes it a compile error to discard the procedure's return values. Useful when ignoring the result is always a bug, such as a procedure returning an error.",
+	"require"                    = "```odin\n@(require)\n```\n\nForces the entity to be included in the build even when it appears to be unused.",
+	"disabled"                   = "```odin\n@(disabled=<boolean>)\n```\n\nWhen the condition is true, calls to the procedure are removed at compile time. The procedure must not return any values. Commonly used for assertions and logging that should vanish in release builds.",
+	// Calling convention and codegen
+	"default_calling_convention" = "```odin\n@(default_calling_convention=<string>)\n```\n\nSets the calling convention for every procedure in a `foreign` block, e.g. `\"c\"` or `\"stdcall\"`, so each declaration does not have to repeat it.",
+	"optimization_mode"          = "```odin\n@(optimization_mode=<string>)\n```\n\nSets the optimization mode for a single procedure. One of `\"none\"`, `\"minimal\"`, `\"size\"`, `\"speed\"`.",
+	"cold"                       = "```odin\n@(cold)\n```\n\nHints to the compiler that the procedure is rarely called, so it can be optimized for size and moved off the hot path.",
+	"instrumentation_enter"      = "```odin\n@(instrumentation_enter)\n```\n\nMarks the procedure as the one called on entry to every instrumented procedure. Used with `-sanitize:address` style instrumentation builds.",
+	"instrumentation_exit"       = "```odin\n@(instrumentation_exit)\n```\n\nMarks the procedure as the one called on exit from every instrumented procedure.",
+	"rodata"                     = "```odin\n@(rodata)\n```\n\nPlaces the variable in read-only memory.",
+	"static"                     = "```odin\n@(static)\n```\n\nGives a local variable static storage duration, so it persists across calls rather than living on the stack.",
+	"thread_local"               = "```odin\n@(thread_local)\n```\n\nGives the variable thread-local storage, so each thread gets its own copy.",
+	// Objective-C interop
+	"objc_class"                 = "```odin\n@(objc_class=<string>)\n```\n\nBinds the type to an Objective-C class of the given name.",
+	"objc_name"                  = "```odin\n@(objc_name=<string>)\n```\n\nBinds the procedure to an Objective-C selector of the given name.",
+	"objc_type"                  = "```odin\n@(objc_type=<type>)\n```\n\nAssociates the procedure with an Objective-C bound type, making it callable as a method on that type.",
+	"objc_is_class_method"       = "```odin\n@(objc_is_class_method=<boolean>)\n```\n\nMarks the bound Objective-C method as a class method rather than an instance method.",
+	// Miscellaneous
+	"builtin"                    = "```odin\n@(builtin)\n```\n\nMakes the entity available without qualification, as the `builtin` package does.",
+	"deprecated"                 = "```odin\n@(deprecated=<string>)\n```\n\nMarks the entity as deprecated. The string is reported as a warning at each use site, and should say what to use instead.",
+	"extra_linker_flags"         = "```odin\n@(extra_linker_flags=<string>)\n```\n\nPasses additional flags to the linker for a `foreign` block or `foreign import`.",
+	// Sanitizers and instrumentation
+	"no_instrumentation"         = "```odin\n@(no_instrumentation)\n```\n\nExcludes the procedure from the instrumentation applied by `@(instrumentation_enter)` / `@(instrumentation_exit)`.",
+	"no_sanitize_address"        = "```odin\n@(no_sanitize_address)\n```\n\nExcludes the procedure from address sanitizer instrumentation. Takes no parameter.",
+	"no_sanitize_memory"         = "```odin\n@(no_sanitize_memory)\n```\n\nExcludes the procedure from memory sanitizer instrumentation. Takes no parameter.",
+	"no_sanitize_thread"         = "```odin\n@(no_sanitize_thread)\n```\n\nExcludes the procedure from thread sanitizer instrumentation. Takes no parameter.",
+	// Target features and codegen
+	"enable_target_feature"      = "```odin\n@(enable_target_feature=<string>)\n```\n\nEnables the named target CPU features for this procedure, letting it use instructions the rest of the build is not compiled with.",
+	"require_target_feature"     = "```odin\n@(require_target_feature=<string>)\n```\n\nRequires the named target CPU features. The build fails if the target does not provide them.",
+	"fast_math"                  = "```odin\n@(fast_math=<bit_set>)\n```\n\nApplies floating-point fast-math flags to the procedure. Expects a constant `bit_set` of type `intrinsics.Fast_Math_Flags`.",
+	// Entry point and linking
+	"entry_point_only"           = "```odin\n@(entry_point_only)\n```\n\nMarks the entity as only usable from the entry point. Takes no parameter.",
+	"ignore_duplicates"          = "```odin\n@(ignore_duplicates)\n```\n\nAllows the declaration to be duplicated without the compiler reporting a redeclaration. Takes no parameter.",
+	"priority_index"             = "```odin\n@(priority_index=<integer>)\n```\n\nSets the ordering of a `foreign import` relative to others, for cases where link order matters.",
+	"raddbg_type_view"           = "```odin\n@(raddbg_type_view=<string>)\n```\n\nAttaches a RAD Debugger type view expression to the type, controlling how the debugger renders values of it.",
+	// Objective-C interop
+	"objc_selector"              = "```odin\n@(objc_selector=<identifier>)\n```\n\nSets the Objective-C selector the procedure binds to, when it differs from the Odin name.",
+	"objc_superclass"            = "```odin\n@(objc_superclass=<type>)\n```\n\nNames the Objective-C superclass of a type declared with `@(objc_class)`. Expects a named type.",
+	"objc_ivar"                  = "```odin\n@(objc_ivar=<type>)\n```\n\nNames the Odin type used as the instance-variable storage for an Objective-C class. Requires `@(objc_implement)`.",
+	"objc_implement"             = "```odin\n@(objc_implement)\n// or\n@(objc_implement=<boolean>)\n```\n\nImplements the Objective-C class in Odin rather than only binding to an existing one. Requires `@(objc_class)`.",
+	"objc_context_provider"      = "```odin\n@(objc_context_provider=<procedure>)\n```\n\nSupplies the Odin `context` used by bound Objective-C methods. Requires `@(objc_implement)`.",
+}

--- a/tests/completions_test.odin
+++ b/tests/completions_test.odin
@@ -6164,3 +6164,91 @@ ast_distinct_selector_array_swizzle_completion :: proc(t: ^testing.T) {
 
 	test.expect_completion_labels(t, &source, ".", {"x", "y", "z", "w", "r", "g", "b", "a"})
 }
+
+@(test)
+ast_attribute_completion :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		@({*})
+		foo :: proc() {}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "@", {"deferred_none", "private", "require_results", "init"})
+}
+
+@(test)
+ast_attribute_completion_partial :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		@(deferred{*})
+		foo :: proc() {}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "@", {"deferred_none", "deferred_in", "deferred_out"})
+}
+
+@(test)
+ast_attribute_completion_not_offered_in_code :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		main :: proc() {
+			my_local := 2
+			my_{*}
+		}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "", {"my_local"}, {"deferred_none", "private"})
+}
+
+@(test)
+ast_attribute_completion_not_offered_in_comment :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		main :: proc() {
+			my_local := 2
+			// @todo my_{*}
+		}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "", {"my_local"}, {"private", "deferred_none"})
+}
+
+@(test)
+ast_attribute_completion_not_offered_after_closed_attribute :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		@(private) my_glob{*}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "", {}, {"private", "deferred_none"})
+}
+
+@(test)
+ast_attribute_completion_not_offered_for_value :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		my_cleanup :: proc() {}
+		@(deferred_none=my_{*})
+		foo :: proc() {}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "", {"my_cleanup"}, {"private", "deferred_none"})
+}
+
+@(test)
+ast_attribute_completion_after_comma :: proc(t: ^testing.T) {
+	source := test.Source {
+		main = `package main
+		@(link_name="foo", requ{*})
+		bar :: proc() {}
+		`,
+	}
+
+	test.expect_completion_labels(t, &source, "", {"require", "require_results"})
+}


### PR DESCRIPTION
Closes #1625.

`get_attribute_completion` was an empty stub with no call site, so typing `@(` returned nothing. This implements it the same way `get_directive_completion` already works: an `attribute_docs` table next to `directive_docs`, an `.Attribute` completion type, and dispatch in `get_completion_list`.

The attribute names come from the compiler's `src/checker.cpp` rather than being written by hand, 51 of them. `force` is left out because the compiler rejects it with "'force' was replaced with 'require'".

**On the detection method.** `is_in_attribute` scans the source backwards for `@` instead of going through the AST. An attribute is typed before the declaration it applies to, so while you are still writing one there is no parseable declaration to hang an `ast.Attribute` off, which is also why `DocumentPositionContext` has no field for one. The scan:

- stops at `)`, so a finished `@(private)` earlier on the line does not keep offering attributes
- stops at `=`, so `@(deferred_none=my_proc` completes identifiers rather than attribute names, unless a comma has already closed that pair (`@(link_name="x", requ`)
- ignores an `@` inside a comment, checked against `file.comments`

Happy to move this to the position context instead if you would rather, it just needs the parser to hand back something usable for a half-typed attribute.

**Known gaps.** The parenthesis-less form (`@private`) is not offered, ols returns early on that shape before completion type selection. An attribute list split across lines is not completed past the first line, since the scan stops at a newline.

**Tests.** Seven tests in `tests/completions_test.odin`, covering the plain and partial cases and each of the three ways the scan bails out. Suite goes 894 to 901, all passing. The 9 failures on my machine are identical on a clean `master` checkout, all hover/doc-comment related and unrelated to this change.
