### PR TITLE
Align constant definitions in nested blocks

### DIFF
--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -975,6 +975,10 @@ visit_stmt :: proc(
 
 		set_source_position(p, v.pos)
 
+		if p.config.align_constant_definitions {
+			compute_constant_alignment(p, v.stmts)
+		}
+
 		block := visit_block_stmts(p, v.stmts)
 
 		comment_end, _ := visit_comments(p, tokenizer.Pos{line = v.end.line, offset = v.end.offset})

--- a/tools/odinfmt/tests/constant_align/.snapshots/constant_align.odin
+++ b/tools/odinfmt/tests/constant_align/.snapshots/constant_align.odin
@@ -34,3 +34,24 @@ Z :: 30
 SHORT         : int : 1
 VERY_LONG_NAME: int : 2
 MEDIUM        : int : 3
+
+main :: proc() {
+	SHORT       :: 1
+	LONGER_NAME :: 2
+
+	if true {
+		IF_SHORT       :: 1
+		IF_LONGER_NAME :: 2
+	}
+
+	when ODIN_OS == .Windows {
+		WHEN_SHORT       :: 1
+		WHEN_LONGER_NAME :: 2
+	}
+
+	for {
+		LOOP_SHORT       :: 1
+		LOOP_LONGER_NAME :: 2
+		break
+	}
+}

--- a/tools/odinfmt/tests/constant_align/constant_align.odin
+++ b/tools/odinfmt/tests/constant_align/constant_align.odin
@@ -34,3 +34,24 @@ Z :: 30
 SHORT : int : 1
 VERY_LONG_NAME : int : 2
 MEDIUM : int : 3
+
+main :: proc() {
+	SHORT :: 1
+	LONGER_NAME :: 2
+
+	if true {
+		IF_SHORT :: 1
+		IF_LONGER_NAME :: 2
+	}
+
+	when ODIN_OS == .Windows {
+		WHEN_SHORT :: 1
+		WHEN_LONGER_NAME :: 2
+	}
+
+	for {
+		LOOP_SHORT :: 1
+		LOOP_LONGER_NAME :: 2
+		break
+	}
+}


### PR DESCRIPTION
The setting  `align_constant_definitions` currently only applies to file-level declarations. Constants inside procedures and nested control-flow blocks remain unaligned.

**Note**: I may be misunderstanding the intended behavior, but I found the current behavior surprising and believe this is a feature gap. You can just close this PR if the current behavior is intentional.


  ## Cause

  The constant alignment map is populated for `file.decls`, but nested statement lists are not scanned before formatting:

  ```odin
  main :: proc() {
        SHORT :: 1
        LONGER_NAME :: 2
  }
  ```

  ## Fix

  Compute constant alignment in the `Block_Stmt` visitor before calling `visit_block_stmts`.

  All braced bodies ultimately pass through this visitor, so the option now applies consistently inside procedures, `if`, `when`, and loop blocks:

  ```odin
  main :: proc() {
        SHORT       :: 1
        LONGER_NAME :: 2
  }
  ```

  ## Verification

  Added snapshot coverage for constants inside:

  - Procedure bodies
  - `if` blocks
  - `when` blocks
  - Loop bodies

  The complete `odinfmt` snapshot suite passes.