### PR TITLE
Feature: optionally preserve blank lines between struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Options:
 
 - `multiline_composite_literals`: When enabled, composite literals that were written across multiple lines are kept multiline.
 
+- `preserve_struct_blank_lines`: Preserve blank lines between struct fields, up to `newline_limit`.
+
 ## Features
 
 Support Language server features:

--- a/misc/odinfmt.schema.json
+++ b/misc/odinfmt.schema.json
@@ -95,6 +95,11 @@
 			"type": "boolean",
 			"default": false,
 			"description": "Composite literals that span multiple lines are not forcibly inlined"
+		},
+		"preserve_struct_blank_lines": {
+			"type": "boolean",
+			"default": false,
+			"description": "Preserve blank lines between struct fields, up to newline_limit"
 		}
 	},
 	"required": []

--- a/src/odin/printer/printer.odin
+++ b/src/odin/printer/printer.odin
@@ -72,6 +72,7 @@ Config :: struct {
 	align_constant_definitions:   bool,
 	align_comments:               bool, //Align trailing line comments to the same column.
 	multiline_composite_literals: bool,
+	preserve_struct_blank_lines:  bool,
 }
 
 Brace_Style :: enum {
@@ -127,6 +128,7 @@ when ODIN_OS == .Windows {
 		align_constant_definitions   = false,
 		align_comments               = false,
 		multiline_composite_literals = false,
+		preserve_struct_blank_lines  = false,
 	}
 } else {
 	default_style := Config {
@@ -147,6 +149,7 @@ when ODIN_OS == .Windows {
 		align_constant_definitions   = false,
 		align_comments               = false,
 		multiline_composite_literals = false,
+		preserve_struct_blank_lines  = false,
 	}
 }
 

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -2219,8 +2219,12 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		}
 
 		if i != len(list.list) - 1 && .Enforce_Newline in options {
-			comment, _ := visit_comments(p, list.list[i + 1].pos)
-			document = cons(document, comment, newline(1))
+			if p.config.preserve_struct_blank_lines {
+				document = cons(document, move_line(p, list.list[i + 1].pos))
+			} else {
+				comment, _ := visit_comments(p, list.list[i + 1].pos)
+				document = cons(document, comment, newline(1))
+			}
 		} else {
 			comment, _ := visit_comments(p, list.end)
 			document = cons(document, comment)

--- a/src/odin/printer/visit.odin
+++ b/src/odin/printer/visit.odin
@@ -2100,16 +2100,28 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		return document
 	}
 
