### PR TITLE
fix for find references skipping fields set in struct literals that happen to be after a return statement

### DIFF
--- a/src/server/file_resolve.odin
+++ b/src/server/file_resolve.odin
@@ -528,6 +528,9 @@ resolve_node :: proc(node: ^ast.Node, data: ^FileResolveData) {
 		resolve_node(r.stmt, data)
 	case ^ast.Return_Stmt:
 		data.position_context.returns = n
+		defer {
+			data.position_context.returns = nil
+		}
 		resolve_nodes(n.results, data)
 	case ^ast.Defer_Stmt:
 		resolve_node(n.stmt, data)


### PR DESCRIPTION
I noticed sometimes find references wouldn't list things, it turns out if I'm using a struct literal and it's placed below a return statement in the file, it will be skipped 

its due to the position_context.returns becoming stale as it walks over the file (since returns is checked before assign)

simple repro scenario: 
```
package main

Config :: struct {
	width: int,
}

// when there is a proc with return anywhere earlier in the file,
// find references on a struct field is unable to see places where that field is set inside a struct literal
unrelated :: proc() {
	return
}

apply :: proc() {
	config: Config
	config = { 	// the struct/compound literal
		width = 1, // find references on 'width' will miss this line
	}
	config.width = 1 // but this one is found
}

```