-	declaration_alignment := 0
-	if p.config.align_struct_declarations && .Enforce_Newline in options {
-		declaration_alignment = get_possible_field_declaration_alignment(list.list)
-	}
+	// Declaration alignment (align_struct_declarations) takes precedence: it pads before the colon,
+	// while field-type alignment pads after it.
+	align_declarations := p.config.align_struct_declarations
+	align_field_types := p.config.align_struct_fields && !align_declarations
+
+	multiline_alignment_enabled := .Enforce_Newline in options && (align_field_types || align_declarations)
+
+	section_name_width := 0
+	// section_end is exclusive. Reaching it starts the next alignment group.
+	section_end := 0
 
 	for field, i in list.list {
 		align := empty()
 		declaration_align := empty()
 
 		p.source_position = field.pos
+
+		// Initialize alignment for the first section and update it at each section boundary.
+		if multiline_alignment_enabled && i == section_end {
+			section_end = get_struct_field_alignment_section_end(p, list.list, i)
+			section_name_width = get_max_struct_field_name_width(list.list[i:section_end])
+		}
 
 		// A field is neither a Decl nor a Stmt, so it reaches neither place that consults
 		// disabled_lines and the region has to be emitted here. Its text already carries the
@@ -2147,46 +2159,14 @@ visit_struct_field_list :: proc(p: ^Printer, list: ^ast.Field_List, options := L
 		name_options := List_Options{.Add_Comma}
 
 		if (.Enforce_Newline in options) {
-			// When align_struct_declarations is active, it handles the visual
-			if p.config.align_struct_fields && !p.config.align_struct_declarations {
-				alignment := get_possible_field_alignment(list.list)
-
-				if alignment > 0 {
-					length := 0
-					for name in field.names {
-						length += get_node_length(name)
-					}
-					if len(field.names) > 1 {
-						length += 2 * (len(field.names) - 1)
-					}
-					if .Using in field.flags {
-						length += 6
-					}
-					if .Subtype in field.flags {
-						length += 9
-					}
-					align = repeat_space(alignment - length)
-				}
+			if align_field_types && section_name_width > 0 {
+				align = repeat_space(section_name_width - get_struct_field_name_width(field))
 			}
 
-			if p.config.align_struct_declarations && declaration_alignment > 0 {
-				name_length := 0
-				for name in field.names {
-					name_length += get_node_length(name)
-				}
-				if len(field.names) > 1 {
-					name_length += 2 * (len(field.names) - 1)
-				}
-
-				if .Using in field.flags {
-					name_length += 6
-				}
-				if .Subtype in field.flags {
-					name_length += 9
-				}
-
-				if name_length > 0 && name_length < declaration_alignment {
-					declaration_align = repeat_space(declaration_alignment - name_length)
+			if align_declarations && section_name_width > 0 {
+				name_width := get_struct_field_name_width(field)
+				if name_width > 0 && name_width < section_name_width {
+					declaration_align = repeat_space(section_name_width - name_width)
 				}
 			}
 
@@ -2580,52 +2560,70 @@ get_node_length :: proc(node: ^ast.Node) -> int {
 }
 
 @(private)
-get_possible_field_alignment :: proc(fields: []^ast.Field) -> int {
-	longest_name := 0
+struct_fields_have_blank_line_between :: proc(previous, next: ^ast.Field) -> bool {
+	last_occupied_line := previous.end.line
 
-	for field in fields {
-		length := 0
-		for name in field.names {
-			length += get_node_length(name)
-		}
-
-		if len(field.names) > 1 {
-			length += 2 * (len(field.names) - 1)
-		}
-
-		if .Using in field.flags {
-			length += 6
-		}
-
-		longest_name = max(longest_name, length)
+	if previous.comment != nil {
+		last_occupied_line = max(last_occupied_line, previous.comment.end.line)
 	}
 
-	return longest_name
+	if next.docs != nil {
+		if next.docs.pos.line > last_occupied_line + 1 {
+			return true
+		}
+
+		last_occupied_line = max(last_occupied_line, next.docs.end.line)
+	}
+
+	return next.pos.line > last_occupied_line + 1
 }
 
 @(private)
-get_possible_field_declaration_alignment :: proc(fields: []^ast.Field) -> int {
+get_struct_field_alignment_section_end :: proc(p: ^Printer, fields: []^ast.Field, start: int) -> int {
+	if !p.config.preserve_struct_blank_lines {
+		return len(fields)
+	}
+
+	// With a zero limit, source blank lines are collapsed in the output. They must
+	// not reset alignment when there is no visible section break.
+	if p.config.newline_limit <= 0 {
+		return len(fields)
+	}
+
+	end := start + 1
+	for end < len(fields) && !struct_fields_have_blank_line_between(fields[end - 1], fields[end]) {
+		end += 1
+	}
+
+	return end
+}
+
+@(private)
+get_struct_field_name_width :: proc(field: ^ast.Field) -> int {
+	width := 0
+	for name, i in field.names {
+		width += get_node_length(name)
+		if i < len(field.names) - 1 {
+			width += 2 // ", "
+		}
+	}
+
+	if .Using in field.flags {
+		width += 6 // "using "
+	}
+	if .Subtype in field.flags {
+		width += 9 // "#subtype "
+	}
+
+	return width
+}
+
+@(private)
+get_max_struct_field_name_width :: proc(fields: []^ast.Field) -> int {
 	longest_name := 0
 
 	for field in fields {
-		length := 0
-		for name in field.names {
-			length += get_node_length(name)
-		}
-
-		if len(field.names) > 1 {
-			length += 2 * (len(field.names) - 1)
-		}
-
-		if .Using in field.flags {
-			length += 6 // "using "
-		}
-
-		if .Subtype in field.flags {
-			length += 9 // "#subtype "
-		}
-
-		longest_name = max(longest_name, length)
+		longest_name = max(longest_name, get_struct_field_name_width(field))
 	}
 
 	return longest_name

--- a/tools/odinfmt/tests/collapse_struct_field_blank_lines/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/collapse_struct_field_blank_lines/.snapshots/structs.odin
@@ -1,0 +1,6 @@
+package collapse_struct_field_blank_lines
+
+Pair :: struct {
+	first:  int,
+	second: int,
+}

--- a/tools/odinfmt/tests/collapse_struct_field_blank_lines/structs.odin
+++ b/tools/odinfmt/tests/collapse_struct_field_blank_lines/structs.odin
@@ -1,0 +1,7 @@
+package collapse_struct_field_blank_lines
+
+Pair :: struct {
+	first: int,
+
+	second: int,
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/.snapshots/structs.odin
@@ -1,0 +1,9 @@
+package preserve_struct_blank_lines_align_declarations
+
+Fields :: struct {
+	short       : int,
+	medium_name : int,
+
+	much_longer_name : int,
+	x                : int,
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/odinfmt.json
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/odinfmt.json
@@ -1,0 +1,5 @@
+{
+	"align_struct_declarations": true,
+	"preserve_struct_blank_lines": true,
+	"spaces_around_colons": true
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_align_declarations/structs.odin
@@ -1,0 +1,9 @@
+package preserve_struct_blank_lines_align_declarations
+
+Fields :: struct {
+	short : int,
+	medium_name : int,
+
+	much_longer_name : int,
+	x : int,
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/.snapshots/structs.odin
@@ -1,0 +1,5 @@
+package preserve_struct_blank_lines_newline_zero
+Fields :: struct {
+	short:            int,
+	much_longer_name: int,
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/odinfmt.json
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/odinfmt.json
@@ -1,0 +1,4 @@
+{
+	"newline_limit": 0,
+	"preserve_struct_blank_lines": true
+}

--- a/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_blank_lines_newline_zero/structs.odin
@@ -1,0 +1,7 @@
+package preserve_struct_blank_lines_newline_zero
+
+Fields :: struct {
+	short: int,
+
+	much_longer_name: int,
+}

--- a/tools/odinfmt/tests/preserve_struct_field_blank_lines/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_field_blank_lines/.snapshots/structs.odin
@@ -1,0 +1,27 @@
+package preserve_struct_field_blank_lines
+
+Settings :: struct {
+	window_width:  int,
+	window_height: int,
+	target_fps:    int,
+
+	fullscreen:    bool,
+	vertical_sync: bool,
+}
+
+With_Comments :: struct {
+	first:  int, // trailing comment
+
+	// The second group.
+	second: int,
+
+	// The third group follows this comment without a blank line.
+	third:  int,
+}
+
+Capped_By_Newline_Limit :: struct {
+	first:  int,
+
+
+	second: int,
+}

--- a/tools/odinfmt/tests/preserve_struct_field_blank_lines/.snapshots/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_field_blank_lines/.snapshots/structs.odin
@@ -9,18 +9,62 @@ Settings :: struct {
 	vertical_sync: bool,
 }
 
+Different_Section_Widths :: struct {
+	short:       int,
+	medium_name: int,
+
+	much_longer_name: int,
+	x:                int,
+}
+
+Comment_Within_Section :: struct {
+	short:            int,
+	// This comment does not start a new section.
+	much_longer_name: int,
+}
+
+Subtype_Alignment :: struct {
+	#subtype embedded: Embedded,
+	regular:           int,
+}
+
+Block_Comment_Within_Section :: struct {
+	short:            int,
+	/* This comment contains an empty line.
+
+	It does not create a new field section. */
+	much_longer_name: int,
+}
+
+Trailing_Block_Comment_Within_Section :: struct {
+	short:            int,
+	/* This trailing comment contains an empty line.
+
+	It does not create a new field section. */
+	much_longer_name: int,
+}
+
+Block_Comment_Starts_Section :: struct {
+	short: int,
+
+	/* This comment starts after an actual field-section break.
+
+	Its own empty line is irrelevant. */
+	much_longer_name: int,
+}
+
 With_Comments :: struct {
-	first:  int, // trailing comment
+	first: int, // trailing comment
 
 	// The second group.
 	second: int,
 
 	// The third group follows this comment without a blank line.
-	third:  int,
+	third: int,
 }
 
 Capped_By_Newline_Limit :: struct {
-	first:  int,
+	first: int,
 
 
 	second: int,

--- a/tools/odinfmt/tests/preserve_struct_field_blank_lines/odinfmt.json
+++ b/tools/odinfmt/tests/preserve_struct_field_blank_lines/odinfmt.json
@@ -1,0 +1,4 @@
+{
+	"newline_limit": 2,
+	"preserve_struct_blank_lines": true
+}

--- a/tools/odinfmt/tests/preserve_struct_field_blank_lines/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_field_blank_lines/structs.odin
@@ -9,6 +9,49 @@ Settings :: struct {
 	vertical_sync: bool,
 }
 
+Different_Section_Widths :: struct {
+	short: int,
+	medium_name: int,
+
+	much_longer_name: int,
+	x: int,
+}
+
+Comment_Within_Section :: struct {
+	short: int,
+	// This comment does not start a new section.
+	much_longer_name: int,
+}
+
+Subtype_Alignment :: struct {
+	#subtype embedded: Embedded,
+	regular: int,
+}
+
+Block_Comment_Within_Section :: struct {
+	short: int,
+	/* This comment contains an empty line.
+
+	It does not create a new field section. */
+	much_longer_name: int,
+}
+
+Trailing_Block_Comment_Within_Section :: struct {
+	short: int, /* This trailing comment contains an empty line.
+
+	It does not create a new field section. */
+	much_longer_name: int,
+}
+
+Block_Comment_Starts_Section :: struct {
+	short: int,
+
+	/* This comment starts after an actual field-section break.
+
+	Its own empty line is irrelevant. */
+	much_longer_name: int,
+}
+
 With_Comments :: struct {
 	first: int, // trailing comment
 

--- a/tools/odinfmt/tests/preserve_struct_field_blank_lines/structs.odin
+++ b/tools/odinfmt/tests/preserve_struct_field_blank_lines/structs.odin
@@ -1,0 +1,29 @@
+package preserve_struct_field_blank_lines
+
+Settings :: struct {
+	window_width:  int,
+	window_height: int,
+	target_fps:    int,
+
+	fullscreen:   bool,
+	vertical_sync: bool,
+}
+
+With_Comments :: struct {
+	first: int, // trailing comment
+
+	// The second group.
+	second: int,
+
+	// The third group follows this comment without a blank line.
+	third: int,
+}
+
+Capped_By_Newline_Limit :: struct {
+	first: int,
+
+
+
+
+	second: int,
+}


### PR DESCRIPTION
## Motivation

`odinfmt` currently collapses blank lines between struct fields, but I often want to separate fields visually into logical groups.

For example, this:

```odin
Settings :: struct {
	window_width:  int,
	window_height: int,
	target_fps:    int,

	fullscreen:    bool,
	vertical_sync: bool,
}
```

becomes:

```odin
Settings :: struct {
	window_width:  int,
	window_height: int,
	target_fps:    int,
	fullscreen:    bool,
	vertical_sync: bool,
}
```

It is possible to preserve the visual separation by adding a comment, but a comment should not be necessary solely for formatting:

```odin
Settings :: struct {
	window_width:  int,
	window_height: int,
	target_fps:    int,

	// Display options
	fullscreen:    bool,
	vertical_sync: bool,
}
```

## Proposed Solution

This PR adds an opt-in `preserve_struct_blank_lines` setting:

```json
{
	"preserve_struct_blank_lines": true
}
```

When enabled, the formatter preserves blank lines between struct fields while respecting the existing `newline_limit`
setting.

Each blank-line-separated section is also aligned independently, similar to `gofmt`. A long field name in one logical
section therefore does not add padding to fields in another section. This applies to both `align_struct_fields` and
`align_struct_declarations`.

Comments attached to fields are treated as part of those fields when identifying section boundaries. Blank lines inside multiline block comments do not create sections, while an actual blank line between a field and the next field or its documentation does.

When `newline_limit` is zero, blank lines are removed and alignment continues across the whole struct because no visible section boundary remains.

The option defaults to false, so existing formatting behavior remains unchanged.

### Example

Fields previously aligned across the entire struct:

```odin
Fields :: struct {
      short:            int,
      medium_name:      int,

      much_longer_name: int,
      x:                int,
}
```

With `preserve_struct_blank_lines` enabled, each blank-line-separated section now has its own alignment width:

```odin
Fields :: struct {
      short:       int,
      medium_name: int,

      much_longer_name: int,
      x:                int,
}
```

## Alignment Improvements

This PR also fixes an inconsistency where `#subtype` was included in declaration alignment widths but omitted from field-type alignment widths. For example, with `align_struct_fields` enabled:

```odin
  Fields :: struct {
        #subtype embedded: Embedded,
        regular: int,
  }
```

Previously, `#subtype` was omitted when calculating the maximum width, producing:

```odin
  Fields :: struct {
        #subtype embedded: Embedded,
        regular:  int,
  }
```

After including `#subtype` in the shared width calculation:

```odin
  Fields :: struct {
        #subtype embedded: Embedded,
        regular:           int,
  }
```

## Verification

Added snapshot coverage for:

- Preserving blank lines between field groups
- Aligning each field group independently
- Section alignment with both `align_struct_fields` and `align_struct_declarations`
- Leading, trailing, line, and multiline block comments around section boundaries
- Ignoring blank lines contained within multiline block comments
- Accounting for `#subtype` prefixes during alignment
- Limiting excessive blank lines according to `newline_limit`
- Using whole-struct alignment when `newline_limit` is zero
- Retaining the existing collapsing behavior when the option is disabled

The `odinfmt` snapshot suite passes.
